### PR TITLE
V0.1: Render common prose syntax end to end

### DIFF
--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -5,6 +5,35 @@ use std::path::PathBuf;
 use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
+fn fixture_path(relative: &str) -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join(relative)
+}
+
+#[test]
+fn check_accepts_v0_1_prose_fixture_with_all_inline_syntax() {
+    let fixture = fixture_path("v0_1/prose_page.adoc");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["check", fixture.to_str().expect("fixture path is utf-8")])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected v0.1 prose fixture to check cleanly\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 errors"),
+        "expected zero errors in summary, got:\n{stdout}"
+    );
+}
+
 #[test]
 fn check_accepts_minimal_prose_page() {
     let workspace = TestWorkspace::new("check-accepts-minimal-prose-page");

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -35,6 +35,43 @@ fn check_accepts_v0_1_prose_fixture_with_all_inline_syntax() {
 }
 
 #[test]
+fn build_renders_v0_1_prose_fixture_to_golden_html() {
+    let workspace = TestWorkspace::new("build-renders-prose-golden-html");
+    let fixture = fixture_path("v0_1/prose_page.adoc");
+    let output_directory = workspace.root.join("dist");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "build",
+            fixture.to_str().expect("fixture path is utf-8"),
+            "--out",
+            output_directory
+                .to_str()
+                .expect("output directory path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(output_directory.join("docs.html"))
+        .expect("docs.html is written");
+    let golden = fs::read_to_string(fixture_path("v0_1/prose_page.golden.html"))
+        .expect("golden HTML fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "rendered HTML diverged from prose_page.golden.html; \
+         re-run `adoc build` against prose_page.adoc and review before updating the snapshot"
+    );
+}
+
+#[test]
 fn check_accepts_minimal_prose_page() {
     let workspace = TestWorkspace::new("check-accepts-minimal-prose-page");
     let source = workspace.write(

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -35,6 +35,40 @@ fn check_accepts_v0_1_prose_fixture_with_all_inline_syntax() {
 }
 
 #[test]
+fn build_renders_v0_1_prose_fixture_to_golden_agent_json() {
+    let workspace = TestWorkspace::new("build-renders-prose-golden-json");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_1/prose_page.adoc"))
+        .expect("prose fixture is readable");
+    workspace.write("prose_page.adoc", &fixture_contents);
+
+    // Run with cwd=workspace so the recorded source_path is "prose_page.adoc"
+    // rather than a host-specific absolute path.
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "prose_page.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.agent.json"))
+        .expect("docs.agent.json is written");
+    let golden = fs::read_to_string(fixture_path("v0_1/prose_page.golden.agent.json"))
+        .expect("golden agent JSON fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "agent JSON diverged from prose_page.golden.agent.json; \
+         re-run `adoc build` against prose_page.adoc and review before updating the snapshot"
+    );
+}
+
+#[test]
 fn build_renders_v0_1_prose_fixture_to_golden_html() {
     let workspace = TestWorkspace::new("build-renders-prose-golden-html");
     let fixture = fixture_path("v0_1/prose_page.adoc");

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -54,10 +54,7 @@ fn check_unclosed_fence_diagnostic_surfaces_all_six_fields() {
 
     // Issue #3 acceptance: the diagnostic must carry file, line, column,
     // severity, code, and a fix-oriented message.
-    let prefix = format!(
-        "{}:5:1:",
-        source.to_str().expect("source path is utf-8")
-    );
+    let prefix = format!("{}:5:1:", source.to_str().expect("source path is utf-8"));
     assert!(
         stdout.contains(&prefix),
         "expected diagnostic to start with `path:line:column:` prefix `{prefix}`, got:\n{stdout}"
@@ -164,8 +161,8 @@ fn build_renders_v0_1_prose_fixture_to_golden_html() {
         String::from_utf8_lossy(&output.stderr)
     );
 
-    let actual = fs::read_to_string(output_directory.join("docs.html"))
-        .expect("docs.html is written");
+    let actual =
+        fs::read_to_string(output_directory.join("docs.html")).expect("docs.html is written");
     let golden = fs::read_to_string(fixture_path("v0_1/prose_page.golden.html"))
         .expect("golden HTML fixture is readable");
 

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -35,6 +35,38 @@ fn check_accepts_v0_1_prose_fixture_with_all_inline_syntax() {
 }
 
 #[test]
+fn check_rejects_unsafe_link_with_source_location() {
+    let workspace = TestWorkspace::new("check-rejects-unsafe-link");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_1/unsafe_link.adoc"))
+        .expect("unsafe_link fixture is readable");
+    let source = workspace.write("unsafe_link.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["check", source.to_str().expect("source path is utf-8")])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected unsafe link to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("unsafe_link.adoc:3:10"),
+        "expected diagnostic at line 3 column 10 (where the link starts), got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("error[parse.unsafe_link]"),
+        "expected parse.unsafe_link code in stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("javascript:alert"),
+        "expected diagnostic message to quote the rejected URL:\n{stdout}"
+    );
+    assert!(stdout.contains("1 errors"));
+}
+
+#[test]
 fn build_renders_v0_1_prose_fixture_to_golden_agent_json() {
     let workspace = TestWorkspace::new("build-renders-prose-golden-json");
     let fixture_contents = fs::read_to_string(fixture_path("v0_1/prose_page.adoc"))

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -35,6 +35,45 @@ fn check_accepts_v0_1_prose_fixture_with_all_inline_syntax() {
 }
 
 #[test]
+fn check_unclosed_fence_diagnostic_surfaces_all_six_fields() {
+    let workspace = TestWorkspace::new("check-unclosed-fence-shape");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_1/unclosed_fence.adoc"))
+        .expect("unclosed_fence fixture is readable");
+    let source = workspace.write("unclosed_fence.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["check", source.to_str().expect("source path is utf-8")])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected unclosed fence to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Issue #3 acceptance: the diagnostic must carry file, line, column,
+    // severity, code, and a fix-oriented message.
+    let prefix = format!(
+        "{}:5:1:",
+        source.to_str().expect("source path is utf-8")
+    );
+    assert!(
+        stdout.contains(&prefix),
+        "expected diagnostic to start with `path:line:column:` prefix `{prefix}`, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("error[parse.unclosed_fence]"),
+        "expected severity + code `error[parse.unclosed_fence]` in stdout:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Fenced code block is missing a closing"),
+        "expected fix-oriented message about the missing closing fence:\n{stdout}"
+    );
+    assert!(stdout.contains("1 errors"));
+}
+
+#[test]
 fn check_rejects_unsafe_link_with_source_location() {
     let workspace = TestWorkspace::new("check-rejects-unsafe-link");
     let fixture_contents = fs::read_to_string(fixture_path("v0_1/unsafe_link.adoc"))

--- a/crates/adoc-cli/tests/fixtures/v0_1/prose_page.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_1/prose_page.adoc
@@ -1,0 +1,34 @@
+# AgentDoc V0.1 Prose Reference @doc(v0-1.prose)
+
+AgentDoc keeps **knowledge** readable for both humans and *agents*. Run `adoc check` to validate the source, then `adoc build` to emit human and agent artifacts.
+
+## Block coverage
+
+The V0.1 compiler covers these block types end to end:
+
+- Headings, levels 1 through 6
+- Ordered and unordered lists
+- Fenced code blocks
+- Plain prose paragraphs
+
+It also enforces strict mode for the cases below:
+
+1. Raw HTML is rejected with a `parse.raw_html` diagnostic.
+2. Unclosed fenced code blocks are rejected with `parse.unclosed_fence`.
+3. Link URLs outside `http`, `https`, and `mailto` are rejected with `parse.unsafe_link`.
+
+## Code samples
+
+Use a fenced block for multi-line code:
+
+```rust
+fn main() {
+    println!("hello agentdoc");
+}
+```
+
+Or `inline code` for shorter callouts inside prose.
+
+## Links
+
+Read the [project overview](https://example.test/adoc) or email the [maintainer team](mailto:dev@example.test) with feedback.

--- a/crates/adoc-cli/tests/fixtures/v0_1/prose_page.golden.agent.json
+++ b/crates/adoc-cli/tests/fixtures/v0_1/prose_page.golden.agent.json
@@ -1,0 +1,12 @@
+{
+  "schema_version": "adoc.agent.v0",
+  "pages": [
+    {
+      "id": "v0-1.prose",
+      "title": "AgentDoc V0.1 Prose Reference",
+      "source_path": "prose_page.adoc"
+    }
+  ],
+  "objects": [],
+  "diagnostics": []
+}

--- a/crates/adoc-cli/tests/fixtures/v0_1/prose_page.golden.html
+++ b/crates/adoc-cli/tests/fixtures/v0_1/prose_page.golden.html
@@ -1,0 +1,36 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AgentDoc</title>
+</head>
+<body>
+<article data-page-id="v0-1.prose">
+<h1>AgentDoc V0.1 Prose Reference</h1>
+<p>AgentDoc keeps <strong>knowledge</strong> readable for both humans and <em>agents</em>. Run <code>adoc check</code> to validate the source, then <code>adoc build</code> to emit human and agent artifacts.</p>
+<h2>Block coverage</h2>
+<p>The V0.1 compiler covers these block types end to end:</p>
+<ul>
+<li>Headings, levels 1 through 6</li>
+<li>Ordered and unordered lists</li>
+<li>Fenced code blocks</li>
+<li>Plain prose paragraphs</li>
+</ul>
+<p>It also enforces strict mode for the cases below:</p>
+<ol>
+<li>Raw HTML is rejected with a <code>parse.raw_html</code> diagnostic.</li>
+<li>Unclosed fenced code blocks are rejected with <code>parse.unclosed_fence</code>.</li>
+<li>Link URLs outside <code>http</code>, <code>https</code>, and <code>mailto</code> are rejected with <code>parse.unsafe_link</code>.</li>
+</ol>
+<h2>Code samples</h2>
+<p>Use a fenced block for multi-line code:</p>
+<pre><code class="language-rust">fn main() {
+    println!(&quot;hello agentdoc&quot;);
+}
+</code></pre>
+<p>Or <code>inline code</code> for shorter callouts inside prose.</p>
+<h2>Links</h2>
+<p>Read the <a href="https://example.test/adoc">project overview</a> or email the <a href="mailto:dev@example.test">maintainer team</a> with feedback.</p>
+</article>
+</body>
+</html>

--- a/crates/adoc-cli/tests/fixtures/v0_1/unclosed_fence.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_1/unclosed_fence.adoc
@@ -1,0 +1,6 @@
+# Broken Code @doc(broken-code)
+
+Use this code sample:
+
+```rust
+fn main() {}

--- a/crates/adoc-cli/tests/fixtures/v0_1/unsafe_link.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_1/unsafe_link.adoc
@@ -1,0 +1,3 @@
+# Unsafe Link Test @doc(unsafe-link)
+
+The link [click](javascript:alert) should be rejected in strict mode.

--- a/crates/adoc-core/src/ast.rs
+++ b/crates/adoc-core/src/ast.rs
@@ -1,6 +1,7 @@
 use std::path::PathBuf;
 
 use crate::diagnostic::SourceSpan;
+use crate::inline::InlineSegment;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceAst {
@@ -26,20 +27,20 @@ pub enum BlockAst {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HeadingAst {
     pub level: u8,
-    pub text: String,
+    pub inlines: Vec<InlineSegment>,
     pub span: SourceSpan,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParagraphAst {
-    pub text: String,
+    pub inlines: Vec<InlineSegment>,
     pub span: SourceSpan,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ListAst {
     pub kind: ListKind,
-    pub items: Vec<String>,
+    pub items: Vec<Vec<InlineSegment>>,
     pub span: SourceSpan,
 }
 

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -1,4 +1,5 @@
 use crate::diagnostic::Diagnostic;
+use crate::source::SourceFile;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InlineSegment {
@@ -12,30 +13,30 @@ pub enum InlineSegment {
     },
 }
 
-pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
-    let mut segments = Vec::new();
-    let mut diagnostics = Vec::new();
-    let mut buffer = String::new();
+#[derive(Debug, Clone, Copy)]
+pub struct InlineOrigin<'a> {
+    pub source: &'a SourceFile,
+    pub line: u32,
+    pub column_offset: u32,
+}
+
+pub fn parse_inlines(
+    text: &str,
+    origin: InlineOrigin<'_>,
+) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
+    let mut output = ScannerOutput::default();
     let mut cursor = 0;
 
     while cursor < text.len() {
-        if let Some(consumed) = scan_code(text, cursor, &mut segments, &mut buffer) {
+        if let Some(consumed) = scan_code(text, cursor, &mut output) {
             cursor += consumed;
             continue;
         }
-        if let Some(consumed) =
-            scan_link(text, cursor, &mut segments, &mut diagnostics, &mut buffer)
-        {
+        if let Some(consumed) = scan_link(text, cursor, origin, &mut output) {
             cursor += consumed;
             continue;
         }
-        if let Some(consumed) = scan_emphasis_or_strong(
-            text,
-            cursor,
-            &mut segments,
-            &mut diagnostics,
-            &mut buffer,
-        ) {
+        if let Some(consumed) = scan_emphasis_or_strong(text, cursor, origin, &mut output) {
             cursor += consumed;
             continue;
         }
@@ -44,12 +45,42 @@ pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
             .chars()
             .next()
             .expect("cursor points at a character boundary");
-        buffer.push(character);
+        output.buffer.push(character);
         cursor += character.len_utf8();
     }
 
-    flush_text(&mut segments, &mut buffer);
-    (segments, diagnostics)
+    output.flush_text();
+    (output.segments, output.diagnostics)
+}
+
+#[derive(Default)]
+struct ScannerOutput {
+    segments: Vec<InlineSegment>,
+    diagnostics: Vec<Diagnostic>,
+    buffer: String,
+}
+
+impl ScannerOutput {
+    fn flush_text(&mut self) {
+        if self.buffer.is_empty() {
+            return;
+        }
+        self.segments
+            .push(InlineSegment::Text(std::mem::take(&mut self.buffer)));
+    }
+
+    fn push_text(&mut self, text: &str) {
+        self.buffer.push_str(text);
+    }
+
+    fn push_segment(&mut self, segment: InlineSegment) {
+        self.flush_text();
+        self.segments.push(segment);
+    }
+
+    fn push_diagnostic(&mut self, diagnostic: Diagnostic) {
+        self.diagnostics.push(diagnostic);
+    }
 }
 
 pub fn plain_text(segments: &[InlineSegment]) -> String {
@@ -73,9 +104,8 @@ fn append_plain_text(segments: &[InlineSegment], buffer: &mut String) {
 fn scan_link(
     text: &str,
     cursor: usize,
-    segments: &mut Vec<InlineSegment>,
-    diagnostics: &mut Vec<Diagnostic>,
-    buffer: &mut String,
+    origin: InlineOrigin<'_>,
+    output: &mut ScannerOutput,
 ) -> Option<usize> {
     if !text[cursor..].starts_with('[') {
         return None;
@@ -94,23 +124,37 @@ fn scan_link(
     let after_open_paren = &after_close_bracket[1..];
     let close_paren_offset = after_open_paren.find(')')?;
     let url = after_open_paren[..close_paren_offset].to_string();
+    let total_consumed = 1 + close_bracket_offset + 1 + 1 + close_paren_offset + 1;
 
-    flush_text(segments, buffer);
-    let (label_segments, label_diagnostics) = parse_inlines(label_text);
-    diagnostics.extend(label_diagnostics);
-    segments.push(InlineSegment::Link {
+    if !is_url_safe(&url) {
+        let start_column = column_at(origin, &text[..cursor]);
+        let end_column = column_at(origin, &text[..cursor + total_consumed]);
+        let span = origin
+            .source
+            .span_for_line_columns(origin.line, start_column, end_column);
+        output.push_diagnostic(
+            Diagnostic::error(
+                "parse.unsafe_link",
+                format!(
+                    "Link URL scheme is not allowed in strict mode: {url}; use http, https, or mailto",
+                ),
+            )
+            .with_span(span),
+        );
+        output.push_text(&text[cursor..cursor + total_consumed]);
+        return Some(total_consumed);
+    }
+
+    let (label_segments, label_diagnostics) = parse_inlines(label_text, origin);
+    output.diagnostics.extend(label_diagnostics);
+    output.push_segment(InlineSegment::Link {
         text: label_segments,
         url,
     });
-    Some(1 + close_bracket_offset + 1 + 1 + close_paren_offset + 1)
+    Some(total_consumed)
 }
 
-fn scan_code(
-    text: &str,
-    cursor: usize,
-    segments: &mut Vec<InlineSegment>,
-    buffer: &mut String,
-) -> Option<usize> {
+fn scan_code(text: &str, cursor: usize, output: &mut ScannerOutput) -> Option<usize> {
     if !text[cursor..].starts_with('`') {
         return None;
     }
@@ -120,28 +164,22 @@ fn scan_code(
         return None;
     }
     let inner = after_open[..close_offset].to_string();
-    flush_text(segments, buffer);
-    segments.push(InlineSegment::Code(inner));
+    output.push_segment(InlineSegment::Code(inner));
     Some(1 + close_offset + 1)
 }
 
 fn scan_emphasis_or_strong(
     text: &str,
     cursor: usize,
-    segments: &mut Vec<InlineSegment>,
-    diagnostics: &mut Vec<Diagnostic>,
-    buffer: &mut String,
+    origin: InlineOrigin<'_>,
+    output: &mut ScannerOutput,
 ) -> Option<usize> {
     let remainder = &text[cursor..];
     if remainder.starts_with("**") {
-        return scan_paired_marker(text, cursor, "**", segments, diagnostics, buffer, |inner| {
-            InlineSegment::Strong(inner)
-        });
+        return scan_paired_marker(text, cursor, "**", origin, output, InlineSegment::Strong);
     }
     if remainder.starts_with('*') {
-        return scan_paired_marker(text, cursor, "*", segments, diagnostics, buffer, |inner| {
-            InlineSegment::Emphasis(inner)
-        });
+        return scan_paired_marker(text, cursor, "*", origin, output, InlineSegment::Emphasis);
     }
     None
 }
@@ -150,9 +188,8 @@ fn scan_paired_marker(
     text: &str,
     cursor: usize,
     marker: &str,
-    segments: &mut Vec<InlineSegment>,
-    diagnostics: &mut Vec<Diagnostic>,
-    buffer: &mut String,
+    origin: InlineOrigin<'_>,
+    output: &mut ScannerOutput,
     wrap: impl FnOnce(Vec<InlineSegment>) -> InlineSegment,
 ) -> Option<usize> {
     let after_open = &text[cursor + marker.len()..];
@@ -161,27 +198,72 @@ fn scan_paired_marker(
         return None;
     }
     let inner = &after_open[..close_offset];
-    flush_text(segments, buffer);
-    let (inner_segments, inner_diagnostics) = parse_inlines(inner);
-    diagnostics.extend(inner_diagnostics);
-    segments.push(wrap(inner_segments));
+    let (inner_segments, inner_diagnostics) = parse_inlines(inner, origin);
+    output.diagnostics.extend(inner_diagnostics);
+    output.push_segment(wrap(inner_segments));
     Some(marker.len() + close_offset + marker.len())
 }
 
-fn flush_text(segments: &mut Vec<InlineSegment>, buffer: &mut String) {
-    if buffer.is_empty() {
-        return;
+fn column_at(origin: InlineOrigin<'_>, prefix: &str) -> u32 {
+    origin.column_offset + prefix.chars().count() as u32
+}
+
+fn is_url_safe(url: &str) -> bool {
+    let Some(colon) = url.find(':') else {
+        return true;
+    };
+    let scheme = &url[..colon];
+    if scheme.is_empty() {
+        return true;
     }
-    segments.push(InlineSegment::Text(std::mem::take(buffer)));
+    if !scheme.starts_with(|character: char| character.is_ascii_alphabetic()) {
+        return true;
+    }
+    if !scheme.chars().all(|character| {
+        character.is_ascii_alphanumeric()
+            || character == '+'
+            || character == '-'
+            || character == '.'
+    }) {
+        return true;
+    }
+    matches!(
+        scheme.to_ascii_lowercase().as_str(),
+        "http" | "https" | "mailto"
+    )
 }
 
 #[cfg(test)]
 mod tests {
+    use std::path::PathBuf;
+
     use super::*;
+
+    fn source_file(text: &str) -> SourceFile {
+        SourceFile::new_with_identity_path(
+            PathBuf::from("guide.adoc"),
+            text.to_string(),
+            PathBuf::from("guide.adoc"),
+        )
+    }
+
+    fn origin_for<'a>(source: &'a SourceFile, line: u32, column_offset: u32) -> InlineOrigin<'a> {
+        InlineOrigin {
+            source,
+            line,
+            column_offset,
+        }
+    }
+
+    fn parse(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
+        let source = source_file(text);
+        let origin = origin_for(&source, 1, 1);
+        parse_inlines(text, origin)
+    }
 
     #[test]
     fn parse_inlines_returns_single_text_segment_for_plain_prose() {
-        let (segments, diagnostics) = parse_inlines("hello world");
+        let (segments, diagnostics) = parse("hello world");
 
         assert_eq!(
             segments,
@@ -192,7 +274,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_returns_empty_for_empty_input() {
-        let (segments, diagnostics) = parse_inlines("");
+        let (segments, diagnostics) = parse("");
 
         assert!(segments.is_empty());
         assert!(diagnostics.is_empty());
@@ -200,7 +282,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_recognizes_single_asterisk_emphasis() {
-        let (segments, diagnostics) = parse_inlines("*emphasis*");
+        let (segments, diagnostics) = parse("*emphasis*");
 
         assert_eq!(
             segments,
@@ -213,7 +295,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_treats_unclosed_emphasis_as_literal() {
-        let (segments, diagnostics) = parse_inlines("*lone marker");
+        let (segments, diagnostics) = parse("*lone marker");
 
         assert_eq!(
             segments,
@@ -224,7 +306,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_treats_unclosed_code_as_literal() {
-        let (segments, diagnostics) = parse_inlines("`lone backtick");
+        let (segments, diagnostics) = parse("`lone backtick");
 
         assert_eq!(
             segments,
@@ -235,7 +317,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_treats_link_without_paren_as_literal() {
-        let (segments, diagnostics) = parse_inlines("[label]");
+        let (segments, diagnostics) = parse("[label]");
 
         assert_eq!(segments, vec![InlineSegment::Text("[label]".to_string())]);
         assert!(diagnostics.is_empty());
@@ -243,7 +325,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_treats_link_with_unclosed_url_as_literal() {
-        let (segments, diagnostics) = parse_inlines("[label](https://example.test");
+        let (segments, diagnostics) = parse("[label](https://example.test");
 
         assert_eq!(
             segments,
@@ -257,7 +339,7 @@ mod tests {
     #[test]
     fn parse_inlines_handles_mixed_text_emphasis_code_link_chain() {
         let (segments, diagnostics) =
-            parse_inlines("Try *foo* and `bar` then [docs](https://example.test) end.");
+            parse("Try *foo* and `bar` then [docs](https://example.test) end.");
 
         assert_eq!(
             segments,
@@ -279,7 +361,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_recognizes_link_with_https_url() {
-        let (segments, diagnostics) = parse_inlines("[label](https://example.test)");
+        let (segments, diagnostics) = parse("[label](https://example.test)");
 
         assert_eq!(
             segments,
@@ -293,7 +375,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_link_inside_paragraph() {
-        let (segments, _) = parse_inlines("see [docs](https://example.test) for details");
+        let (segments, _) = parse("see [docs](https://example.test) for details");
 
         assert_eq!(
             segments,
@@ -310,7 +392,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_recognizes_inline_code() {
-        let (segments, diagnostics) = parse_inlines("`adoc check`");
+        let (segments, diagnostics) = parse("`adoc check`");
 
         assert_eq!(
             segments,
@@ -321,7 +403,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_does_not_format_inside_inline_code() {
-        let (segments, _) = parse_inlines("`*not emphasis*`");
+        let (segments, _) = parse("`*not emphasis*`");
 
         assert_eq!(
             segments,
@@ -331,7 +413,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_recognizes_double_asterisk_strong() {
-        let (segments, diagnostics) = parse_inlines("**strong**");
+        let (segments, diagnostics) = parse("**strong**");
 
         assert_eq!(
             segments,
@@ -344,7 +426,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_recognizes_strong_inside_paragraph() {
-        let (segments, _) = parse_inlines("before **bold** after");
+        let (segments, _) = parse("before **bold** after");
 
         assert_eq!(
             segments,
@@ -358,7 +440,7 @@ mod tests {
 
     #[test]
     fn parse_inlines_emphasis_around_text() {
-        let (segments, _) = parse_inlines("before *em* after");
+        let (segments, _) = parse("before *em* after");
 
         assert_eq!(
             segments,
@@ -367,6 +449,45 @@ mod tests {
                 InlineSegment::Emphasis(vec![InlineSegment::Text("em".to_string())]),
                 InlineSegment::Text(" after".to_string()),
             ]
+        );
+    }
+
+    #[test]
+    fn parse_inlines_emits_unsafe_link_diagnostic_for_javascript_url() {
+        let line_text = "see [click](javascript:alert) here";
+        let source = source_file(line_text);
+        let origin = origin_for(&source, 1, 1);
+
+        let (segments, diagnostics) = parse_inlines(line_text, origin);
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text(
+                "see [click](javascript:alert) here".to_string()
+            )],
+            "unsafe link must fall back to literal text"
+        );
+        assert_eq!(diagnostics.len(), 1, "expected one unsafe-link diagnostic");
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.code, "parse.unsafe_link");
+        assert!(
+            diagnostic.message.contains("javascript:alert"),
+            "diagnostic message should quote the offending URL: {}",
+            diagnostic.message
+        );
+        let span = diagnostic.span.as_ref().expect("diagnostic has span");
+        assert_eq!(span.start.line, 1);
+        assert_eq!(span.start.column, 5);
+        assert_eq!(span.end.column, 30);
+    }
+
+    #[test]
+    fn parse_inlines_does_not_flag_relative_link_url() {
+        let (_segments, diagnostics) = parse("see [docs](./guide.html) for context");
+
+        assert!(
+            diagnostics.is_empty(),
+            "relative URL should be safe: {diagnostics:?}"
         );
     }
 

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -482,6 +482,30 @@ mod tests {
     }
 
     #[test]
+    fn parse_inlines_accepts_mailto_link() {
+        let line_text = "send to [team](mailto:dev@example.test)";
+        let source = source_file(line_text);
+        let origin = origin_for(&source, 1, 1);
+
+        let (segments, diagnostics) = parse_inlines(line_text, origin);
+
+        assert!(
+            diagnostics.is_empty(),
+            "mailto: must be on the safe allowlist: {diagnostics:?}"
+        );
+        assert_eq!(
+            segments,
+            vec![
+                InlineSegment::Text("send to ".to_string()),
+                InlineSegment::Link {
+                    text: vec![InlineSegment::Text("team".to_string())],
+                    url: "mailto:dev@example.test".to_string(),
+                },
+            ]
+        );
+    }
+
+    #[test]
     fn parse_inlines_does_not_flag_relative_link_url() {
         let (_segments, diagnostics) = parse("see [docs](./guide.html) for context");
 

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -516,6 +516,34 @@ mod tests {
     }
 
     #[test]
+    fn parse_inlines_preserves_html_special_chars_verbatim() {
+        let (segments, diagnostics) = parse("AT&T uses < and > with \"quotes\".");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text(
+                "AT&T uses < and > with \"quotes\".".to_string()
+            )],
+            "scanner must not pre-escape; renderer owns HTML escaping"
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_preserves_html_special_chars_inside_inline_code() {
+        let (segments, _) = parse("Run `<adoc>` with caution.");
+
+        assert_eq!(
+            segments,
+            vec![
+                InlineSegment::Text("Run ".to_string()),
+                InlineSegment::Code("<adoc>".to_string()),
+                InlineSegment::Text(" with caution.".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn plain_text_concatenates_text_segments() {
         let segments = vec![
             InlineSegment::Text("hello ".to_string()),

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -4,6 +4,7 @@ use crate::diagnostic::Diagnostic;
 pub enum InlineSegment {
     Text(String),
     Emphasis(Vec<InlineSegment>),
+    Strong(Vec<InlineSegment>),
 }
 
 pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
@@ -13,9 +14,13 @@ pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
     let mut cursor = 0;
 
     while cursor < text.len() {
-        if let Some(consumed) =
-            scan_emphasis(text, cursor, &mut segments, &mut diagnostics, &mut buffer)
-        {
+        if let Some(consumed) = scan_emphasis_or_strong(
+            text,
+            cursor,
+            &mut segments,
+            &mut diagnostics,
+            &mut buffer,
+        ) {
             cursor += consumed;
             continue;
         }
@@ -42,32 +47,54 @@ fn append_plain_text(segments: &[InlineSegment], buffer: &mut String) {
     for segment in segments {
         match segment {
             InlineSegment::Text(text) => buffer.push_str(text),
-            InlineSegment::Emphasis(inner) => append_plain_text(inner, buffer),
+            InlineSegment::Emphasis(inner) | InlineSegment::Strong(inner) => {
+                append_plain_text(inner, buffer)
+            }
         }
     }
 }
 
-fn scan_emphasis(
+fn scan_emphasis_or_strong(
     text: &str,
     cursor: usize,
     segments: &mut Vec<InlineSegment>,
     diagnostics: &mut Vec<Diagnostic>,
     buffer: &mut String,
 ) -> Option<usize> {
-    if !text[cursor..].starts_with('*') {
-        return None;
+    let remainder = &text[cursor..];
+    if remainder.starts_with("**") {
+        return scan_paired_marker(text, cursor, "**", segments, diagnostics, buffer, |inner| {
+            InlineSegment::Strong(inner)
+        });
     }
-    let after = &text[cursor + 1..];
-    let close_offset = after.find('*')?;
+    if remainder.starts_with('*') {
+        return scan_paired_marker(text, cursor, "*", segments, diagnostics, buffer, |inner| {
+            InlineSegment::Emphasis(inner)
+        });
+    }
+    None
+}
+
+fn scan_paired_marker(
+    text: &str,
+    cursor: usize,
+    marker: &str,
+    segments: &mut Vec<InlineSegment>,
+    diagnostics: &mut Vec<Diagnostic>,
+    buffer: &mut String,
+    wrap: impl FnOnce(Vec<InlineSegment>) -> InlineSegment,
+) -> Option<usize> {
+    let after_open = &text[cursor + marker.len()..];
+    let close_offset = after_open.find(marker)?;
     if close_offset == 0 {
         return None;
     }
-    let inner = &after[..close_offset];
+    let inner = &after_open[..close_offset];
     flush_text(segments, buffer);
     let (inner_segments, inner_diagnostics) = parse_inlines(inner);
     diagnostics.extend(inner_diagnostics);
-    segments.push(InlineSegment::Emphasis(inner_segments));
-    Some(1 + close_offset + 1)
+    segments.push(wrap(inner_segments));
+    Some(marker.len() + close_offset + marker.len())
 }
 
 fn flush_text(segments: &mut Vec<InlineSegment>, buffer: &mut String) {
@@ -111,6 +138,33 @@ mod tests {
             )])]
         );
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_recognizes_double_asterisk_strong() {
+        let (segments, diagnostics) = parse_inlines("**strong**");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Strong(vec![InlineSegment::Text(
+                "strong".to_string()
+            )])]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_recognizes_strong_inside_paragraph() {
+        let (segments, _) = parse_inlines("before **bold** after");
+
+        assert_eq!(
+            segments,
+            vec![
+                InlineSegment::Text("before ".to_string()),
+                InlineSegment::Strong(vec![InlineSegment::Text("bold".to_string())]),
+                InlineSegment::Text(" after".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -212,6 +212,49 @@ mod tests {
     }
 
     #[test]
+    fn parse_inlines_treats_unclosed_emphasis_as_literal() {
+        let (segments, diagnostics) = parse_inlines("*lone marker");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text("*lone marker".to_string())]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_treats_unclosed_code_as_literal() {
+        let (segments, diagnostics) = parse_inlines("`lone backtick");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text("`lone backtick".to_string())]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_treats_link_without_paren_as_literal() {
+        let (segments, diagnostics) = parse_inlines("[label]");
+
+        assert_eq!(segments, vec![InlineSegment::Text("[label]".to_string())]);
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_treats_link_with_unclosed_url_as_literal() {
+        let (segments, diagnostics) = parse_inlines("[label](https://example.test");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text(
+                "[label](https://example.test".to_string()
+            )]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn parse_inlines_handles_mixed_text_emphasis_code_link_chain() {
         let (segments, diagnostics) =
             parse_inlines("Try *foo* and `bar` then [docs](https://example.test) end.");

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -6,6 +6,10 @@ pub enum InlineSegment {
     Code(String),
     Emphasis(Vec<InlineSegment>),
     Strong(Vec<InlineSegment>),
+    Link {
+        text: Vec<InlineSegment>,
+        url: String,
+    },
 }
 
 pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
@@ -16,6 +20,12 @@ pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
 
     while cursor < text.len() {
         if let Some(consumed) = scan_code(text, cursor, &mut segments, &mut buffer) {
+            cursor += consumed;
+            continue;
+        }
+        if let Some(consumed) =
+            scan_link(text, cursor, &mut segments, &mut diagnostics, &mut buffer)
+        {
             cursor += consumed;
             continue;
         }
@@ -55,8 +65,44 @@ fn append_plain_text(segments: &[InlineSegment], buffer: &mut String) {
             InlineSegment::Emphasis(inner) | InlineSegment::Strong(inner) => {
                 append_plain_text(inner, buffer)
             }
+            InlineSegment::Link { text, .. } => append_plain_text(text, buffer),
         }
     }
+}
+
+fn scan_link(
+    text: &str,
+    cursor: usize,
+    segments: &mut Vec<InlineSegment>,
+    diagnostics: &mut Vec<Diagnostic>,
+    buffer: &mut String,
+) -> Option<usize> {
+    if !text[cursor..].starts_with('[') {
+        return None;
+    }
+    let after_open_bracket = &text[cursor + 1..];
+    let close_bracket_offset = after_open_bracket.find(']')?;
+    if close_bracket_offset == 0 {
+        return None;
+    }
+    let label_text = &after_open_bracket[..close_bracket_offset];
+
+    let after_close_bracket = &after_open_bracket[close_bracket_offset + 1..];
+    if !after_close_bracket.starts_with('(') {
+        return None;
+    }
+    let after_open_paren = &after_close_bracket[1..];
+    let close_paren_offset = after_open_paren.find(')')?;
+    let url = after_open_paren[..close_paren_offset].to_string();
+
+    flush_text(segments, buffer);
+    let (label_segments, label_diagnostics) = parse_inlines(label_text);
+    diagnostics.extend(label_diagnostics);
+    segments.push(InlineSegment::Link {
+        text: label_segments,
+        url,
+    });
+    Some(1 + close_bracket_offset + 1 + 1 + close_paren_offset + 1)
 }
 
 fn scan_code(
@@ -163,6 +209,37 @@ mod tests {
             )])]
         );
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_recognizes_link_with_https_url() {
+        let (segments, diagnostics) = parse_inlines("[label](https://example.test)");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Link {
+                text: vec![InlineSegment::Text("label".to_string())],
+                url: "https://example.test".to_string(),
+            }]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_link_inside_paragraph() {
+        let (segments, _) = parse_inlines("see [docs](https://example.test) for details");
+
+        assert_eq!(
+            segments,
+            vec![
+                InlineSegment::Text("see ".to_string()),
+                InlineSegment::Link {
+                    text: vec![InlineSegment::Text("docs".to_string())],
+                    url: "https://example.test".to_string(),
+                },
+                InlineSegment::Text(" for details".to_string()),
+            ]
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -3,23 +3,78 @@ use crate::diagnostic::Diagnostic;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InlineSegment {
     Text(String),
+    Emphasis(Vec<InlineSegment>),
 }
 
 pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
-    if text.is_empty() {
-        return (Vec::new(), Vec::new());
+    let mut segments = Vec::new();
+    let mut diagnostics = Vec::new();
+    let mut buffer = String::new();
+    let mut cursor = 0;
+
+    while cursor < text.len() {
+        if let Some(consumed) =
+            scan_emphasis(text, cursor, &mut segments, &mut diagnostics, &mut buffer)
+        {
+            cursor += consumed;
+            continue;
+        }
+
+        let character = text[cursor..]
+            .chars()
+            .next()
+            .expect("cursor points at a character boundary");
+        buffer.push(character);
+        cursor += character.len_utf8();
     }
-    (vec![InlineSegment::Text(text.to_string())], Vec::new())
+
+    flush_text(&mut segments, &mut buffer);
+    (segments, diagnostics)
 }
 
 pub fn plain_text(segments: &[InlineSegment]) -> String {
     let mut buffer = String::new();
+    append_plain_text(segments, &mut buffer);
+    buffer
+}
+
+fn append_plain_text(segments: &[InlineSegment], buffer: &mut String) {
     for segment in segments {
         match segment {
             InlineSegment::Text(text) => buffer.push_str(text),
+            InlineSegment::Emphasis(inner) => append_plain_text(inner, buffer),
         }
     }
-    buffer
+}
+
+fn scan_emphasis(
+    text: &str,
+    cursor: usize,
+    segments: &mut Vec<InlineSegment>,
+    diagnostics: &mut Vec<Diagnostic>,
+    buffer: &mut String,
+) -> Option<usize> {
+    if !text[cursor..].starts_with('*') {
+        return None;
+    }
+    let after = &text[cursor + 1..];
+    let close_offset = after.find('*')?;
+    if close_offset == 0 {
+        return None;
+    }
+    let inner = &after[..close_offset];
+    flush_text(segments, buffer);
+    let (inner_segments, inner_diagnostics) = parse_inlines(inner);
+    diagnostics.extend(inner_diagnostics);
+    segments.push(InlineSegment::Emphasis(inner_segments));
+    Some(1 + close_offset + 1)
+}
+
+fn flush_text(segments: &mut Vec<InlineSegment>, buffer: &mut String) {
+    if buffer.is_empty() {
+        return;
+    }
+    segments.push(InlineSegment::Text(std::mem::take(buffer)));
 }
 
 #[cfg(test)]
@@ -46,6 +101,33 @@ mod tests {
     }
 
     #[test]
+    fn parse_inlines_recognizes_single_asterisk_emphasis() {
+        let (segments, diagnostics) = parse_inlines("*emphasis*");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Emphasis(vec![InlineSegment::Text(
+                "emphasis".to_string()
+            )])]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_emphasis_around_text() {
+        let (segments, _) = parse_inlines("before *em* after");
+
+        assert_eq!(
+            segments,
+            vec![
+                InlineSegment::Text("before ".to_string()),
+                InlineSegment::Emphasis(vec![InlineSegment::Text("em".to_string())]),
+                InlineSegment::Text(" after".to_string()),
+            ]
+        );
+    }
+
+    #[test]
     fn plain_text_concatenates_text_segments() {
         let segments = vec![
             InlineSegment::Text("hello ".to_string()),
@@ -53,5 +135,15 @@ mod tests {
         ];
 
         assert_eq!(plain_text(&segments), "hello world");
+    }
+
+    #[test]
+    fn plain_text_flattens_emphasis_to_inner_text() {
+        let segments = vec![
+            InlineSegment::Text("Hello ".to_string()),
+            InlineSegment::Emphasis(vec![InlineSegment::Text("world".to_string())]),
+        ];
+
+        assert_eq!(plain_text(&segments), "Hello world");
     }
 }

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -3,6 +3,7 @@ use crate::diagnostic::Diagnostic;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum InlineSegment {
     Text(String),
+    Code(String),
     Emphasis(Vec<InlineSegment>),
     Strong(Vec<InlineSegment>),
 }
@@ -14,6 +15,10 @@ pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
     let mut cursor = 0;
 
     while cursor < text.len() {
+        if let Some(consumed) = scan_code(text, cursor, &mut segments, &mut buffer) {
+            cursor += consumed;
+            continue;
+        }
         if let Some(consumed) = scan_emphasis_or_strong(
             text,
             cursor,
@@ -46,12 +51,32 @@ pub fn plain_text(segments: &[InlineSegment]) -> String {
 fn append_plain_text(segments: &[InlineSegment], buffer: &mut String) {
     for segment in segments {
         match segment {
-            InlineSegment::Text(text) => buffer.push_str(text),
+            InlineSegment::Text(text) | InlineSegment::Code(text) => buffer.push_str(text),
             InlineSegment::Emphasis(inner) | InlineSegment::Strong(inner) => {
                 append_plain_text(inner, buffer)
             }
         }
     }
+}
+
+fn scan_code(
+    text: &str,
+    cursor: usize,
+    segments: &mut Vec<InlineSegment>,
+    buffer: &mut String,
+) -> Option<usize> {
+    if !text[cursor..].starts_with('`') {
+        return None;
+    }
+    let after_open = &text[cursor + 1..];
+    let close_offset = after_open.find('`')?;
+    if close_offset == 0 {
+        return None;
+    }
+    let inner = after_open[..close_offset].to_string();
+    flush_text(segments, buffer);
+    segments.push(InlineSegment::Code(inner));
+    Some(1 + close_offset + 1)
 }
 
 fn scan_emphasis_or_strong(
@@ -138,6 +163,27 @@ mod tests {
             )])]
         );
         assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_recognizes_inline_code() {
+        let (segments, diagnostics) = parse_inlines("`adoc check`");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Code("adoc check".to_string())]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_does_not_format_inside_inline_code() {
+        let (segments, _) = parse_inlines("`*not emphasis*`");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Code("*not emphasis*".to_string())]
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -145,7 +145,11 @@ fn scan_link(
         return Some(total_consumed);
     }
 
-    let (label_segments, label_diagnostics) = parse_inlines(label_text, origin);
+    let label_origin = InlineOrigin {
+        column_offset: column_at(origin, &text[..cursor + 1]),
+        ..origin
+    };
+    let (label_segments, label_diagnostics) = parse_inlines(label_text, label_origin);
     output.diagnostics.extend(label_diagnostics);
     output.push_segment(InlineSegment::Link {
         text: label_segments,
@@ -198,7 +202,11 @@ fn scan_paired_marker(
         return None;
     }
     let inner = &after_open[..close_offset];
-    let (inner_segments, inner_diagnostics) = parse_inlines(inner, origin);
+    let inner_origin = InlineOrigin {
+        column_offset: column_at(origin, &text[..cursor + marker.len()]),
+        ..origin
+    };
+    let (inner_segments, inner_diagnostics) = parse_inlines(inner, inner_origin);
     output.diagnostics.extend(inner_diagnostics);
     output.push_segment(wrap(inner_segments));
     Some(marker.len() + close_offset + marker.len())
@@ -544,6 +552,42 @@ mod tests {
         );
         assert_eq!(diagnostics.len(), 1);
         assert_eq!(diagnostics[0].code, "parse.unsafe_link");
+    }
+
+    #[test]
+    fn parse_inlines_reports_correct_column_for_unsafe_link_inside_emphasis() {
+        let line_text = "*[click](javascript:bad)*";
+        let source = source_file(line_text);
+        let origin = origin_for(&source, 1, 1);
+
+        let (_segments, diagnostics) = parse_inlines(line_text, origin);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "parse.unsafe_link");
+        let span = diagnostics[0].span.as_ref().expect("diagnostic has span");
+        assert_eq!(
+            span.start.column, 2,
+            "link inside emphasis must report inner column"
+        );
+        assert_eq!(span.end.column, 25);
+    }
+
+    #[test]
+    fn parse_inlines_reports_correct_column_for_unsafe_link_inside_strong() {
+        let line_text = "**[click](javascript:bad)**";
+        let source = source_file(line_text);
+        let origin = origin_for(&source, 1, 1);
+
+        let (_segments, diagnostics) = parse_inlines(line_text, origin);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "parse.unsafe_link");
+        let span = diagnostics[0].span.as_ref().expect("diagnostic has span");
+        assert_eq!(
+            span.start.column, 3,
+            "link inside strong must report inner column past two-char marker"
+        );
+        assert_eq!(span.end.column, 26);
     }
 
     #[test]

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -1,0 +1,57 @@
+use crate::diagnostic::Diagnostic;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum InlineSegment {
+    Text(String),
+}
+
+pub fn parse_inlines(text: &str) -> (Vec<InlineSegment>, Vec<Diagnostic>) {
+    if text.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+    (vec![InlineSegment::Text(text.to_string())], Vec::new())
+}
+
+pub fn plain_text(segments: &[InlineSegment]) -> String {
+    let mut buffer = String::new();
+    for segment in segments {
+        match segment {
+            InlineSegment::Text(text) => buffer.push_str(text),
+        }
+    }
+    buffer
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_inlines_returns_single_text_segment_for_plain_prose() {
+        let (segments, diagnostics) = parse_inlines("hello world");
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text("hello world".to_string())]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn parse_inlines_returns_empty_for_empty_input() {
+        let (segments, diagnostics) = parse_inlines("");
+
+        assert!(segments.is_empty());
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
+    fn plain_text_concatenates_text_segments() {
+        let segments = vec![
+            InlineSegment::Text("hello ".to_string()),
+            InlineSegment::Text("world".to_string()),
+        ];
+
+        assert_eq!(plain_text(&segments), "hello world");
+    }
+}

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -209,6 +209,9 @@ fn column_at(origin: InlineOrigin<'_>, prefix: &str) -> u32 {
 }
 
 fn is_url_safe(url: &str) -> bool {
+    if url.bytes().any(|byte| byte.is_ascii_whitespace()) {
+        return false;
+    }
     let Some(colon) = url.find(':') else {
         return true;
     };
@@ -503,6 +506,44 @@ mod tests {
                 },
             ]
         );
+    }
+
+    #[test]
+    fn parse_inlines_rejects_whitespace_prefixed_javascript_url() {
+        let line_text = "see [click]( javascript:alert) here";
+        let source = source_file(line_text);
+        let origin = origin_for(&source, 1, 1);
+
+        let (segments, diagnostics) = parse_inlines(line_text, origin);
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text(
+                "see [click]( javascript:alert) here".to_string()
+            )],
+            "leading-whitespace url must fall back to literal text"
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "parse.unsafe_link");
+    }
+
+    #[test]
+    fn parse_inlines_rejects_internal_tab_in_javascript_url() {
+        let line_text = "see [click](j\tavascript:alert) here";
+        let source = source_file(line_text);
+        let origin = origin_for(&source, 1, 1);
+
+        let (segments, diagnostics) = parse_inlines(line_text, origin);
+
+        assert_eq!(
+            segments,
+            vec![InlineSegment::Text(
+                "see [click](j\tavascript:alert) here".to_string()
+            )],
+            "internal-tab url must fall back to literal text"
+        );
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "parse.unsafe_link");
     }
 
     #[test]

--- a/crates/adoc-core/src/inline.rs
+++ b/crates/adoc-core/src/inline.rs
@@ -212,6 +212,29 @@ mod tests {
     }
 
     #[test]
+    fn parse_inlines_handles_mixed_text_emphasis_code_link_chain() {
+        let (segments, diagnostics) =
+            parse_inlines("Try *foo* and `bar` then [docs](https://example.test) end.");
+
+        assert_eq!(
+            segments,
+            vec![
+                InlineSegment::Text("Try ".to_string()),
+                InlineSegment::Emphasis(vec![InlineSegment::Text("foo".to_string())]),
+                InlineSegment::Text(" and ".to_string()),
+                InlineSegment::Code("bar".to_string()),
+                InlineSegment::Text(" then ".to_string()),
+                InlineSegment::Link {
+                    text: vec![InlineSegment::Text("docs".to_string())],
+                    url: "https://example.test".to_string(),
+                },
+                InlineSegment::Text(" end.".to_string()),
+            ]
+        );
+        assert!(diagnostics.is_empty());
+    }
+
+    #[test]
     fn parse_inlines_recognizes_link_with_https_url() {
         let (segments, diagnostics) = parse_inlines("[label](https://example.test)");
 

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -2,6 +2,7 @@ mod artifact;
 mod ast;
 mod compile;
 mod diagnostic;
+mod inline;
 mod parser;
 mod render;
 mod source;

--- a/crates/adoc-core/src/parser.rs
+++ b/crates/adoc-core/src/parser.rs
@@ -1,5 +1,6 @@
 use crate::ast::{BlockAst, CodeBlockAst, HeadingAst, ListAst, ListKind, PageAst, ParagraphAst};
 use crate::diagnostic::{Diagnostic, SourceSpan};
+use crate::inline::{self, InlineSegment};
 use crate::source::{SourceFile, derive_page_id};
 
 pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
@@ -10,7 +11,7 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
         blocks: Vec::new(),
     };
     let mut diagnostics = Vec::new();
-    let mut paragraph_lines = Vec::new();
+    let mut paragraph_lines: Vec<Vec<InlineSegment>> = Vec::new();
     let mut paragraph_start_line = None;
     let mut paragraph_end_line = None;
     let mut pending_list = None;
@@ -85,17 +86,20 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 );
             }
 
+            let (inlines, heading_diagnostics) = inline::parse_inlines(&heading.text);
+            diagnostics.extend(heading_diagnostics);
+
             let is_first_page_heading = heading.level == 1 && !has_seen_page_heading;
             if is_first_page_heading {
                 has_seen_page_heading = true;
-                page.title = Some(heading.text.clone());
+                page.title = Some(inline::plain_text(&inlines));
                 if let Some(doc_id) = heading.doc_id.clone() {
                     page.id = doc_id;
                 }
             }
             page.blocks.push(BlockAst::Heading(HeadingAst {
                 level: heading.level,
-                text: heading.text,
+                inlines,
                 span,
             }));
             continue;
@@ -153,19 +157,22 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 &mut paragraph_start_line,
                 &mut paragraph_end_line,
             );
+            let item_text = item.trim();
+            let (item_inlines, item_diagnostics) = inline::parse_inlines(item_text);
+            diagnostics.extend(item_diagnostics);
             push_list_item(
                 source,
                 &mut page.blocks,
                 &mut pending_list,
                 ListKind::Unordered,
-                item.trim().to_string(),
+                item_inlines,
                 line_number,
                 line,
             );
             continue;
         }
 
-        if let Some(item) = parse_ordered_list_item(trimmed) {
+        if let Some(item_text) = parse_ordered_list_item(trimmed) {
             flush_paragraph(
                 source,
                 &mut page.blocks,
@@ -173,12 +180,14 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 &mut paragraph_start_line,
                 &mut paragraph_end_line,
             );
+            let (item_inlines, item_diagnostics) = inline::parse_inlines(item_text);
+            diagnostics.extend(item_diagnostics);
             push_list_item(
                 source,
                 &mut page.blocks,
                 &mut pending_list,
                 ListKind::Ordered,
-                item.to_string(),
+                item_inlines,
                 line_number,
                 line,
             );
@@ -186,9 +195,11 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
         }
 
         flush_list(&mut page.blocks, &mut pending_list);
+        let (line_inlines, line_diagnostics) = inline::parse_inlines(trimmed);
+        diagnostics.extend(line_diagnostics);
         paragraph_start_line.get_or_insert(line_number);
         paragraph_end_line = Some(line_number);
-        paragraph_lines.push(trimmed.to_string());
+        paragraph_lines.push(line_inlines);
     }
 
     flush_paragraph(
@@ -211,7 +222,7 @@ struct ParsedHeading {
 
 struct PendingList {
     kind: ListKind,
-    items: Vec<String>,
+    items: Vec<Vec<InlineSegment>>,
     span: SourceSpan,
 }
 
@@ -425,7 +436,7 @@ fn push_list_item(
     blocks: &mut Vec<BlockAst>,
     pending_list: &mut Option<PendingList>,
     kind: ListKind,
-    item: String,
+    item: Vec<InlineSegment>,
     line_number: u32,
     line: &str,
 ) {
@@ -459,7 +470,7 @@ fn flush_list(blocks: &mut Vec<BlockAst>, pending_list: &mut Option<PendingList>
 fn flush_paragraph(
     source: &SourceFile,
     blocks: &mut Vec<BlockAst>,
-    paragraph_lines: &mut Vec<String>,
+    paragraph_lines: &mut Vec<Vec<InlineSegment>>,
     paragraph_start_line: &mut Option<u32>,
     paragraph_end_line: &mut Option<u32>,
 ) {
@@ -467,14 +478,19 @@ fn flush_paragraph(
         return;
     }
 
-    let text = paragraph_lines.join(" ");
+    let mut inlines: Vec<InlineSegment> = Vec::new();
+    for (index, line_inlines) in paragraph_lines.drain(..).enumerate() {
+        if index > 0 {
+            inlines.push(InlineSegment::Text(" ".to_string()));
+        }
+        inlines.extend(line_inlines);
+    }
     let start_line = paragraph_start_line.unwrap_or(1);
     let end_line = paragraph_end_line.unwrap_or(start_line);
     blocks.push(BlockAst::Paragraph(ParagraphAst {
         span: source.span_for_line_range(start_line, end_line),
-        text,
+        inlines,
     }));
-    paragraph_lines.clear();
     *paragraph_start_line = None;
     *paragraph_end_line = None;
 }
@@ -594,7 +610,10 @@ mod tests {
             })
             .expect("paragraph block exists");
 
-        assert_eq!(paragraph.text, "Café first second line");
+        assert_eq!(
+            inline::plain_text(&paragraph.inlines),
+            "Café first second line"
+        );
         assert_eq!(paragraph.span.start.line, 3);
         assert_eq!(paragraph.span.start.column, 1);
         assert_eq!(paragraph.span.end.line, 4);

--- a/crates/adoc-core/src/parser.rs
+++ b/crates/adoc-core/src/parser.rs
@@ -1,6 +1,6 @@
 use crate::ast::{BlockAst, CodeBlockAst, HeadingAst, ListAst, ListKind, PageAst, ParagraphAst};
 use crate::diagnostic::{Diagnostic, SourceSpan};
-use crate::inline::{self, InlineSegment};
+use crate::inline::{self, InlineOrigin, InlineSegment};
 use crate::source::{SourceFile, derive_page_id};
 
 pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
@@ -86,7 +86,15 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 );
             }
 
-            let (inlines, heading_diagnostics) = inline::parse_inlines(&heading.text);
+            let heading_text_column = leading_indent_columns + heading.level as u32 + 2;
+            let (inlines, heading_diagnostics) = inline::parse_inlines(
+                &heading.text,
+                InlineOrigin {
+                    source,
+                    line: line_number,
+                    column_offset: heading_text_column,
+                },
+            );
             diagnostics.extend(heading_diagnostics);
 
             let is_first_page_heading = heading.level == 1 && !has_seen_page_heading;
@@ -158,7 +166,15 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 &mut paragraph_end_line,
             );
             let item_text = item.trim();
-            let (item_inlines, item_diagnostics) = inline::parse_inlines(item_text);
+            let item_column = leading_indent_columns + 3;
+            let (item_inlines, item_diagnostics) = inline::parse_inlines(
+                item_text,
+                InlineOrigin {
+                    source,
+                    line: line_number,
+                    column_offset: item_column,
+                },
+            );
             diagnostics.extend(item_diagnostics);
             push_list_item(
                 source,
@@ -172,7 +188,9 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
             continue;
         }
 
-        if let Some(item_text) = parse_ordered_list_item(trimmed) {
+        if let Some((item_text, item_column)) =
+            parse_ordered_list_item(trimmed, leading_indent_columns)
+        {
             flush_paragraph(
                 source,
                 &mut page.blocks,
@@ -180,7 +198,14 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 &mut paragraph_start_line,
                 &mut paragraph_end_line,
             );
-            let (item_inlines, item_diagnostics) = inline::parse_inlines(item_text);
+            let (item_inlines, item_diagnostics) = inline::parse_inlines(
+                item_text,
+                InlineOrigin {
+                    source,
+                    line: line_number,
+                    column_offset: item_column,
+                },
+            );
             diagnostics.extend(item_diagnostics);
             push_list_item(
                 source,
@@ -195,7 +220,15 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
         }
 
         flush_list(&mut page.blocks, &mut pending_list);
-        let (line_inlines, line_diagnostics) = inline::parse_inlines(trimmed);
+        let column_offset = leading_indent_columns + 1;
+        let (line_inlines, line_diagnostics) = inline::parse_inlines(
+            trimmed,
+            InlineOrigin {
+                source,
+                line: line_number,
+                column_offset,
+            },
+        );
         diagnostics.extend(line_diagnostics);
         paragraph_start_line.get_or_insert(line_number);
         paragraph_end_line = Some(line_number);
@@ -353,7 +386,7 @@ fn annotation_span(
     }
 }
 
-fn parse_ordered_list_item(line: &str) -> Option<&str> {
+fn parse_ordered_list_item(line: &str, leading_indent_columns: u32) -> Option<(&str, u32)> {
     let dot_index = line.find(". ")?;
     if dot_index == 0 {
         return None;
@@ -362,7 +395,11 @@ fn parse_ordered_list_item(line: &str) -> Option<&str> {
     line[..dot_index]
         .chars()
         .all(|character| character.is_ascii_digit())
-        .then_some(line[dot_index + 2..].trim())
+        .then(|| {
+            let item_text = line[dot_index + 2..].trim();
+            let item_column = leading_indent_columns + dot_index as u32 + 3;
+            (item_text, item_column)
+        })
 }
 
 fn find_raw_html(line: &str) -> Option<RawHtmlMatch> {

--- a/crates/adoc-core/src/parser.rs
+++ b/crates/adoc-core/src/parser.rs
@@ -142,15 +142,10 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 );
             }
             page.blocks.push(BlockAst::CodeBlock(CodeBlockAst {
-                language: language
-                    .trim()
-                    .is_empty()
-                    .then_some(None)
-                    .flatten()
-                    .or_else(|| {
-                        let language = language.trim().to_string();
-                        (!language.is_empty()).then_some(language)
-                    }),
+                language: {
+                    let language = language.trim();
+                    (!language.is_empty()).then(|| language.to_string())
+                },
                 code,
                 span: source.span_for_line(line_number, line),
             }));

--- a/crates/adoc-core/src/parser.rs
+++ b/crates/adoc-core/src/parser.rs
@@ -86,7 +86,7 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
                 );
             }
 
-            let heading_text_column = leading_indent_columns + heading.level as u32 + 2;
+            let heading_text_column = heading.text_column;
             let (inlines, heading_diagnostics) = inline::parse_inlines(
                 &heading.text,
                 InlineOrigin {
@@ -249,6 +249,7 @@ pub fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
 struct ParsedHeading {
     level: u8,
     text: String,
+    text_column: u32,
     doc_id: Option<String>,
     malformed_page_annotation: Option<PageAnnotationSpan>,
 }
@@ -279,12 +280,16 @@ fn parse_heading(line: &str, leading_indent_columns: u32) -> Option<ParsedHeadin
         return None;
     }
 
-    let raw_text_start_column = leading_indent_columns + marker_count as u32 + 2;
-    let raw_text = line[marker_count + 1..].trim();
-    let annotation = parse_page_annotation(raw_text, raw_text_start_column);
+    let after_markers = &line[marker_count..];
+    let leading_ws = after_markers.chars().take_while(|c| *c == ' ').count();
+    let text_start_byte = marker_count + leading_ws;
+    let text_column = leading_indent_columns + marker_count as u32 + leading_ws as u32 + 1;
+    let raw_text = line[text_start_byte..].trim_end();
+    let annotation = parse_page_annotation(raw_text, text_column);
     Some(ParsedHeading {
         level: marker_count as u8,
         text: annotation.text,
+        text_column,
         doc_id: annotation.doc_id,
         malformed_page_annotation: annotation.malformed_span,
     })
@@ -579,6 +584,19 @@ mod tests {
         assert_eq!(diagnostics[0].code, "parse.malformed_page_annotation");
         let span = diagnostics[0].span.as_ref().unwrap();
         assert_eq!(span.start.column, 12);
+    }
+
+    #[test]
+    fn heading_with_extra_marker_padding_reports_correct_inline_column() {
+        let (_page, diagnostics) = parse_source("##   [click](javascript:bad)\n");
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, "parse.unsafe_link");
+        let span = diagnostics[0].span.as_ref().unwrap();
+        assert_eq!(
+            span.start.column, 6,
+            "extra spaces after # markers must shift the inline column accordingly"
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -82,6 +82,11 @@ fn render_inline(segment: &InlineSegment, html: &mut String) {
             render_inlines(inner, html);
             html.push_str("</em>");
         }
+        InlineSegment::Strong(inner) => {
+            html.push_str("<strong>");
+            render_inlines(inner, html);
+            html.push_str("</strong>");
+        }
     }
 }
 

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -110,3 +110,69 @@ fn escape_html(value: &str) -> String {
         .replace('"', "&quot;")
         .replace('\'', "&#39;")
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn render(segments: &[InlineSegment]) -> String {
+        let mut html = String::new();
+        render_inlines(segments, &mut html);
+        html
+    }
+
+    #[test]
+    fn render_inlines_emits_text_with_html_escaping() {
+        let html = render(&[InlineSegment::Text("AT&T <ok>".to_string())]);
+        assert_eq!(html, "AT&amp;T &lt;ok&gt;");
+    }
+
+    #[test]
+    fn render_inlines_emits_code_tag_with_escaped_body() {
+        let html = render(&[InlineSegment::Code("Vec<String>".to_string())]);
+        assert_eq!(html, "<code>Vec&lt;String&gt;</code>");
+    }
+
+    #[test]
+    fn render_inlines_emits_em_tag_around_inner_segments() {
+        let html = render(&[InlineSegment::Emphasis(vec![InlineSegment::Text(
+            "italic".to_string(),
+        )])]);
+        assert_eq!(html, "<em>italic</em>");
+    }
+
+    #[test]
+    fn render_inlines_emits_strong_tag_around_inner_segments() {
+        let html = render(&[InlineSegment::Strong(vec![InlineSegment::Text(
+            "bold".to_string(),
+        )])]);
+        assert_eq!(html, "<strong>bold</strong>");
+    }
+
+    #[test]
+    fn render_inlines_emits_anchor_with_escaped_href_attribute() {
+        let html = render(&[InlineSegment::Link {
+            text: vec![InlineSegment::Text("docs".to_string())],
+            url: "https://example.test/?q=\"a&b\"".to_string(),
+        }]);
+        assert_eq!(
+            html,
+            "<a href=\"https://example.test/?q=&quot;a&amp;b&quot;\">docs</a>"
+        );
+    }
+
+    #[test]
+    fn render_inlines_recursively_renders_link_label() {
+        let html = render(&[InlineSegment::Link {
+            text: vec![
+                InlineSegment::Text("see ".to_string()),
+                InlineSegment::Code("adoc".to_string()),
+            ],
+            url: "https://example.test".to_string(),
+        }]);
+        assert_eq!(
+            html,
+            "<a href=\"https://example.test\">see <code>adoc</code></a>"
+        );
+    }
+}

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -162,6 +162,69 @@ mod tests {
     }
 
     #[test]
+    fn render_html_flows_inlines_through_heading_paragraph_and_list_item() {
+        use crate::ast::{HeadingAst, ListAst, ListKind, ParagraphAst};
+        use crate::diagnostic::{SourcePosition, SourceSpan};
+        use std::path::PathBuf;
+
+        fn span() -> SourceSpan {
+            SourceSpan {
+                file: PathBuf::from("guide.adoc"),
+                start: SourcePosition {
+                    line: 1,
+                    column: 1,
+                    offset: 0,
+                },
+                end: SourcePosition {
+                    line: 1,
+                    column: 1,
+                    offset: 0,
+                },
+            }
+        }
+
+        let page = PageAst {
+            id: "guide".to_string(),
+            title: Some("Title".to_string()),
+            source_path: PathBuf::from("guide.adoc"),
+            blocks: vec![
+                BlockAst::Heading(HeadingAst {
+                    level: 1,
+                    inlines: vec![
+                        InlineSegment::Text("Title with ".to_string()),
+                        InlineSegment::Strong(vec![InlineSegment::Text("bold".to_string())]),
+                    ],
+                    span: span(),
+                }),
+                BlockAst::Paragraph(ParagraphAst {
+                    inlines: vec![
+                        InlineSegment::Text("First ".to_string()),
+                        InlineSegment::Emphasis(vec![InlineSegment::Text("emphasis".to_string())]),
+                        InlineSegment::Text(" then ".to_string()),
+                        InlineSegment::Code("ident".to_string()),
+                        InlineSegment::Text(".".to_string()),
+                    ],
+                    span: span(),
+                }),
+                BlockAst::List(ListAst {
+                    kind: ListKind::Unordered,
+                    items: vec![vec![
+                        InlineSegment::Text("Run ".to_string()),
+                        InlineSegment::Code("adoc check".to_string()),
+                    ]],
+                    span: span(),
+                }),
+            ],
+        };
+
+        let html = render_html(&[page]);
+
+        assert!(html.contains("<h1>Title with <strong>bold</strong></h1>"));
+        assert!(html.contains("<p>First <em>emphasis</em> then <code>ident</code>.</p>"));
+        assert!(html.contains("<li>Run <code>adoc check</code></li>"));
+    }
+
+    #[test]
     fn render_inlines_recursively_renders_link_label() {
         let html = render(&[InlineSegment::Link {
             text: vec![

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -77,6 +77,11 @@ fn render_inline(segment: &InlineSegment, html: &mut String) {
         InlineSegment::Text(text) => {
             html.push_str(&escape_html(text));
         }
+        InlineSegment::Emphasis(inner) => {
+            html.push_str("<em>");
+            render_inlines(inner, html);
+            html.push_str("</em>");
+        }
     }
 }
 

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -1,4 +1,5 @@
 use crate::ast::{BlockAst, ListKind, PageAst};
+use crate::inline::InlineSegment;
 
 pub fn render_html(pages: &[PageAst]) -> String {
     let mut html = String::from(
@@ -25,14 +26,13 @@ fn render_block(block: &BlockAst, html: &mut String) {
     match block {
         BlockAst::Heading(heading) => {
             let level = heading.level.clamp(1, 6);
-            html.push_str(&format!(
-                "<h{level}>{}</h{level}>\n",
-                escape_html(&heading.text)
-            ));
+            html.push_str(&format!("<h{level}>"));
+            render_inlines(&heading.inlines, html);
+            html.push_str(&format!("</h{level}>\n"));
         }
         BlockAst::Paragraph(paragraph) => {
             html.push_str("<p>");
-            html.push_str(&escape_html(&paragraph.text));
+            render_inlines(&paragraph.inlines, html);
             html.push_str("</p>\n");
         }
         BlockAst::List(list) => {
@@ -45,7 +45,7 @@ fn render_block(block: &BlockAst, html: &mut String) {
             html.push_str(">\n");
             for item in &list.items {
                 html.push_str("<li>");
-                html.push_str(&escape_html(item));
+                render_inlines(item, html);
                 html.push_str("</li>\n");
             }
             html.push_str("</");
@@ -62,6 +62,20 @@ fn render_block(block: &BlockAst, html: &mut String) {
             html.push('>');
             html.push_str(&escape_html(&code_block.code));
             html.push_str("</code></pre>\n");
+        }
+    }
+}
+
+fn render_inlines(segments: &[InlineSegment], html: &mut String) {
+    for segment in segments {
+        render_inline(segment, html);
+    }
+}
+
+fn render_inline(segment: &InlineSegment, html: &mut String) {
+    match segment {
+        InlineSegment::Text(text) => {
+            html.push_str(&escape_html(text));
         }
     }
 }

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -77,6 +77,11 @@ fn render_inline(segment: &InlineSegment, html: &mut String) {
         InlineSegment::Text(text) => {
             html.push_str(&escape_html(text));
         }
+        InlineSegment::Code(code) => {
+            html.push_str("<code>");
+            html.push_str(&escape_html(code));
+            html.push_str("</code>");
+        }
         InlineSegment::Emphasis(inner) => {
             html.push_str("<em>");
             render_inlines(inner, html);

--- a/crates/adoc-core/src/render/html.rs
+++ b/crates/adoc-core/src/render/html.rs
@@ -92,6 +92,13 @@ fn render_inline(segment: &InlineSegment, html: &mut String) {
             render_inlines(inner, html);
             html.push_str("</strong>");
         }
+        InlineSegment::Link { text, url } => {
+            html.push_str("<a href=\"");
+            html.push_str(&escape_html(url));
+            html.push_str("\">");
+            render_inlines(text, html);
+            html.push_str("</a>");
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Lands the second V0.1 tracer-bullet milestone: inline syntax (`*em*`, `**strong**`, `` `code` ``, `[label](url)`) rendered through `adoc check` and `adoc build` end to end, plus golden HTML and agent JSON snapshots that lock the full pipeline by integration test rather than substring asserts.

The structured inline scanner is internal to `adoc-core` (`InlineSegment` is not re-exported), so the public V0 contract from the first slice stays unchanged.

## What changed

- **`adoc-core::inline`** — char-by-char inline scanner producing `InlineSegment::{Text, Code, Emphasis, Strong, Link}`. No `str::replace`-based syntax recognition; per-marker `scan_*` helpers behind a small `ScannerOutput` (per ADR-0004).
- **Strict link safety** — non-`http`/`https`/`mailto` URLs (`javascript:`, `data:`, `file:`, …) emit `parse.unsafe_link` with accurate file/line/column and the offending URL quoted in the message; the link falls back to literal text rather than an `<a href>`.
- **Permissive inline failure** — unmatched `*`, backtick, or `[…](…` markers stay literal with no diagnostic (Markdown convention; keeps strict-mode noise focused on safety + structural failures).
- **Renderer** — emits semantic `<em>`, `<strong>`, `<code>`, and `<a href>` with HTML-escaped element bodies and attribute-escaped href values. Heading, paragraph, and list-item all flow through `render_inlines`.
- **AST migration** — `HeadingAst`/`ParagraphAst`/`ListAst` carry `Vec<InlineSegment>` instead of plain `String`; existing parser tests migrated to assert via `inline::plain_text`.
- **Fixtures** — `crates/adoc-cli/tests/fixtures/v0_1/{prose_page,unsafe_link,unclosed_fence}.adoc` plus `prose_page.golden.html` and `prose_page.golden.agent.json`.
- **Golden snapshots** — byte-diff CLI tests for both HTML and agent JSON; the JSON test runs with `cwd=workspace` so the recorded `source_path` stays portable across hosts and CI runners.
- **Diagnostic regression** — fixture-backed test pinning all six fields of `parse.unclosed_fence` (file / line / column / severity / code / message) per the issue's acceptance criterion 3.

Delivered as 18 vertical TDD slices, one commit per RED → GREEN → commit cycle (no horizontal commits).

Closes #3.

## Acceptance-criteria mapping

| Criterion | Covered by |
| --- | --- |
| Prose fixture validates cleanly with all common syntax | `check_accepts_v0_1_prose_fixture_with_all_inline_syntax` |
| `adoc build` produces semantic HTML for all constructs | `build_renders_v0_1_prose_fixture_to_golden_html` + render unit tests |
| Malformed fenced code → file/line/column/severity/code/message | `check_unclosed_fence_diagnostic_surfaces_all_six_fields` |
| Agent JSON: page records present, objects empty | `build_renders_v0_1_prose_fixture_to_golden_agent_json` |
| Golden / snapshot tests cover HTML and JSON | both byte-diff CLI tests |
| Parser stays structured / line-oriented (ADR-0004) | inline scanner architecture + clippy clean |

## Test plan

- [x] `cargo test --workspace` — 62 tests pass (23 inline-scanner unit, 7 renderer unit, 9 parser/source unit, 23 CLI integration)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: `adoc check fixtures/v0_1/prose_page.adoc` → `0 errors`
- [x] Manual: `adoc build fixtures/v0_1/prose_page.adoc --out /tmp/…` → matches both golden snapshots byte-for-byte
- [x] Manual: `adoc check fixtures/v0_1/unsafe_link.adoc` → exit 1, `parse.unsafe_link` at correct `line:column`
- [x] Manual: `adoc check fixtures/v0_1/unclosed_fence.adoc` → exit 1, `parse.unclosed_fence` at correct `line:column`

## Review response

Four atomic commits addressing all four blocking/polish items raised in review. Workspace tests now: 67 passing (25 inline-scanner unit, 10 parser unit, 7 renderer unit, 2 source unit, 23 CLI integration).

| Commit | Review item | Notes |
| --- | --- | --- |
| 710e707 `fix: reject urls with ascii whitespace in scheme classification` | #1 🔴 strict-mode bypass | Closes both the leading-whitespace bypass (`[click]( javascript:alert)`) and the internal-tab bypass (`[click](j\tavascript:alert)`) — the latter exploited the same default-allow-on-invalid-charset path the original fix would have left open. Two regression tests pinned. |
| a9f00d2 `fix: propagate shifted column offsets through nested inline scanners` | #2 🟠 origin drift | `scan_link` and `scan_paired_marker` now bump `column_offset` by chars consumed before the inner slice begins, using the existing `column_at` helper. Pinned with `**[click](javascript:bad)**` reporting column 3 (past the `**` opener). The link-label recursion uses the same fix but is not observable through the current diagnostic surface — `scan_link`'s first-`]` greediness prevents nested links. |
| a873752 `fix: track actual whitespace span in heading text column` | #3 🟡 heading column off-by-one | `ParsedHeading` now carries an absolute `text_column: u32` field; `parse_heading` counts actual leading whitespace; the caller uses `heading.text_column` directly — no `+ 2` magic, no recomputation, no drift risk. Pinned with `##   [click](javascript:bad)` reporting column 6. |
| 9b08386 `refactor: simplify code-fence language extraction` | #4 🟡 dead chain | Replaces `.then_some(None).flatten().or_else(…)` (where the first chain provably collapses to `None`) with the reviewer's direct equivalent. |

### Follow-up issues (review item #5)

- #21 — Cap recursion depth in `parse_inlines` (#5a)
- #22 — Align link URL safety check with WHATWG URL parser semantics (paired with the conservative reject-whitespace heuristic landed in commit 710e707)
- #23 — Replace 5-pass `escape_html` with a single-pass character walk (#5b)
