### PR TITLE
feat(adoc-core): render claim optional-field metadata footer in HTML

### DIFF
--- a/crates/adoc-cli/tests/fixtures/v0_2/claim_basic.golden.html
+++ b/crates/adoc-cli/tests/fixtures/v0_2/claim_basic.golden.html
@@ -11,6 +11,11 @@
 <section class="claim" id="billing.credits">
 <header class="claim__header"><span class="claim__kind">claim</span><code class="claim__id">billing.credits</code><span class="claim__status">verified</span></header>
 <div class="claim__body"><p>The system credits users automatically when a payment fails.</p></div>
+<footer class="claim__metadata">
+<dl>
+<dt>owner</dt><dd>team-billing</dd>
+</dl>
+</footer>
 </section>
 </article>
 </body>

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -87,6 +87,19 @@ fn render_block(block: &BlockAst, html: &mut String) {
                 html.push_str("<div class=\"claim__body\"><p>");
                 html.push_str(&escape_html(claim.body().as_str()));
                 html.push_str("</p></div>\n");
+                if !claim.fields().is_empty() {
+                    html.push_str("<footer class=\"claim__metadata\">\n");
+                    html.push_str("<dl>\n");
+                    for (key, value) in claim.fields().iter() {
+                        html.push_str("<dt>");
+                        html.push_str(&escape_html(key));
+                        html.push_str("</dt><dd>");
+                        html.push_str(&escape_html(value));
+                        html.push_str("</dd>\n");
+                    }
+                    html.push_str("</dl>\n");
+                    html.push_str("</footer>\n");
+                }
                 html.push_str("</section>\n");
             }
         },
@@ -322,6 +335,104 @@ mod tests {
         assert!(
             html.contains("<p>body content</p>"),
             "missing body paragraph: {html}"
+        );
+    }
+
+    #[test]
+    fn claim_omits_metadata_footer_when_fields_are_empty() {
+        let block = make_claim(
+            "billing.credits",
+            "verified",
+            "body content",
+            std::collections::BTreeMap::new(),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        assert!(
+            !html.contains("<footer class=\"claim__metadata\">"),
+            "unexpected metadata footer: {html}"
+        );
+    }
+
+    #[test]
+    fn claim_renders_metadata_footer_when_fields_are_present() {
+        let mut fields = std::collections::BTreeMap::new();
+        fields.insert("source".to_string(), "ledger".to_string());
+        fields.insert("owner".to_string(), "".to_string());
+        let block = make_claim(
+            "billing.credits",
+            "verified",
+            "body content",
+            fields,
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        assert!(
+            html.contains("<footer class=\"claim__metadata\">\n<dl>\n"),
+            "missing metadata footer: {html}"
+        );
+        assert!(
+            html.contains("<dt>source</dt><dd>ledger</dd>"),
+            "missing populated field: {html}"
+        );
+        assert!(
+            html.contains("<dt>owner</dt><dd></dd>"),
+            "missing empty value field: {html}"
+        );
+    }
+
+    #[test]
+    fn claim_renders_metadata_fields_in_sorted_key_order() {
+        let mut fields = std::collections::BTreeMap::new();
+        fields.insert("zeta".to_string(), "last".to_string());
+        fields.insert("alpha".to_string(), "first".to_string());
+        fields.insert("middle".to_string(), "second".to_string());
+        let block = make_claim(
+            "billing.credits",
+            "verified",
+            "body content",
+            fields,
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        let alpha = html.find("<dt>alpha</dt>").expect("missing alpha field");
+        let middle = html.find("<dt>middle</dt>").expect("missing middle field");
+        let zeta = html.find("<dt>zeta</dt>").expect("missing zeta field");
+
+        assert!(
+            alpha < middle && middle < zeta,
+            "fields not sorted by key: {html}"
+        );
+    }
+
+    #[test]
+    fn claim_html_escapes_metadata_keys_and_values() {
+        let mut fields = std::collections::BTreeMap::new();
+        fields.insert(
+            "a <key> & \"id\"".to_string(),
+            "value 'x' & <y>".to_string(),
+        );
+        let block = make_claim(
+            "billing.credits",
+            "verified",
+            "body content",
+            fields,
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        assert!(
+            html.contains(
+                "<dt>a &lt;key&gt; &amp; &quot;id&quot;</dt><dd>value &#39;x&#39; &amp; &lt;y&gt;</dd>"
+            ),
+            "metadata key or value not escaped: {html}"
         );
     }
 

--- a/crates/adoc-core/tests/clean_artifact_fixtures.rs
+++ b/crates/adoc-core/tests/clean_artifact_fixtures.rs
@@ -1,0 +1,106 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use adoc_core::{CompileInput, compile_workspace};
+
+#[test]
+fn clean_claim_fixtures_match_expected_artifacts() {
+    for fixture in clean_claim_fixtures() {
+        fixture.assert_matches_expected_artifacts();
+    }
+}
+
+#[derive(Debug)]
+struct CleanFixture {
+    name: String,
+    directory: PathBuf,
+    compile_root: PathBuf,
+}
+
+impl CleanFixture {
+    fn assert_matches_expected_artifacts(&self) {
+        let result = compile_workspace(CompileInput {
+            root: self.compile_root.clone(),
+        });
+
+        assert!(
+            !result.has_errors(),
+            "fixture {} should compile without errors, got: {:?}",
+            self.name,
+            result.diagnostics
+        );
+        assert!(
+            result.diagnostics.is_empty(),
+            "fixture {} should compile without diagnostics, got: {:?}",
+            self.name,
+            result.diagnostics
+        );
+
+        let artifacts = result
+            .artifacts
+            .expect("clean fixture compilation should produce artifacts");
+
+        let expected_html = read_fixture_file(&self.directory, "expected.html");
+        assert_eq!(
+            artifacts.html, expected_html,
+            "fixture {} HTML artifact mismatch",
+            self.name
+        );
+
+        let expected_agent_json = read_fixture_file(&self.directory, "expected.agent.json");
+        let actual_agent_json = format!(
+            "{}\n",
+            artifacts
+                .agent_json
+                .to_pretty_json()
+                .expect("agent JSON should serialize")
+        );
+        assert_eq!(
+            actual_agent_json, expected_agent_json,
+            "fixture {} agent JSON artifact mismatch",
+            self.name
+        );
+    }
+}
+
+fn clean_claim_fixtures() -> Vec<CleanFixture> {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let fixture_root = manifest_dir.join("tests/fixtures/claim");
+    let mut fixtures = fs::read_dir(&fixture_root)
+        .unwrap_or_else(|error| {
+            panic!(
+                "claim fixture root {} should be readable: {error}",
+                fixture_root.display()
+            )
+        })
+        .filter_map(|entry| entry.ok())
+        .filter(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
+        .map(|entry| {
+            let directory = entry.path();
+            let name = entry.file_name().to_string_lossy().into_owned();
+            let input = directory.join("input.adoc");
+            let compile_root = input
+                .strip_prefix(&manifest_dir)
+                .expect("fixture input should live under crate manifest dir")
+                .to_path_buf();
+
+            CleanFixture {
+                name,
+                directory,
+                compile_root,
+            }
+        })
+        .collect::<Vec<_>>();
+    fixtures.sort_by(|left, right| left.name.cmp(&right.name));
+    fixtures
+}
+
+fn read_fixture_file(directory: &Path, file_name: &str) -> String {
+    let path = directory.join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "fixture file {} should be readable: {error}",
+            path.display()
+        )
+    })
+}

--- a/crates/adoc-core/tests/fixtures/claim/valid_claim_no_optional_fields/expected.agent.json
+++ b/crates/adoc-core/tests/fixtures/claim/valid_claim_no_optional_fields/expected.agent.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "adoc.agent.v0",
+  "pages": [
+    {
+      "id": "team.billing",
+      "title": "Billing Guide",
+      "source_path": "tests/fixtures/claim/valid_claim_no_optional_fields/input.adoc"
+    }
+  ],
+  "objects": [
+    {
+      "id": "billing.no-optional",
+      "kind": "claim",
+      "status": "draft",
+      "body": "A billing claim can omit optional metadata.",
+      "page_id": "team.billing",
+      "source_span": {
+        "path": "tests/fixtures/claim/valid_claim_no_optional_fields/input.adoc",
+        "line": 5,
+        "column": 1
+      },
+      "fields": {},
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    }
+  ],
+  "diagnostics": []
+}

--- a/crates/adoc-core/tests/fixtures/claim/valid_claim_no_optional_fields/expected.html
+++ b/crates/adoc-core/tests/fixtures/claim/valid_claim_no_optional_fields/expected.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AgentDoc</title>
+</head>
+<body>
+<article data-page-id="team.billing">
+<h1>Billing Guide</h1>
+<p>The billing system records clean claim metadata.</p>
+<section class="claim" id="billing.no-optional">
+<header class="claim__header"><span class="claim__kind">claim</span><code class="claim__id">billing.no-optional</code><span class="claim__status">draft</span></header>
+<div class="claim__body"><p>A billing claim can omit optional metadata.</p></div>
+</section>
+</article>
+</body>
+</html>

--- a/crates/adoc-core/tests/fixtures/claim/valid_claim_no_optional_fields/input.adoc
+++ b/crates/adoc-core/tests/fixtures/claim/valid_claim_no_optional_fields/input.adoc
@@ -1,0 +1,9 @@
+# Billing Guide @doc(team.billing)
+
+The billing system records clean claim metadata.
+
+::claim billing.no-optional
+status: draft
+--
+A billing claim can omit optional metadata.
+::

--- a/crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/expected.agent.json
+++ b/crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/expected.agent.json
@@ -1,0 +1,34 @@
+{
+  "schema_version": "adoc.agent.v0",
+  "pages": [
+    {
+      "id": "team.billing",
+      "title": "Billing Guide",
+      "source_path": "tests/fixtures/claim/valid_claim_with_optional_fields/input.adoc"
+    }
+  ],
+  "objects": [
+    {
+      "id": "billing.optional-fields",
+      "kind": "claim",
+      "status": "verified",
+      "body": "The billing system credits users automatically when a payment fails.",
+      "page_id": "team.billing",
+      "source_span": {
+        "path": "tests/fixtures/claim/valid_claim_with_optional_fields/input.adoc",
+        "line": 5,
+        "column": 1
+      },
+      "fields": {
+        "owner": "team-billing's auditors",
+        "source": "payments & \"ledger\""
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    }
+  ],
+  "diagnostics": []
+}

--- a/crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/expected.html
+++ b/crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/expected.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AgentDoc</title>
+</head>
+<body>
+<article data-page-id="team.billing">
+<h1>Billing Guide</h1>
+<p>The billing system records clean claim metadata.</p>
+<section class="claim" id="billing.optional-fields">
+<header class="claim__header"><span class="claim__kind">claim</span><code class="claim__id">billing.optional-fields</code><span class="claim__status">verified</span></header>
+<div class="claim__body"><p>The billing system credits users automatically when a payment fails.</p></div>
+<footer class="claim__metadata">
+<dl>
+<dt>owner</dt><dd>team-billing&#39;s auditors</dd>
+<dt>source</dt><dd>payments &amp; &quot;ledger&quot;</dd>
+</dl>
+</footer>
+</section>
+</article>
+</body>
+</html>

--- a/crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/input.adoc
+++ b/crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/input.adoc
@@ -1,0 +1,11 @@
+# Billing Guide @doc(team.billing)
+
+The billing system records clean claim metadata.
+
+::claim billing.optional-fields
+status: verified
+source: payments & "ledger"
+owner: team-billing's auditors
+--
+The billing system credits users automatically when a payment fails.
+::


### PR DESCRIPTION
## Summary

- Render an optional-field metadata `<dl>` footer beneath the claim body in HTML output when `ClaimFields` is non-empty.
- Omit the footer entirely when `ClaimFields::is_empty()` — no empty `<footer>` element is emitted.
- Keys appear in alphabetical (BTreeMap-natural) order; both keys and values are HTML-escaped.

Narrow, HTML-adapter-only slice — no domain, validator, or JSON output changes. Existing `valid_claim_with_optional_fields/expected.agent.json` is byte-identical.

## Changes

- `crates/adoc-core/src/infrastructure/render/html.rs` — extend the `BlockAst::KnowledgeObject(Claim(_))` arm to emit the `<footer class="claim__metadata">` block when fields are present.
- `crates/adoc-core/tests/clean_artifact_fixtures.rs` — add a claim artifact fixture runner that drives the new fixtures.
- New fixtures:
  - `valid_claim_with_optional_fields/` — pins footer presence and alphabetical key order.
  - `valid_claim_no_optional_fields/` — pins footer omission when `ClaimFields::is_empty()`.
- Updated `adoc-cli` claim HTML golden to reflect the metadata footer for the existing claim sample.

## Test plan

- [ ] `cargo test --workspace`
- [ ] `cargo clippy --workspace -- -D warnings`
- [ ] `git diff -- crates/adoc-core/tests/fixtures/claim/valid_claim_with_optional_fields/expected.agent.json` is empty (JSON unchanged)
- [ ] `crates/adoc-core/tests/public_surface.rs` unchanged

## Refs

- Closes #29
- Parent: #4 (V0.2 plan)
- Builds on Slice 1's claim wiring already merged into `feat/issue-4`