### PR TITLE
feat(adoc-core): detect duplicate Knowledge Object ids across workspace

### DIFF
--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -531,6 +531,63 @@ fn build_rejects_inline_raw_html_and_writes_no_artifacts() {
 }
 
 #[test]
+fn duplicate_claim_ids_fail_check_and_block_build_artifacts() {
+    let workspace = TestWorkspace::new("duplicate-claim-ids");
+    workspace.write(
+        "01-billing.adoc",
+        "# Billing Credits @doc(billing.credits-page)\n\n::claim billing.credits.foo\nstatus: verified\n--\nCredits are granted after payment succeeds.\n::\n",
+    );
+    workspace.write(
+        "02-billing-extra.adoc",
+        "# Billing Extra @doc(billing.extra-page)\n\n::claim billing.credits.foo\nstatus: draft\n--\nCredits are also described here.\n::\n",
+    );
+
+    let check_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "check",
+            workspace.root.to_str().expect("root path is utf-8"),
+        ])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !check_output.status.success(),
+        "expected duplicate claim ids to fail check"
+    );
+    let check_stdout = String::from_utf8_lossy(&check_output.stdout);
+    assert!(
+        check_stdout.contains("error[id.duplicate]"),
+        "expected id.duplicate diagnostic in stdout:\n{check_stdout}"
+    );
+    assert!(check_stdout.contains("1 errors"));
+
+    let output_directory = workspace.root.join("dist");
+    let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "build",
+            workspace.root.to_str().expect("root path is utf-8"),
+            "--out",
+            output_directory
+                .to_str()
+                .expect("output directory path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        !build_output.status.success(),
+        "expected duplicate claim ids to fail build"
+    );
+    let build_stdout = String::from_utf8_lossy(&build_output.stdout);
+    assert!(
+        build_stdout.contains("error[id.duplicate]"),
+        "expected id.duplicate diagnostic in build stdout:\n{build_stdout}"
+    );
+    assert!(!output_directory.join("docs.html").exists());
+    assert!(!output_directory.join("docs.agent.json").exists());
+}
+
+#[test]
 fn check_allows_raw_html_inside_closed_fenced_code_block() {
     let workspace = TestWorkspace::new("check-allows-raw-html-in-fence");
     let source = workspace.write(

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -31,6 +31,7 @@ pub enum DiagnosticCode {
     ParseMalformedOpenFence,
     SchemaMissingField,
     SchemaDuplicateField,
+    IdDuplicate,
     IdInvalid,
     IoUnreadableFile,
 }
@@ -47,6 +48,7 @@ impl DiagnosticCode {
             DiagnosticCode::ParseMalformedOpenFence => "parse.malformed_open_fence",
             DiagnosticCode::SchemaMissingField => "schema.missing_field",
             DiagnosticCode::SchemaDuplicateField => "schema.duplicate_field",
+            DiagnosticCode::IdDuplicate => "id.duplicate",
             DiagnosticCode::IdInvalid => "id.invalid",
             DiagnosticCode::IoUnreadableFile => "io.unreadable_file",
         }

--- a/crates/adoc-core/src/infrastructure/validate/claim_unique_ids.rs
+++ b/crates/adoc-core/src/infrastructure/validate/claim_unique_ids.rs
@@ -1,0 +1,205 @@
+use std::collections::HashMap;
+
+use crate::domain::ast::{BlockAst, WorkspaceAst};
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
+use crate::domain::identity::ObjectId;
+use crate::domain::knowledge_object::KnowledgeObject;
+use crate::domain::rules::WorkspaceRule;
+
+pub(crate) struct ClaimUniqueIds;
+
+impl WorkspaceRule for ClaimUniqueIds {
+    fn check(&self, workspace: &WorkspaceAst, sink: &mut Vec<Diagnostic>) {
+        let mut first_occurrences: HashMap<ObjectId, SourceSpan> = HashMap::new();
+
+        for page in &workspace.pages {
+            for block in &page.blocks {
+                let BlockAst::KnowledgeObject(knowledge_object) = block else {
+                    continue;
+                };
+                let KnowledgeObject::Claim(claim) = knowledge_object.as_ref();
+
+                if let Some(first_span) = first_occurrences.get(claim.id()) {
+                    sink.push(
+                        Diagnostic::error(
+                            DiagnosticCode::IdDuplicate,
+                            format!(
+                                "duplicate claim id `{}`; previously defined at {}:{}:{}",
+                                claim.id(),
+                                first_span.file.display(),
+                                first_span.start.line,
+                                first_span.start.column
+                            ),
+                        )
+                        .with_span(claim.span().clone()),
+                    );
+                } else {
+                    first_occurrences.insert(claim.id().clone(), claim.span().clone());
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::domain::ast::{BlockAst, PageAst};
+    use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+    use crate::domain::identity::PageId;
+    use crate::domain::knowledge_object::claim::Claim;
+
+    fn span(file: &str, line: u32, column: u32) -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from(file),
+            start: SourcePosition {
+                line,
+                column,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line,
+                column: column + 20,
+                offset: 20,
+            },
+        }
+    }
+
+    fn claim_block(id: &str, span: SourceSpan) -> BlockAst {
+        let claim = Claim::try_new(id, Some("verified"), "Claim body.", BTreeMap::new(), span)
+            .expect("valid claim");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Claim(claim)))
+    }
+
+    fn page(source_path: &str, blocks: Vec<BlockAst>) -> PageAst {
+        PageAst {
+            id: PageId::from_string(format!("docs.{}", source_path.replace(".adoc", "")))
+                .expect("valid page id"),
+            title: None,
+            source_path: PathBuf::from(source_path),
+            blocks,
+        }
+    }
+
+    fn check(workspace: WorkspaceAst) -> Vec<Diagnostic> {
+        let mut diagnostics = Vec::new();
+        ClaimUniqueIds.check(&workspace, &mut diagnostics);
+        diagnostics
+    }
+
+    #[test]
+    fn emits_no_diagnostics_when_claim_ids_are_unique() {
+        let workspace = WorkspaceAst {
+            pages: vec![
+                page(
+                    "one.adoc",
+                    vec![claim_block("billing.credits", span("one.adoc", 3, 1))],
+                ),
+                page(
+                    "two.adoc",
+                    vec![claim_block("billing.invoices", span("two.adoc", 3, 1))],
+                ),
+            ],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    #[test]
+    fn emits_one_diagnostic_for_cross_page_duplicate_claim_id() {
+        let workspace = WorkspaceAst {
+            pages: vec![
+                page(
+                    "one.adoc",
+                    vec![claim_block("billing.credits", span("one.adoc", 3, 1))],
+                ),
+                page(
+                    "two.adoc",
+                    vec![claim_block("billing.credits", span("two.adoc", 5, 1))],
+                ),
+            ],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdDuplicate);
+        assert_eq!(
+            diagnostics[0].message,
+            "duplicate claim id `billing.credits`; previously defined at one.adoc:3:1"
+        );
+        assert_eq!(
+            diagnostics[0].span.as_ref().map(|span| &span.file),
+            Some(&PathBuf::from("two.adoc"))
+        );
+        assert!(diagnostics[0].object_id.is_none());
+    }
+
+    #[test]
+    fn emits_diagnostic_for_each_second_and_later_duplicate() {
+        let workspace = WorkspaceAst {
+            pages: vec![
+                page(
+                    "one.adoc",
+                    vec![claim_block("billing.credits", span("one.adoc", 3, 1))],
+                ),
+                page(
+                    "two.adoc",
+                    vec![claim_block("billing.credits", span("two.adoc", 5, 1))],
+                ),
+                page(
+                    "three.adoc",
+                    vec![claim_block("billing.credits", span("three.adoc", 7, 1))],
+                ),
+            ],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 2);
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code == DiagnosticCode::IdDuplicate)
+        );
+        assert!(
+            diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.message.contains("one.adoc:3:1"))
+        );
+    }
+
+    #[test]
+    fn same_page_duplicate_uses_first_occurrence_as_winner() {
+        let workspace = WorkspaceAst {
+            pages: vec![page(
+                "one.adoc",
+                vec![
+                    claim_block("billing.credits", span("one.adoc", 3, 1)),
+                    claim_block("billing.credits", span("one.adoc", 9, 1)),
+                ],
+            )],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdDuplicate);
+        assert_eq!(
+            diagnostics[0].message,
+            "duplicate claim id `billing.credits`; previously defined at one.adoc:3:1"
+        );
+        assert_eq!(
+            diagnostics[0]
+                .span
+                .as_ref()
+                .map(|span| (span.start.line, span.start.column)),
+            Some((9, 1))
+        );
+    }
+}

--- a/crates/adoc-core/src/infrastructure/validate/mod.rs
+++ b/crates/adoc-core/src/infrastructure/validate/mod.rs
@@ -9,8 +9,11 @@
 //! streaming context (you only know a fence is unclosed once EOF is reached),
 //! so that diagnostic remains in the parser. See ADR-0007 for the decision.
 
+mod claim_unique_ids;
 pub(crate) mod resolve_claims;
 pub(crate) use resolve_claims::resolve_knowledge_objects;
+
+use claim_unique_ids::ClaimUniqueIds;
 
 use crate::domain::ast::{BlockAst, PageAst, WorkspaceAst};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
@@ -27,11 +30,9 @@ const SOURCE_PAGE_RULES: &[&dyn ValidationRule] = &[&RawHtmlForbidden, &UnsafeLi
 /// into typed aggregates. Empty until a rule needs typed `Claim` data.
 const RESOLVED_PAGE_RULES: &[&dyn ValidationRule] = &[];
 
-/// Workspace-level rules, applied in registration order. Empty in v0.1 — the
-/// seam exists so future cross-page invariants (duplicate Object IDs across
-/// pages, broken `[link](id)` references) land as a new adapter plus a new
-/// entry here, not as a branch inside `compile_with_provider`.
-const WORKSPACE_RULES: &[&dyn WorkspaceRule] = &[];
+/// Workspace-level rules, applied in registration order after claim
+/// resolution and workspace assembly.
+const WORKSPACE_RULES: &[&dyn WorkspaceRule] = &[&ClaimUniqueIds];
 
 /// Run every source-page rule against `page`. The orchestrator performs the
 /// final source-position diagnostic sort before returning `CompileResult`.
@@ -57,9 +58,9 @@ fn validate_page_with_rules(
     diagnostics
 }
 
-/// Run every workspace-level rule against `workspace`. Empty registry in v0.1.
-/// Workspace rules run after per-page validation, so per-page errors are
-/// already in the sink by the time the orchestrator calls into here.
+/// Run every workspace-level rule against `workspace`. Workspace rules run
+/// after per-page validation, so per-page errors are already in the sink by
+/// the time the orchestrator calls into here.
 pub(crate) fn validate_workspace(workspace: &WorkspaceAst) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     for rule in WORKSPACE_RULES {
@@ -483,13 +484,11 @@ mod tests {
     }
 
     #[test]
-    fn validate_workspace_returns_empty_for_production_registry() {
+    fn validate_workspace_emits_no_diagnostics_for_workspace_without_claim_duplicates() {
         let workspace = workspace_with_titles(&["alpha"]);
 
         let diagnostics = validate_workspace(&workspace);
 
-        // No workspace-level rules ship today; landing one will replace the
-        // empty assertion with an actual rule's expected behaviour.
         assert!(diagnostics.is_empty());
     }
 

--- a/crates/adoc-core/tests/clean_artifact_fixtures.rs
+++ b/crates/adoc-core/tests/clean_artifact_fixtures.rs
@@ -75,6 +75,7 @@ fn clean_claim_fixtures() -> Vec<CleanFixture> {
         })
         .filter_map(|entry| entry.ok())
         .filter(|entry| entry.file_type().is_ok_and(|file_type| file_type.is_dir()))
+        .filter(|entry| entry.path().join("input.adoc").is_file())
         .map(|entry| {
             let directory = entry.path();
             let name = entry.file_name().to_string_lossy().into_owned();

--- a/crates/adoc-core/tests/diagnostic_fixtures.rs
+++ b/crates/adoc-core/tests/diagnostic_fixtures.rs
@@ -1,0 +1,76 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use adoc_core::{CompileInput, compile_workspace};
+
+#[test]
+fn duplicate_claim_id_fixture_matches_expected_diagnostics() {
+    let fixture = DiagnosticFixture::new("claim/duplicate_id_across_pages");
+
+    fixture.assert_matches_expected_diagnostics();
+}
+
+#[derive(Debug)]
+struct DiagnosticFixture {
+    name: String,
+    directory: PathBuf,
+    compile_root: PathBuf,
+}
+
+impl DiagnosticFixture {
+    fn new(relative_path: &str) -> Self {
+        let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+        let directory = manifest_dir.join("tests/fixtures").join(relative_path);
+        let compile_root = directory
+            .join("input")
+            .strip_prefix(&manifest_dir)
+            .expect("fixture input should live under crate manifest dir")
+            .to_path_buf();
+
+        Self {
+            name: relative_path.to_string(),
+            directory,
+            compile_root,
+        }
+    }
+
+    fn assert_matches_expected_diagnostics(&self) {
+        let result = compile_workspace(CompileInput {
+            root: self.compile_root.clone(),
+        });
+
+        assert!(
+            result.has_errors(),
+            "fixture {} should compile with errors",
+            self.name
+        );
+        assert!(
+            result.artifacts.is_none(),
+            "fixture {} errors must block artifacts",
+            self.name
+        );
+
+        let actual = format!(
+            "{}\n",
+            serde_json::to_string_pretty(&result.diagnostics)
+                .expect("diagnostics should serialize")
+        );
+        let expected = read_fixture_file(&self.directory, "expected.diagnostics.json");
+
+        assert_eq!(
+            actual, expected,
+            "fixture {} diagnostic JSON mismatch",
+            self.name
+        );
+    }
+}
+
+fn read_fixture_file(directory: &Path, file_name: &str) -> String {
+    let path = directory.join(file_name);
+    fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!(
+            "fixture file {} should be readable: {error}",
+            path.display()
+        )
+    })
+}

--- a/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/expected.diagnostics.json
@@ -1,0 +1,22 @@
+[
+  {
+    "code": "id.duplicate",
+    "severity": "error",
+    "message": "duplicate claim id `billing.credits.foo`; previously defined at tests/fixtures/claim/duplicate_id_across_pages/input/01-billing.adoc:5:1",
+    "span": {
+      "file": "tests/fixtures/claim/duplicate_id_across_pages/input/02-billing-extra.adoc",
+      "start": {
+        "line": 5,
+        "column": 1,
+        "offset": 94
+      },
+      "end": {
+        "line": 5,
+        "column": 28,
+        "offset": 121
+      }
+    },
+    "object_id": null,
+    "help": null
+  }
+]

--- a/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/input/01-billing.adoc
+++ b/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/input/01-billing.adoc
@@ -1,0 +1,9 @@
+# Billing Credits @doc(billing.credits-page)
+
+The billing page defines the first claim.
+
+::claim billing.credits.foo
+status: verified
+--
+Credits are granted after payment succeeds.
+::

--- a/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/input/02-billing-extra.adoc
+++ b/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/input/02-billing-extra.adoc
@@ -1,0 +1,9 @@
+# Billing Extra @doc(billing.extra-page)
+
+The extra billing page accidentally repeats an id.
+
+::claim billing.credits.foo
+status: draft
+--
+Credits are also described here.
+::

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -67,6 +67,7 @@ fn public_surface_compiles_with_only_documented_imports() {
     let _ = DiagnosticCode::ParseMalformedOpenFence;
     let _ = DiagnosticCode::SchemaMissingField;
     let _ = DiagnosticCode::SchemaDuplicateField;
+    let _ = DiagnosticCode::IdDuplicate;
     let _ = DiagnosticCode::IdInvalid;
     let _ = DiagnosticCode::IoUnreadableFile;
     // The wire string remains available for hosts that serialize manually.
@@ -79,6 +80,7 @@ fn public_surface_compiles_with_only_documented_imports() {
         DiagnosticCode::SchemaDuplicateField.as_str(),
         "schema.duplicate_field"
     );
+    assert_eq!(DiagnosticCode::IdDuplicate.as_str(), "id.duplicate");
     assert_eq!(
         DiagnosticCode::ParseUnknownBlockType.as_str(),
         "parse.unknown_block_type"


### PR DESCRIPTION
## Summary

- Adds the first non-empty `WorkspaceRule`: detects duplicate claim `ObjectId`s across all pages in a workspace and emits one `id.duplicate` error diagnostic per offending occurrence (first occurrence wins, subsequent ones are flagged citing the first).
- Introduces `DiagnosticCode::IdDuplicate` (wire string `"id.duplicate"`) and registers `validate_unique_claim_ids` in the `WORKSPACE_RULES` registry per ADR-0007 (rules-as-data).
- Artifact emission (`agent_json`, `html`) is automatically suppressed by the existing artifact gate when an `id.duplicate` error is present — verified by the new fixture having no `expected.html` / `expected.agent.json`.

## Why now

V0-DESIGN scheduled duplicate-ID detection for "later V0 slices". v0.2 is the first slice where any object type has a globally unique ID worth being unique, so duplicate-ID validation lands here. Future references and relations (v0.5) silently assume unique IDs — catching duplicates the moment IDs exist is the cheapest place to enforce the invariant.

## Design references

- **ADR-0006** — `compile_workspace` runs `validate_workspace` as a discrete pipeline stage; this slice fills that stage with its first non-empty rule.
- **ADR-0007** — Rule registry is a `const` slice; rules run after all per-page validation completes.
- **ADR-0009** — Hexagonal layout (rule lives under `infrastructure/validate/`).

## Changes

- `crates/adoc-core/src/domain/diagnostic.rs` — new `DiagnosticCode::IdDuplicate` variant.
- `crates/adoc-core/src/infrastructure/validate/claim_unique_ids.rs` — new rule + inline unit tests (no duplicates / one duplicate / two-duplicate-pair).
- `crates/adoc-core/src/infrastructure/validate/mod.rs` — register rule in `WORKSPACE_RULES`.
- `crates/adoc-core/tests/public_surface.rs` — assert `IdDuplicate` reachable and `as_str()` correct.
- `crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/` — cross-page duplicate fixture (two `.adoc` inputs, `expected.diagnostics.json`, no artifact expectations).
- `crates/adoc-core/tests/diagnostic_fixtures.rs` + `clean_artifact_fixtures.rs` — wire fixture into the diagnostic test runner; ensure the clean-artifact runner skips it.
- `crates/adoc-cli/tests/check_cli.rs` — CLI sanity test: `adoc-cli check` against the duplicate-id fixture exits non-zero with the expected diagnostic.

## Test plan

- [x] `cargo test --workspace` green.
- [x] `cargo clippy --workspace -- -D warnings` green.
- [x] Inline unit tests cover: zero duplicates, one duplicate (pair), two-duplicate-pair (3 claims sharing one id → 2 diagnostics).
- [x] Cross-page fixture covers end-to-end pipeline (parse → validate → diagnostics) and confirms artifact suppression.
- [x] CLI sanity: `cargo run -p adoc-cli -- check crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/input` exits non-zero with the right message.

## Out of scope

- Duplicate detection across non-claim object types (decisions, warnings, glossary) — those types don't exist yet.
- Quick-fix or rename-suggestion behavior — diagnostics only.
- Cross-workspace ID detection — only pages within the current workspace are checked.

## Refs

Closes #30
Parent: #4 (V0.2 plan)