### PR TITLE
feat(core): compile warning knowledge objects end to end

### DIFF
--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -1173,6 +1173,162 @@ fn build_renders_v0_4_accepted_decision_to_golden_agent_json() {
 }
 
 #[test]
+fn check_accepts_v0_4_warning_fixture() {
+    let workspace = TestWorkspace::new("check-accepts-v0-4-warning");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_basic.adoc"))
+        .expect("warning_basic fixture is readable");
+    workspace.write("warning_basic.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "warning_basic.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected v0.4 warning fixture to check cleanly\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 errors, 0 warnings"),
+        "expected clean summary, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn build_renders_v0_4_warning_to_golden_html() {
+    let workspace = TestWorkspace::new("build-renders-warning-golden-html");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_basic.adoc"))
+        .expect("warning_basic fixture is readable");
+    workspace.write("warning_basic.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "warning_basic.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
+        .expect("docs.html is written");
+    let golden = fs::read_to_string(fixture_path("v0_4/warning_basic.golden.html"))
+        .expect("golden HTML fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "rendered HTML diverged from warning_basic.golden.html"
+    );
+    assert!(
+        actual.contains("<section class=\"warning\" id=\"auth.session.clock-skew\">"),
+        "warning section missing from HTML"
+    );
+}
+
+#[test]
+fn build_renders_v0_4_warning_to_golden_agent_json() {
+    let workspace = TestWorkspace::new("build-renders-warning-golden-json");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_basic.adoc"))
+        .expect("warning_basic fixture is readable");
+    workspace.write("warning_basic.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "warning_basic.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.agent.json"))
+        .expect("docs.agent.json is written");
+    let golden = fs::read_to_string(fixture_path("v0_4/warning_basic.golden.agent.json"))
+        .expect("golden agent JSON fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "agent JSON diverged from warning_basic.golden.agent.json"
+    );
+    assert!(
+        actual.contains("\"status\": \"high\""),
+        "warning agent JSON must use status for severity"
+    );
+    assert!(
+        !actual.contains("\"severity\""),
+        "severity must not appear in warning fields"
+    );
+}
+
+#[test]
+fn check_rejects_warning_with_missing_severity() {
+    let workspace = TestWorkspace::new("check-rejects-warning-missing-severity");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_missing_severity.adoc"))
+        .expect("warning_missing_severity fixture is readable");
+    workspace.write("warning_missing_severity.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "warning_missing_severity.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected missing-severity warning to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("error[schema.missing_field]"),
+        "expected schema.missing_field diagnostic, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("severity"),
+        "expected message to mention `severity`, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn check_rejects_warning_with_missing_body() {
+    let workspace = TestWorkspace::new("check-rejects-warning-missing-body");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_missing_body.adoc"))
+        .expect("warning_missing_body fixture is readable");
+    workspace.write("warning_missing_body.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "warning_missing_body.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected missing-body warning to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("error[schema.missing_field]"),
+        "expected schema.missing_field diagnostic, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("body"),
+        "expected message to mention `body`, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn check_rejects_decision_with_missing_status() {
     let workspace = TestWorkspace::new("check-rejects-decision-missing-status");
     let fixture_contents = fs::read_to_string(fixture_path("v0_4/decision_missing_status.adoc"))

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -1228,8 +1228,8 @@ fn build_renders_v0_4_warning_to_golden_html() {
         "rendered HTML diverged from warning_basic.golden.html"
     );
     assert!(
-        actual.contains("<section class=\"warning\" id=\"auth.session.clock-skew\">"),
-        "warning section missing from HTML"
+        actual.contains("<section class=\"warning warning--high\" id=\"auth.session.clock-skew\">"),
+        "warning severity modifier missing from HTML"
     );
 }
 
@@ -1325,6 +1325,62 @@ fn check_rejects_warning_with_missing_body() {
     assert!(
         stdout.contains("body"),
         "expected message to mention `body`, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn check_rejects_warning_with_invalid_severity() {
+    let workspace = TestWorkspace::new("check-rejects-warning-invalid-severity");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_invalid_severity.adoc"))
+        .expect("warning_invalid_severity fixture is readable");
+    workspace.write("warning_invalid_severity.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "warning_invalid_severity.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected invalid-severity warning to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("error[schema.invalid_status]"),
+        "expected schema.invalid_status diagnostic, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("panic"),
+        "expected message to mention rejected severity, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn check_rejects_warning_with_severity_casing() {
+    let workspace = TestWorkspace::new("check-rejects-warning-severity-casing");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_severity_casing.adoc"))
+        .expect("warning_severity_casing fixture is readable");
+    workspace.write("warning_severity_casing.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "warning_severity_casing.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected casing-variant severity warning to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("error[schema.invalid_status]"),
+        "expected schema.invalid_status diagnostic, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Critical"),
+        "expected message to mention rejected severity, got:\n{stdout}"
     );
 }
 

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.adoc
@@ -1,0 +1,10 @@
+# Runtime Warnings @doc(team.warnings)
+
+Warnings that agents should surface before taking action.
+
+::warning auth.session.clock-skew
+severity: high
+owner: platform
+--
+Session clocks can drift enough to reject otherwise valid tokens.
+::

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.golden.agent.json
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.golden.agent.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "adoc.agent.v0",
+  "pages": [
+    {
+      "id": "team.warnings",
+      "title": "Runtime Warnings",
+      "source_path": "warning_basic.adoc"
+    }
+  ],
+  "objects": [
+    {
+      "id": "auth.session.clock-skew",
+      "kind": "warning",
+      "status": "high",
+      "body": "Session clocks can drift enough to reject otherwise valid tokens.",
+      "page_id": "team.warnings",
+      "source_span": {
+        "path": "warning_basic.adoc",
+        "line": 5,
+        "column": 1
+      },
+      "fields": {
+        "owner": "platform"
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    }
+  ],
+  "diagnostics": []
+}

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.golden.html
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.golden.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AgentDoc</title>
+</head>
+<body>
+<article data-page-id="team.warnings">
+<h1>Runtime Warnings</h1>
+<p>Warnings that agents should surface before taking action.</p>
+<section class="warning" id="auth.session.clock-skew">
+<header class="warning__header"><span class="warning__kind">warning</span><code class="warning__id">auth.session.clock-skew</code><span class="warning__severity">high</span></header>
+<div class="warning__body"><p>Session clocks can drift enough to reject otherwise valid tokens.</p></div>
+<footer class="warning__metadata">
+<dl>
+<dt>owner</dt><dd>platform</dd>
+</dl>
+</footer>
+</section>
+</article>
+</body>
+</html>

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.golden.html
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_basic.golden.html
@@ -8,7 +8,7 @@
 <article data-page-id="team.warnings">
 <h1>Runtime Warnings</h1>
 <p>Warnings that agents should surface before taking action.</p>
-<section class="warning" id="auth.session.clock-skew">
+<section class="warning warning--high" id="auth.session.clock-skew">
 <header class="warning__header"><span class="warning__kind">warning</span><code class="warning__id">auth.session.clock-skew</code><span class="warning__severity">high</span></header>
 <div class="warning__body"><p>Session clocks can drift enough to reject otherwise valid tokens.</p></div>
 <footer class="warning__metadata">

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_invalid_severity.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_invalid_severity.adoc
@@ -1,0 +1,7 @@
+# Runtime Warnings @doc(team.warnings)
+
+::warning auth.session.clock-skew
+severity: panic
+--
+Session clocks can drift enough to reject otherwise valid tokens.
+::

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_missing_body.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_missing_body.adoc
@@ -1,0 +1,6 @@
+# Runtime Warnings @doc(team.warnings)
+
+::warning auth.session.clock-skew
+severity: high
+--
+::

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_missing_severity.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_missing_severity.adoc
@@ -1,0 +1,6 @@
+# Runtime Warnings @doc(team.warnings)
+
+::warning auth.session.clock-skew
+--
+Session clocks can drift enough to reject otherwise valid tokens.
+::

--- a/crates/adoc-cli/tests/fixtures/v0_4/warning_severity_casing.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/warning_severity_casing.adoc
@@ -1,0 +1,7 @@
+# Runtime Warnings @doc(team.warnings)
+
+::warning auth.session.clock-skew
+severity: Critical
+--
+Session clocks can drift enough to reject otherwise valid tokens.
+::

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_clean.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_clean.snap
@@ -1,0 +1,8 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: true
+---stdout---
+0 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_invalid_severity_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_invalid_severity_flags.snap
@@ -1,0 +1,9 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: false
+---stdout---
+warning_invalid_severity.adoc:3:1: error[schema.invalid_status] warning `auth.session.clock-skew` has invalid severity `panic`
+1 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_missing_body_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_missing_body_flags.snap
@@ -1,0 +1,9 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: false
+---stdout---
+warning_missing_body.adoc:3:1: error[schema.missing_field] warning is missing required body
+1 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_missing_severity_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_missing_severity_flags.snap
@@ -1,0 +1,9 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: false
+---stdout---
+warning_missing_severity.adoc:3:1: error[schema.missing_field] warning is missing required field `severity`
+1 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_severity_casing_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_warning_severity_casing_flags.snap
@@ -1,0 +1,9 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: false
+---stdout---
+warning_severity_casing.adoc:3:1: error[schema.invalid_status] warning `auth.session.clock-skew` has invalid severity `Critical`
+1 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots_cli.rs
+++ b/crates/adoc-cli/tests/snapshots_cli.rs
@@ -243,3 +243,25 @@ fn snapshot_check_flags_warning_missing_body() {
 
     insta::assert_snapshot!("check_warning_missing_body_flags", combined);
 }
+
+#[test]
+fn snapshot_check_flags_warning_invalid_severity() {
+    let combined = run_check_in_workspace(
+        "snap-check-warning-invalid-severity",
+        "v0_4/warning_invalid_severity.adoc",
+        "warning_invalid_severity.adoc",
+    );
+
+    insta::assert_snapshot!("check_warning_invalid_severity_flags", combined);
+}
+
+#[test]
+fn snapshot_check_flags_warning_severity_casing() {
+    let combined = run_check_in_workspace(
+        "snap-check-warning-severity-casing",
+        "v0_4/warning_severity_casing.adoc",
+        "warning_severity_casing.adoc",
+    );
+
+    insta::assert_snapshot!("check_warning_severity_casing_flags", combined);
+}

--- a/crates/adoc-cli/tests/snapshots_cli.rs
+++ b/crates/adoc-cli/tests/snapshots_cli.rs
@@ -168,6 +168,17 @@ fn snapshot_check_passes_for_v0_4_accepted_decision() {
 }
 
 #[test]
+fn snapshot_check_passes_for_v0_4_warning() {
+    let combined = run_check_in_workspace(
+        "snap-check-warning-clean",
+        "v0_4/warning_basic.adoc",
+        "warning_basic.adoc",
+    );
+
+    insta::assert_snapshot!("check_warning_clean", combined);
+}
+
+#[test]
 fn snapshot_check_flags_decision_missing_status() {
     let combined = run_check_in_workspace(
         "snap-check-decision-missing-status",
@@ -209,4 +220,26 @@ fn snapshot_check_flags_decision_invalid_status() {
     );
 
     insta::assert_snapshot!("check_decision_invalid_status_flags", combined);
+}
+
+#[test]
+fn snapshot_check_flags_warning_missing_severity() {
+    let combined = run_check_in_workspace(
+        "snap-check-warning-missing-severity",
+        "v0_4/warning_missing_severity.adoc",
+        "warning_missing_severity.adoc",
+    );
+
+    insta::assert_snapshot!("check_warning_missing_severity_flags", combined);
+}
+
+#[test]
+fn snapshot_check_flags_warning_missing_body() {
+    let combined = run_check_in_workspace(
+        "snap-check-warning-missing-body",
+        "v0_4/warning_missing_body.adoc",
+        "warning_missing_body.adoc",
+    );
+
+    insta::assert_snapshot!("check_warning_missing_body_flags", combined);
 }

--- a/crates/adoc-core/src/domain/artifact.rs
+++ b/crates/adoc-core/src/domain/artifact.rs
@@ -40,6 +40,8 @@ impl From<&PageAst> for AgentJsonPage {
 pub struct AgentJsonObject {
     pub id: String,
     pub kind: String,
+    /// Kind-primary normalized discriminant. For v0 this is the claim status,
+    /// decision status, or warning severity.
     pub status: String,
     pub body: String,
     pub page_id: String,

--- a/crates/adoc-core/src/domain/knowledge_object/claim.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/claim.rs
@@ -14,6 +14,8 @@ pub(crate) const REVIEWED_BY_FIELD: &str = "reviewed_by";
 pub(crate) const VERIFIED_STATUS: &str = "verified";
 
 const VERIFIED_CLAIM_HELP: &str = "Verified claims require `owner`, `verified_at`, and at least one of `source`, `test`, or `reviewed_by`.";
+const CLAIM_MISSING_STATUS_HELP: &str = "Claims require non-empty `status`.";
+const CLAIM_MISSING_BODY_HELP: &str = "Claims require non-empty body text.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Claim {
@@ -294,14 +296,18 @@ fn emit_claim_error(
                 DiagnosticCode::SchemaMissingField,
                 "claim is missing required field `status`",
             )
-            .with_span(parsed.span.clone()),
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(CLAIM_MISSING_STATUS_HELP),
         ),
         ClaimError::MissingBody => diagnostics.push(
             Diagnostic::error(
                 DiagnosticCode::SchemaMissingField,
                 "claim is missing required body",
             )
-            .with_span(parsed.span.clone()),
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(CLAIM_MISSING_BODY_HELP),
         ),
         ClaimError::MissingVerification => {
             unreachable!("missing verification is handled by verified-claim diagnostics")

--- a/crates/adoc-core/src/domain/knowledge_object/decision.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/decision.rs
@@ -9,6 +9,9 @@ pub(crate) const STATUS_FIELD: &str = "status";
 pub(crate) const DECIDED_BY_FIELD: &str = "decided_by";
 pub(crate) const ACCEPTED_STATUS: &str = "accepted";
 pub(crate) const VALID_STATUS_HELP: &str = "Valid decision statuses are: proposed, accepted.";
+const DECISION_MISSING_STATUS_HELP: &str =
+    "Decisions require non-empty `status`. Valid decision statuses are: proposed, accepted.";
+const DECISION_MISSING_BODY_HELP: &str = "Decisions require non-empty body text.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Decision {
@@ -206,7 +209,9 @@ fn emit_decision_error(
                 DiagnosticCode::SchemaMissingField,
                 "decision is missing required field `status`",
             )
-            .with_span(parsed.span.clone()),
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(DECISION_MISSING_STATUS_HELP),
         ),
         DecisionError::InvalidStatus(status) => diagnostics.push(
             Diagnostic::error(
@@ -225,7 +230,9 @@ fn emit_decision_error(
                 DiagnosticCode::SchemaMissingField,
                 "decision is missing required body",
             )
-            .with_span(parsed.span.clone()),
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(DECISION_MISSING_BODY_HELP),
         ),
         DecisionError::MissingVerdict => {
             unreachable!("accepted decision verdict is validated before construction")

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -2,24 +2,28 @@
 
 pub(crate) mod claim;
 pub(crate) mod decision;
+pub(crate) mod warning;
 
 use claim::Claim;
 use decision::Decision;
+use warning::Warning;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BlockKind {
     Claim,
     Decision,
+    Warning,
 }
 
 impl BlockKind {
     #[cfg(test)]
-    pub(crate) const ALL: &'static [Self] = &[Self::Claim, Self::Decision];
+    pub(crate) const ALL: &'static [Self] = &[Self::Claim, Self::Decision, Self::Warning];
 
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Claim => "claim",
             Self::Decision => "decision",
+            Self::Warning => "warning",
         }
     }
 }
@@ -28,6 +32,7 @@ impl BlockKind {
 pub(crate) enum KnowledgeObject {
     Claim(Claim),
     Decision(Decision),
+    Warning(Warning),
 }
 
 #[cfg(test)]
@@ -38,10 +43,14 @@ mod tests {
     fn block_kind_labels_match_source_fence_words() {
         assert_eq!(BlockKind::Claim.as_str(), "claim");
         assert_eq!(BlockKind::Decision.as_str(), "decision");
+        assert_eq!(BlockKind::Warning.as_str(), "warning");
     }
 
     #[test]
     fn block_kind_all_lists_every_supported_kind() {
-        assert_eq!(BlockKind::ALL, &[BlockKind::Claim, BlockKind::Decision]);
+        assert_eq!(
+            BlockKind::ALL,
+            &[BlockKind::Claim, BlockKind::Decision, BlockKind::Warning]
+        );
     }
 }

--- a/crates/adoc-core/src/domain/knowledge_object/warning.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/warning.rs
@@ -12,7 +12,7 @@ pub(crate) const VALID_SEVERITY_HELP: &str =
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Warning {
     id: ObjectId,
-    severity: Severity,
+    severity: WarningSeverity,
     body: BodyText,
     fields: OptionalFields,
     span: SourceSpan,
@@ -70,7 +70,6 @@ impl Warning {
         }
     }
 
-    #[cfg(test)]
     pub(crate) fn try_new(
         id_text: &str,
         severity_text: Option<&str>,
@@ -78,29 +77,8 @@ impl Warning {
         optional_fields: BTreeMap<String, String>,
         span: SourceSpan,
     ) -> Result<Self, WarningError> {
-        Self::from_raw_parts(id_text, severity_text, body_text, optional_fields, span)
-    }
-
-    #[cfg(not(test))]
-    fn try_new(
-        id_text: &str,
-        severity_text: Option<&str>,
-        body_text: &str,
-        optional_fields: BTreeMap<String, String>,
-        span: SourceSpan,
-    ) -> Result<Self, WarningError> {
-        Self::from_raw_parts(id_text, severity_text, body_text, optional_fields, span)
-    }
-
-    fn from_raw_parts(
-        id_text: &str,
-        severity_text: Option<&str>,
-        body_text: &str,
-        optional_fields: BTreeMap<String, String>,
-        span: SourceSpan,
-    ) -> Result<Self, WarningError> {
         let id = ObjectId::new(id_text).map_err(WarningError::InvalidId)?;
-        let severity = Severity::try_new(severity_text.unwrap_or(""))?;
+        let severity = WarningSeverity::try_new(severity_text.unwrap_or(""))?;
         let body = BodyText::try_new(body_text).ok_or(WarningError::MissingBody)?;
         debug_assert!(
             !optional_fields.contains_key(SEVERITY_FIELD),
@@ -119,7 +97,7 @@ impl Warning {
         &self.id
     }
 
-    pub(crate) fn severity(&self) -> &Severity {
+    pub(crate) fn severity(&self) -> &WarningSeverity {
         &self.severity
     }
 
@@ -184,14 +162,14 @@ fn emit_warning_error(
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub(crate) enum Severity {
+pub(crate) enum WarningSeverity {
     Low,
     Medium,
     High,
     Critical,
 }
 
-impl Severity {
+impl WarningSeverity {
     pub(crate) fn try_new(value: &str) -> Result<Self, WarningError> {
         let trimmed = trim_ascii_edges(value);
         if trimmed.is_empty() {
@@ -279,33 +257,33 @@ mod tests {
     #[test]
     fn warning_severity_accepts_only_canonical_values() {
         for value in ["low", "medium", "high", "critical"] {
-            let severity = Severity::try_new(value).expect("canonical severity");
+            let severity = WarningSeverity::try_new(value).expect("canonical severity");
             assert_eq!(severity.as_str(), value);
         }
     }
 
     #[test]
     fn warning_severity_trims_ascii_edges_for_valid_values() {
-        let severity = Severity::try_new("  critical  ").expect("valid severity");
+        let severity = WarningSeverity::try_new("  critical  ").expect("valid severity");
         assert_eq!(severity.as_str(), "critical");
     }
 
     #[test]
     fn warning_severity_rejects_empty_unknown_and_miscased_values() {
         assert_eq!(
-            Severity::try_new(" \t "),
+            WarningSeverity::try_new(" \t "),
             Err(WarningError::MissingSeverity)
         );
         assert_eq!(
-            Severity::try_new("panic"),
+            WarningSeverity::try_new("panic"),
             Err(WarningError::InvalidSeverity("panic".to_string()))
         );
         assert_eq!(
-            Severity::try_new("Critical"),
+            WarningSeverity::try_new("Critical"),
             Err(WarningError::InvalidSeverity("Critical".to_string()))
         );
         assert_eq!(
-            Severity::try_new("HIGH"),
+            WarningSeverity::try_new("HIGH"),
             Err(WarningError::InvalidSeverity("HIGH".to_string()))
         );
     }

--- a/crates/adoc-core/src/domain/knowledge_object/warning.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/warning.rs
@@ -8,6 +8,8 @@ use crate::domain::values::{BodyText, OptionalFields, trim_ascii_edges};
 pub(crate) const SEVERITY_FIELD: &str = "severity";
 pub(crate) const VALID_SEVERITY_HELP: &str =
     "Valid warning severities are: low, medium, high, critical.";
+const WARNING_MISSING_SEVERITY_HELP: &str = "Warnings require non-empty `severity`. Valid warning severities are: low, medium, high, critical.";
+const WARNING_MISSING_BODY_HELP: &str = "Warnings require non-empty body text.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Warning {
@@ -136,7 +138,7 @@ fn emit_warning_error(
             )
             .with_span(parsed.span.clone())
             .with_object_id(&parsed.id_text)
-            .with_help("Warnings require non-empty `severity`."),
+            .with_help(WARNING_MISSING_SEVERITY_HELP),
         ),
         WarningError::InvalidSeverity(severity) => diagnostics.push(
             Diagnostic::error(
@@ -156,7 +158,8 @@ fn emit_warning_error(
                 "warning is missing required body",
             )
             .with_span(parsed.span.clone())
-            .with_object_id(&parsed.id_text),
+            .with_object_id(&parsed.id_text)
+            .with_help(WARNING_MISSING_BODY_HELP),
         ),
     }
 }

--- a/crates/adoc-core/src/domain/knowledge_object/warning.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/warning.rs
@@ -1,0 +1,349 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::domain::ast::ParsedTypedBlock;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
+use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId, ObjectIdError};
+use crate::domain::values::{BodyText, NonEmptyText, OptionalFields};
+
+pub(crate) const SEVERITY_FIELD: &str = "severity";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Warning {
+    id: ObjectId,
+    severity: Severity,
+    body: BodyText,
+    fields: OptionalFields,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum WarningError {
+    InvalidId(ObjectIdError),
+    MissingSeverity,
+    MissingBody,
+}
+
+impl Warning {
+    pub(crate) fn build_from_parsed(
+        parsed: &ParsedTypedBlock,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Self> {
+        if !parsed.duplicate_keys.is_empty() {
+            let mut emitted_keys = BTreeSet::new();
+            for key in &parsed.duplicate_keys {
+                if emitted_keys.insert(key.as_str()) {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            DiagnosticCode::SchemaDuplicateField,
+                            format!("duplicate field `{key}` in warning"),
+                        )
+                        .with_span(parsed.span.clone()),
+                    );
+                }
+            }
+            return None;
+        }
+
+        let severity_text = parsed.raw_fields.get(SEVERITY_FIELD).map(String::as_str);
+        let optional_fields: BTreeMap<String, String> = parsed
+            .raw_fields
+            .iter()
+            .filter(|(key, _)| key.as_str() != SEVERITY_FIELD)
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect();
+
+        match Self::try_new(
+            &parsed.id_text,
+            severity_text,
+            &parsed.body_text,
+            optional_fields,
+            parsed.span.clone(),
+        ) {
+            Ok(warning) => Some(warning),
+            Err(error) => {
+                emit_warning_error(parsed, error, diagnostics);
+                None
+            }
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn try_new(
+        id_text: &str,
+        severity_text: Option<&str>,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> Result<Self, WarningError> {
+        Self::from_raw_parts(id_text, severity_text, body_text, optional_fields, span)
+    }
+
+    #[cfg(not(test))]
+    fn try_new(
+        id_text: &str,
+        severity_text: Option<&str>,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> Result<Self, WarningError> {
+        Self::from_raw_parts(id_text, severity_text, body_text, optional_fields, span)
+    }
+
+    fn from_raw_parts(
+        id_text: &str,
+        severity_text: Option<&str>,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> Result<Self, WarningError> {
+        let id = ObjectId::new(id_text).map_err(WarningError::InvalidId)?;
+        let severity =
+            Severity::try_new(severity_text.unwrap_or("")).ok_or(WarningError::MissingSeverity)?;
+        let body = BodyText::try_new(body_text).ok_or(WarningError::MissingBody)?;
+        debug_assert!(
+            !optional_fields.contains_key(SEVERITY_FIELD),
+            "optional warning fields must not contain required field `severity`"
+        );
+        Ok(Self {
+            id,
+            severity,
+            body,
+            fields: OptionalFields::from_map(optional_fields),
+            span,
+        })
+    }
+
+    pub(crate) fn id(&self) -> &ObjectId {
+        &self.id
+    }
+
+    pub(crate) fn severity(&self) -> &Severity {
+        &self.severity
+    }
+
+    pub(crate) fn body(&self) -> &BodyText {
+        &self.body
+    }
+
+    pub(crate) fn fields(&self) -> &OptionalFields {
+        &self.fields
+    }
+
+    pub(crate) fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+fn emit_warning_error(
+    parsed: &ParsedTypedBlock,
+    error: WarningError,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    match error {
+        WarningError::InvalidId(error) => diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::IdInvalid,
+                format!("invalid warning id `{}`: {error}", parsed.id_text),
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(OBJECT_ID_GRAMMAR_HELP),
+        ),
+        WarningError::MissingSeverity => diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::SchemaMissingField,
+                "warning is missing required field `severity`",
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help("Warnings require non-empty `severity`."),
+        ),
+        WarningError::MissingBody => diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::SchemaMissingField,
+                "warning is missing required body",
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text),
+        ),
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Severity(String);
+
+impl Severity {
+    pub(crate) fn try_new(value: &str) -> Option<Self> {
+        NonEmptyText::try_new(value).map(|value| Self(value.as_str().to_string()))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+    use crate::domain::knowledge_object::BlockKind;
+
+    fn span() -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from("test.adoc"),
+            start: SourcePosition {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line: 1,
+                column: 8,
+                offset: 7,
+            },
+        }
+    }
+
+    fn parsed_warning(fields: BTreeMap<String, String>, body_text: &str) -> ParsedTypedBlock {
+        ParsedTypedBlock {
+            kind: BlockKind::Warning,
+            id_text: "auth.session.clock-skew".to_string(),
+            raw_fields: fields,
+            duplicate_keys: Vec::new(),
+            body_text: body_text.to_string(),
+            content_spans: Vec::new(),
+            span: span(),
+        }
+    }
+
+    #[test]
+    fn warning_try_new_accepts_required_fields_and_strips_severity_from_metadata() {
+        let warning = Warning::try_new(
+            "auth.session.clock-skew",
+            Some("high"),
+            "Session clocks can drift.",
+            BTreeMap::from([("owner".to_string(), "platform".to_string())]),
+            span(),
+        )
+        .expect("valid warning");
+
+        assert_eq!(warning.id().as_str(), "auth.session.clock-skew");
+        assert_eq!(warning.severity().as_str(), "high");
+        assert_eq!(warning.body().as_str(), "Session clocks can drift.");
+        assert_eq!(
+            warning
+                .fields()
+                .iter()
+                .next()
+                .map(|(key, value)| (key.as_str(), value.as_str())),
+            Some(("owner", "platform"))
+        );
+    }
+
+    #[test]
+    fn warning_severity_accepts_any_non_empty_value() {
+        let severity = Severity::try_new("panic").expect("non-empty severity");
+        assert_eq!(severity.as_str(), "panic");
+    }
+
+    #[test]
+    fn warning_severity_trims_ascii_edges_for_values() {
+        let severity = Severity::try_new("  critical  ").expect("valid severity");
+        assert_eq!(severity.as_str(), "critical");
+    }
+
+    #[test]
+    fn warning_severity_rejects_empty() {
+        assert!(Severity::try_new(" \t ").is_none());
+    }
+
+    #[test]
+    fn warning_try_new_rejects_missing_body() {
+        let result = Warning::try_new(
+            "auth.session.clock-skew",
+            Some("high"),
+            " ",
+            BTreeMap::new(),
+            span(),
+        );
+
+        assert_eq!(result, Err(WarningError::MissingBody));
+    }
+
+    #[test]
+    fn warning_try_new_rejects_invalid_id() {
+        let result = Warning::try_new(
+            "Auth.Session",
+            Some("high"),
+            "Session clocks can drift.",
+            BTreeMap::new(),
+            span(),
+        );
+
+        assert!(matches!(result, Err(WarningError::InvalidId(_))));
+    }
+
+    #[test]
+    fn warning_build_from_parsed_reports_missing_severity_with_object_context() {
+        let parsed = parsed_warning(BTreeMap::new(), "Session clocks can drift.");
+        let mut diagnostics = Vec::new();
+
+        let warning = Warning::build_from_parsed(&parsed, &mut diagnostics);
+
+        assert!(warning.is_none());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaMissingField);
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("auth.session.clock-skew")
+        );
+        assert_eq!(diagnostics[0].span.as_ref(), Some(&span()));
+        assert!(
+            diagnostics[0]
+                .help
+                .as_deref()
+                .is_some_and(|help| help.contains("non-empty `severity`"))
+        );
+    }
+
+    #[test]
+    fn warning_build_from_parsed_strips_severity_from_optional_fields() {
+        let parsed = parsed_warning(
+            BTreeMap::from([
+                (SEVERITY_FIELD.to_string(), "high".to_string()),
+                ("owner".to_string(), "platform".to_string()),
+            ]),
+            "Session clocks can drift.",
+        );
+        let mut diagnostics = Vec::new();
+
+        let warning = Warning::build_from_parsed(&parsed, &mut diagnostics).expect("valid warning");
+
+        assert!(diagnostics.is_empty());
+        let field_keys: Vec<&str> = warning
+            .fields()
+            .iter()
+            .map(|(key, _)| key.as_str())
+            .collect();
+        assert_eq!(field_keys, vec!["owner"]);
+    }
+
+    #[test]
+    fn warning_build_from_parsed_drops_duplicate_fields() {
+        let mut parsed = parsed_warning(
+            BTreeMap::from([(SEVERITY_FIELD.to_string(), "high".to_string())]),
+            "Session clocks can drift.",
+        );
+        parsed.duplicate_keys = vec![SEVERITY_FIELD.to_string(), SEVERITY_FIELD.to_string()];
+        let mut diagnostics = Vec::new();
+
+        let warning = Warning::build_from_parsed(&parsed, &mut diagnostics);
+
+        assert!(warning.is_none());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaDuplicateField);
+        assert!(diagnostics[0].message.contains(SEVERITY_FIELD));
+    }
+}

--- a/crates/adoc-core/src/domain/knowledge_object/warning.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/warning.rs
@@ -3,9 +3,11 @@ use std::collections::{BTreeMap, BTreeSet};
 use crate::domain::ast::ParsedTypedBlock;
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
 use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId, ObjectIdError};
-use crate::domain::values::{BodyText, NonEmptyText, OptionalFields};
+use crate::domain::values::{BodyText, OptionalFields, trim_ascii_edges};
 
 pub(crate) const SEVERITY_FIELD: &str = "severity";
+pub(crate) const VALID_SEVERITY_HELP: &str =
+    "Valid warning severities are: low, medium, high, critical.";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct Warning {
@@ -20,6 +22,7 @@ pub(crate) struct Warning {
 pub(crate) enum WarningError {
     InvalidId(ObjectIdError),
     MissingSeverity,
+    InvalidSeverity(String),
     MissingBody,
 }
 
@@ -97,8 +100,7 @@ impl Warning {
         span: SourceSpan,
     ) -> Result<Self, WarningError> {
         let id = ObjectId::new(id_text).map_err(WarningError::InvalidId)?;
-        let severity =
-            Severity::try_new(severity_text.unwrap_or("")).ok_or(WarningError::MissingSeverity)?;
+        let severity = Severity::try_new(severity_text.unwrap_or(""))?;
         let body = BodyText::try_new(body_text).ok_or(WarningError::MissingBody)?;
         debug_assert!(
             !optional_fields.contains_key(SEVERITY_FIELD),
@@ -158,6 +160,18 @@ fn emit_warning_error(
             .with_object_id(&parsed.id_text)
             .with_help("Warnings require non-empty `severity`."),
         ),
+        WarningError::InvalidSeverity(severity) => diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::SchemaInvalidStatus,
+                format!(
+                    "warning `{}` has invalid severity `{severity}`",
+                    parsed.id_text
+                ),
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(VALID_SEVERITY_HELP),
+        ),
         WarningError::MissingBody => diagnostics.push(
             Diagnostic::error(
                 DiagnosticCode::SchemaMissingField,
@@ -169,16 +183,36 @@ fn emit_warning_error(
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub(crate) struct Severity(String);
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Severity {
+    Low,
+    Medium,
+    High,
+    Critical,
+}
 
 impl Severity {
-    pub(crate) fn try_new(value: &str) -> Option<Self> {
-        NonEmptyText::try_new(value).map(|value| Self(value.as_str().to_string()))
+    pub(crate) fn try_new(value: &str) -> Result<Self, WarningError> {
+        let trimmed = trim_ascii_edges(value);
+        if trimmed.is_empty() {
+            return Err(WarningError::MissingSeverity);
+        }
+        match trimmed {
+            "low" => Ok(Self::Low),
+            "medium" => Ok(Self::Medium),
+            "high" => Ok(Self::High),
+            "critical" => Ok(Self::Critical),
+            _ => Err(WarningError::InvalidSeverity(trimmed.to_string())),
+        }
     }
 
     pub(crate) fn as_str(&self) -> &str {
-        &self.0
+        match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::High => "high",
+            Self::Critical => "critical",
+        }
     }
 }
 
@@ -243,20 +277,37 @@ mod tests {
     }
 
     #[test]
-    fn warning_severity_accepts_any_non_empty_value() {
-        let severity = Severity::try_new("panic").expect("non-empty severity");
-        assert_eq!(severity.as_str(), "panic");
+    fn warning_severity_accepts_only_canonical_values() {
+        for value in ["low", "medium", "high", "critical"] {
+            let severity = Severity::try_new(value).expect("canonical severity");
+            assert_eq!(severity.as_str(), value);
+        }
     }
 
     #[test]
-    fn warning_severity_trims_ascii_edges_for_values() {
+    fn warning_severity_trims_ascii_edges_for_valid_values() {
         let severity = Severity::try_new("  critical  ").expect("valid severity");
         assert_eq!(severity.as_str(), "critical");
     }
 
     #[test]
-    fn warning_severity_rejects_empty() {
-        assert!(Severity::try_new(" \t ").is_none());
+    fn warning_severity_rejects_empty_unknown_and_miscased_values() {
+        assert_eq!(
+            Severity::try_new(" \t "),
+            Err(WarningError::MissingSeverity)
+        );
+        assert_eq!(
+            Severity::try_new("panic"),
+            Err(WarningError::InvalidSeverity("panic".to_string()))
+        );
+        assert_eq!(
+            Severity::try_new("Critical"),
+            Err(WarningError::InvalidSeverity("Critical".to_string()))
+        );
+        assert_eq!(
+            Severity::try_new("HIGH"),
+            Err(WarningError::InvalidSeverity("HIGH".to_string()))
+        );
     }
 
     #[test]
@@ -306,6 +357,31 @@ mod tests {
                 .as_deref()
                 .is_some_and(|help| help.contains("non-empty `severity`"))
         );
+    }
+
+    #[test]
+    fn warning_build_from_parsed_reports_invalid_severity() {
+        let parsed = parsed_warning(
+            BTreeMap::from([(SEVERITY_FIELD.to_string(), "panic".to_string())]),
+            "Session clocks can drift.",
+        );
+        let mut diagnostics = Vec::new();
+
+        let warning = Warning::build_from_parsed(&parsed, &mut diagnostics);
+
+        assert!(warning.is_none());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaInvalidStatus);
+        assert!(
+            diagnostics[0].message.contains("panic"),
+            "message should quote rejected severity: {:?}",
+            diagnostics[0]
+        );
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("auth.session.clock-skew")
+        );
+        assert_eq!(diagnostics[0].help.as_deref(), Some(VALID_SEVERITY_HELP));
     }
 
     #[test]

--- a/crates/adoc-core/src/infrastructure/artifact/agent_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/agent_json.rs
@@ -12,6 +12,7 @@ use crate::domain::knowledge_object::{
         VERIFIED_AT_FIELD,
     },
     decision::{DECIDED_BY_FIELD, Decision},
+    warning::Warning,
 };
 use crate::domain::ports::artifact_writer::ArtifactWriter;
 
@@ -32,6 +33,9 @@ impl ArtifactWriter for AgentJsonArtifact {
                         KnowledgeObject::Decision(decision) => {
                             objects.push(decision_to_agent_object(decision, page.id.as_str()));
                         }
+                        KnowledgeObject::Warning(warning) => {
+                            objects.push(warning_to_agent_object(warning, page.id.as_str()));
+                        }
                     },
                     BlockAst::KnowledgeObjectPending(_) => unreachable!(
                         "resolver must replace pending knowledge objects before artifact emission"
@@ -46,6 +50,28 @@ impl ArtifactWriter for AgentJsonArtifact {
             objects,
             diagnostics: diagnostics.to_vec(),
         }
+    }
+}
+
+fn warning_to_agent_object(warning: &Warning, page_id: &str) -> AgentJsonObject {
+    let span = warning.span();
+    AgentJsonObject {
+        id: warning.id().as_str().to_string(),
+        kind: "warning".to_string(),
+        status: warning.severity().as_str().to_string(),
+        body: warning.body().as_str().to_string(),
+        page_id: page_id.to_string(),
+        source_span: AgentJsonSourceSpan {
+            path: span.file.display().to_string(),
+            line: span.start.line,
+            column: span.start.column,
+        },
+        fields: warning
+            .fields()
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+        relations: AgentJsonRelations::default(),
     }
 }
 
@@ -221,6 +247,18 @@ mod tests {
         BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Decision(decision)))
     }
 
+    fn make_warning(
+        id: &str,
+        severity: &str,
+        body: &str,
+        fields: BTreeMap<String, String>,
+    ) -> BlockAst {
+        use crate::domain::knowledge_object::warning::Warning;
+        let warning =
+            Warning::try_new(id, Some(severity), body, fields, span()).expect("valid warning");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Warning(warning)))
+    }
+
     fn make_page(id: &str, blocks: Vec<BlockAst>) -> PageAst {
         PageAst {
             id: PageId::from_string(id).expect("test page id is valid"),
@@ -374,5 +412,39 @@ mod tests {
             obj.fields.get(DECIDED_BY_FIELD).map(String::as_str),
             Some("architecture")
         );
+    }
+
+    #[test]
+    fn agent_json_artifact_emits_warning_with_severity_as_status() {
+        let page = make_page(
+            "team.warnings",
+            vec![make_warning(
+                "auth.session.clock-skew",
+                "critical",
+                "Session clocks can drift.",
+                BTreeMap::from([("owner".to_string(), "platform".to_string())]),
+            )],
+        );
+        let artifact = AgentJsonArtifact;
+        let doc = artifact.build(&[page], &[]);
+
+        assert_eq!(doc.objects.len(), 1);
+        let obj = &doc.objects[0];
+        assert_eq!(obj.id, "auth.session.clock-skew");
+        assert_eq!(obj.kind, "warning");
+        assert_eq!(obj.status, "critical");
+        assert_eq!(obj.body, "Session clocks can drift.");
+        assert_eq!(obj.page_id, "team.warnings");
+        assert_eq!(obj.source_span.path, "sample.adoc");
+        assert_eq!(obj.source_span.line, 5);
+        assert_eq!(obj.source_span.column, 1);
+        assert_eq!(
+            obj.fields.get("owner").map(String::as_str),
+            Some("platform")
+        );
+        assert!(!obj.fields.contains_key("severity"));
+        assert!(obj.relations.depends_on.is_empty());
+        assert!(obj.relations.supersedes.is_empty());
+        assert!(obj.relations.related_to.is_empty());
     }
 }

--- a/crates/adoc-core/src/infrastructure/parser/mod.rs
+++ b/crates/adoc-core/src/infrastructure/parser/mod.rs
@@ -736,6 +736,34 @@ mod tests {
     }
 
     #[test]
+    fn parse_page_recognizes_warning_as_pending_typed_block() {
+        let (page, diagnostics) = parse_source(concat!(
+            "# Warnings @doc(team.warnings)\n\n",
+            "::warning auth.session.clock-skew\n",
+            "severity: high\n",
+            "--\n",
+            "Session clocks can drift.\n",
+            "::\n",
+        ));
+
+        assert!(
+            diagnostics.is_empty(),
+            "expected warning parser fixture to stay clean: {diagnostics:?}"
+        );
+        let pending = page
+            .blocks
+            .iter()
+            .find_map(|block| match block {
+                BlockAst::KnowledgeObjectPending(pending) => Some(pending),
+                _ => None,
+            })
+            .expect("warning block should be parsed as pending typed block");
+
+        assert_eq!(pending.kind, BlockKind::Warning);
+        assert_eq!(pending.id_text, "auth.session.clock-skew");
+    }
+
+    #[test]
     fn parse_page_still_recognizes_claim_as_pending_typed_block() {
         let (page, diagnostics) = parse_source(concat!(
             "# Claims @doc(team.claims)\n\n",

--- a/crates/adoc-core/src/infrastructure/parser/typed_block.rs
+++ b/crates/adoc-core/src/infrastructure/parser/typed_block.rs
@@ -28,6 +28,10 @@ const SUPPORTED_KINDS: &[SupportedKind] = &[
         word: BlockKind::Decision.as_str(),
         kind: BlockKind::Decision,
     },
+    SupportedKind {
+        word: BlockKind::Warning.as_str(),
+        kind: BlockKind::Warning,
+    },
 ];
 
 /// Result of attempting to open a typed block on an `Idle` line starting with
@@ -554,7 +558,8 @@ mod tests {
                     "message should quote the unknown word"
                 );
                 assert!(
-                    d.message.contains("supported kinds: claim, decision"),
+                    d.message
+                        .contains("supported kinds: claim, decision, warning"),
                     "message should list supported kinds from parser metadata: {}",
                     d.message
                 );

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -4,6 +4,7 @@ use crate::domain::knowledge_object::{
     KnowledgeObject,
     claim::{Claim, Evidence},
     decision::{DECIDED_BY_FIELD, Decision},
+    warning::Warning,
 };
 use crate::domain::ports::renderer::Renderer;
 
@@ -81,11 +82,52 @@ fn render_block(block: &BlockAst, html: &mut String) {
             KnowledgeObject::Decision(decision) => {
                 render_decision(decision, html);
             }
+            KnowledgeObject::Warning(warning) => {
+                render_warning(warning, html);
+            }
         },
         BlockAst::KnowledgeObjectPending(_) => {
             unreachable!("resolver must replace pending knowledge objects before rendering")
         }
     }
+}
+
+fn render_warning(warning: &Warning, html: &mut String) {
+    html.push_str("<section class=\"warning\" id=\"");
+    html.push_str(&escape_html(warning.id().as_str()));
+    html.push_str("\">\n");
+    html.push_str("<header class=\"warning__header\">");
+    html.push_str("<span class=\"warning__kind\">warning</span>");
+    html.push_str("<code class=\"warning__id\">");
+    html.push_str(&escape_html(warning.id().as_str()));
+    html.push_str("</code>");
+    html.push_str("<span class=\"warning__severity\">");
+    html.push_str(&escape_html(warning.severity().as_str()));
+    html.push_str("</span>");
+    html.push_str("</header>\n");
+    html.push_str("<div class=\"warning__body\"><p>");
+    html.push_str(&escape_html(warning.body().as_str()));
+    html.push_str("</p></div>\n");
+    render_warning_metadata(warning, html);
+    html.push_str("</section>\n");
+}
+
+fn render_warning_metadata(warning: &Warning, html: &mut String) {
+    if warning.fields().is_empty() {
+        return;
+    }
+
+    html.push_str("<footer class=\"warning__metadata\">\n");
+    html.push_str("<dl>\n");
+    for (key, value) in warning.fields().iter() {
+        html.push_str("<dt>");
+        html.push_str(&escape_html(key));
+        html.push_str("</dt><dd>");
+        html.push_str(&escape_html(value));
+        html.push_str("</dd>\n");
+    }
+    html.push_str("</dl>\n");
+    html.push_str("</footer>\n");
 }
 
 fn render_decision(decision: &Decision, html: &mut String) {
@@ -475,6 +517,19 @@ mod tests {
         BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Decision(decision)))
     }
 
+    fn make_warning(
+        id: &str,
+        severity: &str,
+        body: &str,
+        fields: std::collections::BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> BlockAst {
+        use crate::domain::knowledge_object::{KnowledgeObject, warning::Warning};
+        let warning = Warning::try_new(id, Some(severity), body, fields, span)
+            .expect("test warning must be valid");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Warning(warning)))
+    }
+
     #[test]
     fn claim_renders_to_section_with_kind_id_status_body() {
         let block = make_claim(
@@ -714,6 +769,97 @@ mod tests {
         assert!(
             !html.contains("<footer class=\"decision__metadata\">\n<dl>\n<dt>decided_by</dt>"),
             "decided_by must not render as generic metadata: {html}"
+        );
+    }
+
+    #[test]
+    fn warning_renders_to_section_with_kind_id_severity_body() {
+        let block = make_warning(
+            "auth.session.clock-skew",
+            "high",
+            "Session clocks can drift.",
+            std::collections::BTreeMap::new(),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        assert!(
+            html.contains("<section class=\"warning\" id=\"auth.session.clock-skew\">"),
+            "missing warning section: {html}"
+        );
+        assert!(
+            html.contains("<span class=\"warning__kind\">warning</span>"),
+            "missing kind span: {html}"
+        );
+        assert!(
+            html.contains("<code class=\"warning__id\">auth.session.clock-skew</code>"),
+            "missing id code: {html}"
+        );
+        assert!(
+            html.contains("<span class=\"warning__severity\">high</span>"),
+            "missing severity span: {html}"
+        );
+        assert!(
+            html.contains("<div class=\"warning__body\"><p>Session clocks can drift.</p></div>"),
+            "missing warning body: {html}"
+        );
+    }
+
+    #[test]
+    fn warning_renders_metadata_footer_only_when_fields_are_present() {
+        let block = make_warning(
+            "auth.session.clock-skew",
+            "medium",
+            "Session clocks can drift.",
+            std::collections::BTreeMap::new(),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+        assert!(
+            !html.contains("<footer class=\"warning__metadata\">"),
+            "unexpected metadata footer: {html}"
+        );
+
+        let block = make_warning(
+            "auth.session.clock-skew",
+            "medium",
+            "Session clocks can drift.",
+            std::collections::BTreeMap::from([("owner".to_string(), "platform".to_string())]),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+        assert!(
+            html.contains("<footer class=\"warning__metadata\">\n<dl>\n"),
+            "missing metadata footer: {html}"
+        );
+        assert!(
+            html.contains("<dt>owner</dt><dd>platform</dd>"),
+            "missing metadata field: {html}"
+        );
+    }
+
+    #[test]
+    fn warning_html_escapes_body_and_metadata() {
+        let block = make_warning(
+            "auth.session.clock-skew",
+            "critical",
+            "clock < token && token > drift",
+            std::collections::BTreeMap::from([("note".to_string(), "value 'x' & <y>".to_string())]),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        assert!(
+            html.contains("clock &lt; token &amp;&amp; token &gt; drift"),
+            "body not escaped: {html}"
+        );
+        assert!(
+            html.contains("<dt>note</dt><dd>value &#39;x&#39; &amp; &lt;y&gt;</dd>"),
+            "metadata not escaped: {html}"
         );
     }
 }

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -93,7 +93,9 @@ fn render_block(block: &BlockAst, html: &mut String) {
 }
 
 fn render_warning(warning: &Warning, html: &mut String) {
-    html.push_str("<section class=\"warning\" id=\"");
+    html.push_str("<section class=\"warning warning--");
+    html.push_str(warning.severity().as_str());
+    html.push_str("\" id=\"");
     html.push_str(&escape_html(warning.id().as_str()));
     html.push_str("\">\n");
     html.push_str("<header class=\"warning__header\">");
@@ -785,7 +787,9 @@ mod tests {
         render_block(&block, &mut html);
 
         assert!(
-            html.contains("<section class=\"warning\" id=\"auth.session.clock-skew\">"),
+            html.contains(
+                "<section class=\"warning warning--high\" id=\"auth.session.clock-skew\">"
+            ),
             "missing warning section: {html}"
         );
         assert!(

--- a/crates/adoc-core/src/infrastructure/validate/knowledge_object_unique_ids.rs
+++ b/crates/adoc-core/src/infrastructure/validate/knowledge_object_unique_ids.rs
@@ -65,6 +65,11 @@ fn knowledge_object_identity(knowledge_object: &KnowledgeObject) -> KnowledgeObj
             id: decision.id(),
             span: decision.span(),
         },
+        KnowledgeObject::Warning(warning) => KnowledgeObjectIdentity {
+            kind: BlockKind::Warning,
+            id: warning.id(),
+            span: warning.span(),
+        },
     }
 }
 
@@ -95,7 +100,7 @@ mod tests {
     use crate::domain::ast::{BlockAst, PageAst};
     use crate::domain::diagnostic::{SourcePosition, SourceSpan};
     use crate::domain::identity::PageId;
-    use crate::domain::knowledge_object::{claim::Claim, decision::Decision};
+    use crate::domain::knowledge_object::{claim::Claim, decision::Decision, warning::Warning};
 
     fn span(file: &str, line: u32, column: u32) -> SourceSpan {
         SourceSpan {
@@ -137,6 +142,18 @@ mod tests {
         )
         .expect("valid decision");
         BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Decision(decision)))
+    }
+
+    fn warning_block(id: &str, span: SourceSpan) -> BlockAst {
+        let warning = Warning::try_new(
+            id,
+            Some("high"),
+            "Session clocks can drift.",
+            BTreeMap::new(),
+            span,
+        )
+        .expect("valid warning");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Warning(warning)))
     }
 
     fn page(source_path: &str, blocks: Vec<BlockAst>) -> PageAst {
@@ -359,5 +376,54 @@ mod tests {
                 .map(|span| (span.start.line, span.start.column)),
             Some((9, 1))
         );
+    }
+
+    #[test]
+    fn emits_one_diagnostic_for_duplicate_warning_id() {
+        let workspace = WorkspaceAst {
+            pages: vec![
+                page(
+                    "one.adoc",
+                    vec![warning_block("auth.session", span("one.adoc", 3, 1))],
+                ),
+                page(
+                    "two.adoc",
+                    vec![warning_block("auth.session", span("two.adoc", 5, 1))],
+                ),
+            ],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdDuplicate);
+        assert_eq!(
+            diagnostics[0].message,
+            "duplicate warning id `auth.session`; previously defined at one.adoc:3:1"
+        );
+        assert_eq!(diagnostics[0].object_id.as_deref(), Some("auth.session"));
+    }
+
+    #[test]
+    fn emits_one_diagnostic_for_warning_id_matching_existing_claim_id() {
+        let workspace = WorkspaceAst {
+            pages: vec![page(
+                "one.adoc",
+                vec![
+                    claim_block("auth.session", span("one.adoc", 3, 1)),
+                    warning_block("auth.session", span("one.adoc", 9, 1)),
+                ],
+            )],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdDuplicate);
+        assert_eq!(
+            diagnostics[0].message,
+            "duplicate knowledge object id `auth.session`; previously defined as claim at one.adoc:3:1"
+        );
+        assert_eq!(diagnostics[0].object_id.as_deref(), Some("auth.session"));
     }
 }

--- a/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
+++ b/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
@@ -555,4 +555,25 @@ mod tests {
         );
         assert!(pairs[0].1.blocks.is_empty());
     }
+
+    #[test]
+    fn emits_invalid_status_for_warning_invalid_severity() {
+        let pending = warning_pending(
+            BTreeMap::from([("severity".to_string(), "HIGH".to_string())]),
+            "Session clocks can drift.",
+        );
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaInvalidStatus);
+        assert!(diagnostics[0].message.contains("HIGH"));
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("auth.session.clock-skew")
+        );
+        assert!(pairs[0].1.blocks.is_empty());
+    }
 }

--- a/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
+++ b/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
@@ -109,6 +109,24 @@ mod tests {
         }
     }
 
+    fn assert_missing_field_has_object_context(
+        diagnostic: &crate::domain::diagnostic::Diagnostic,
+        object_id: &str,
+        help_contains: &str,
+    ) {
+        assert_eq!(diagnostic.code, DiagnosticCode::SchemaMissingField);
+        assert_eq!(diagnostic.span.as_ref(), Some(&span()));
+        assert_eq!(diagnostic.object_id.as_deref(), Some(object_id));
+        assert!(
+            diagnostic
+                .help
+                .as_deref()
+                .is_some_and(|help| help.contains(help_contains)),
+            "expected help to contain `{help_contains}`, got {:?}",
+            diagnostic.help
+        );
+    }
+
     fn valid_pending(id: &str) -> ParsedTypedBlock {
         let mut fields = BTreeMap::new();
         fields.insert("status".to_string(), "verified".to_string());
@@ -236,11 +254,11 @@ mod tests {
         let diagnostics = resolve_knowledge_objects(&mut pairs);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaMissingField);
         assert!(
             diagnostics[0].message.contains("status"),
             "message should mention 'status'"
         );
+        assert_missing_field_has_object_context(&diagnostics[0], "billing.credits", "status");
         assert!(pairs[0].1.blocks.is_empty());
     }
 
@@ -265,11 +283,11 @@ mod tests {
         let diagnostics = resolve_knowledge_objects(&mut pairs);
 
         assert_eq!(diagnostics.len(), 1);
-        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaMissingField);
         assert!(
             diagnostics[0].message.contains("body"),
             "message should mention 'body'"
         );
+        assert_missing_field_has_object_context(&diagnostics[0], "billing.credits", "body");
         assert!(pairs[0].1.blocks.is_empty());
     }
 
@@ -451,6 +469,50 @@ mod tests {
     }
 
     #[test]
+    fn emits_missing_field_for_decision_missing_status_with_object_context() {
+        let pending = ParsedTypedBlock {
+            kind: BlockKind::Decision,
+            id_text: "billing.policy".to_string(),
+            raw_fields: BTreeMap::new(),
+            duplicate_keys: Vec::new(),
+            body_text: "Use the existing billing policy.".to_string(),
+            content_spans: Vec::new(),
+            span: span(),
+        };
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("status"));
+        assert_missing_field_has_object_context(&diagnostics[0], "billing.policy", "status");
+        assert!(pairs[0].1.blocks.is_empty());
+    }
+
+    #[test]
+    fn emits_missing_field_for_decision_missing_body_with_object_context() {
+        let pending = ParsedTypedBlock {
+            kind: BlockKind::Decision,
+            id_text: "billing.policy".to_string(),
+            raw_fields: BTreeMap::from([("status".to_string(), "proposed".to_string())]),
+            duplicate_keys: Vec::new(),
+            body_text: " ".to_string(),
+            content_spans: Vec::new(),
+            span: span(),
+        };
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert!(diagnostics[0].message.contains("body"));
+        assert_missing_field_has_object_context(&diagnostics[0], "billing.policy", "body");
+        assert!(pairs[0].1.blocks.is_empty());
+    }
+
+    #[test]
     fn preserves_decided_by_metadata_for_non_accepted_decisions() {
         let pending = ParsedTypedBlock {
             kind: BlockKind::Decision,
@@ -532,6 +594,12 @@ mod tests {
             diagnostics[0].object_id.as_deref(),
             Some("auth.session.clock-skew")
         );
+        assert!(
+            diagnostics[0]
+                .help
+                .as_deref()
+                .is_some_and(|help| help.contains("severity"))
+        );
         assert!(pairs[0].1.blocks.is_empty());
     }
 
@@ -552,6 +620,12 @@ mod tests {
         assert_eq!(
             diagnostics[0].object_id.as_deref(),
             Some("auth.session.clock-skew")
+        );
+        assert!(
+            diagnostics[0]
+                .help
+                .as_deref()
+                .is_some_and(|help| help.contains("body"))
         );
         assert!(pairs[0].1.blocks.is_empty());
     }

--- a/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
+++ b/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
@@ -9,7 +9,7 @@
 use crate::domain::ast::{BlockAst, PageAst};
 use crate::domain::diagnostic::Diagnostic;
 use crate::domain::knowledge_object::{
-    BlockKind, KnowledgeObject, claim::Claim, decision::Decision,
+    BlockKind, KnowledgeObject, claim::Claim, decision::Decision, warning::Warning,
 };
 use crate::domain::source::SourceFile;
 
@@ -44,6 +44,14 @@ fn resolve_page(page: &mut PageAst, diagnostics: &mut Vec<Diagnostic>) {
                         if let Some(decision) = Decision::build_from_parsed(&parsed, diagnostics) {
                             new_blocks.push(BlockAst::KnowledgeObject(Box::new(
                                 KnowledgeObject::Decision(decision),
+                            )));
+                        }
+                        // failure → block dropped; diagnostics already emitted above
+                    }
+                    BlockKind::Warning => {
+                        if let Some(warning) = Warning::build_from_parsed(&parsed, diagnostics) {
+                            new_blocks.push(BlockAst::KnowledgeObject(Box::new(
+                                KnowledgeObject::Warning(warning),
                             )));
                         }
                         // failure → block dropped; diagnostics already emitted above
@@ -113,6 +121,18 @@ mod tests {
             raw_fields: fields,
             duplicate_keys: Vec::new(),
             body_text: "This is a valid claim body.".to_string(),
+            content_spans: Vec::new(),
+            span: span(),
+        }
+    }
+
+    fn warning_pending(fields: BTreeMap<String, String>, body_text: &str) -> ParsedTypedBlock {
+        ParsedTypedBlock {
+            kind: BlockKind::Warning,
+            id_text: "auth.session.clock-skew".to_string(),
+            raw_fields: fields,
+            duplicate_keys: Vec::new(),
+            body_text: body_text.to_string(),
             content_spans: Vec::new(),
             span: span(),
         }
@@ -465,5 +485,74 @@ mod tests {
                 .map(|(key, value)| (key.as_str(), value.as_str())),
             Some(("decided_by", "architecture"))
         );
+    }
+
+    #[test]
+    fn resolves_warning_and_strips_severity_metadata() {
+        let pending = warning_pending(
+            BTreeMap::from([
+                ("severity".to_string(), "critical".to_string()),
+                ("owner".to_string(), "platform".to_string()),
+            ]),
+            "Session clocks can drift.",
+        );
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert!(diagnostics.is_empty());
+        let BlockAst::KnowledgeObject(ko) = &pairs[0].1.blocks[0] else {
+            panic!("expected KnowledgeObject");
+        };
+        let KnowledgeObject::Warning(warning) = ko.as_ref() else {
+            panic!("expected warning");
+        };
+        assert_eq!(warning.severity().as_str(), "critical");
+        let field_keys: Vec<&str> = warning
+            .fields()
+            .iter()
+            .map(|(key, _)| key.as_str())
+            .collect();
+        assert_eq!(field_keys, vec!["owner"]);
+    }
+
+    #[test]
+    fn emits_missing_field_for_warning_missing_severity() {
+        let pending = warning_pending(BTreeMap::new(), "Session clocks can drift.");
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaMissingField);
+        assert!(diagnostics[0].message.contains("severity"));
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("auth.session.clock-skew")
+        );
+        assert!(pairs[0].1.blocks.is_empty());
+    }
+
+    #[test]
+    fn emits_missing_field_for_warning_missing_body() {
+        let pending = warning_pending(
+            BTreeMap::from([("severity".to_string(), "high".to_string())]),
+            " ",
+        );
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaMissingField);
+        assert!(diagnostics[0].message.contains("body"));
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("auth.session.clock-skew")
+        );
+        assert!(pairs[0].1.blocks.is_empty());
     }
 }

--- a/crates/adoc-core/tests/compile_workspace.rs
+++ b/crates/adoc-core/tests/compile_workspace.rs
@@ -265,7 +265,7 @@ fn compile_workspace_resolves_warning_into_artifacts() {
     assert!(
         artifacts
             .html
-            .contains("<section class=\"warning\" id=\"auth.session.clock-skew\">"),
+            .contains("<section class=\"warning warning--high\" id=\"auth.session.clock-skew\">"),
         "warning section missing: {}",
         artifacts.html
     );
@@ -348,6 +348,38 @@ fn compile_workspace_rejects_warning_missing_body() {
         DiagnosticCode::SchemaMissingField
     );
     assert!(result.diagnostics[0].message.contains("body"));
+    assert_eq!(
+        result.diagnostics[0].object_id.as_deref(),
+        Some("auth.session.clock-skew")
+    );
+}
+
+#[test]
+fn compile_workspace_rejects_warning_invalid_severity() {
+    let workspace = TestWorkspace::new("warning-invalid-severity");
+    let source = workspace.write(
+        "warnings.adoc",
+        concat!(
+            "# Warning Guide @doc(team.warnings)\n",
+            "\n",
+            "::warning auth.session.clock-skew\n",
+            "severity: Critical\n",
+            "--\n",
+            "Session clocks can drift.\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(result.has_errors(), "invalid severity must be rejected");
+    assert!(result.artifacts.is_none(), "errors must block artifacts");
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        DiagnosticCode::SchemaInvalidStatus
+    );
+    assert!(result.diagnostics[0].message.contains("Critical"));
     assert_eq!(
         result.diagnostics[0].object_id.as_deref(),
         Some("auth.session.clock-skew")

--- a/crates/adoc-core/tests/compile_workspace.rs
+++ b/crates/adoc-core/tests/compile_workspace.rs
@@ -215,6 +215,146 @@ fn compile_workspace_resolves_clean_decision_into_artifacts() {
 }
 
 #[test]
+fn compile_workspace_resolves_warning_into_artifacts() {
+    let workspace = TestWorkspace::new("resolve-warning-into-artifacts");
+    let source = workspace.write(
+        "warnings.adoc",
+        concat!(
+            "# Warning Guide @doc(team.warnings)\n",
+            "\n",
+            "::warning auth.session.clock-skew\n",
+            "severity: high\n",
+            "owner: platform\n",
+            "--\n",
+            "Session clocks can drift enough to reject otherwise valid tokens.\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(
+        !result.has_errors(),
+        "expected warning to compile, got: {:?}",
+        result.diagnostics
+    );
+    let artifacts = result.artifacts.expect("artifacts must be produced");
+    let record = artifacts
+        .agent_json
+        .objects
+        .first()
+        .expect("warning object must be emitted");
+    assert_eq!(record.id, "auth.session.clock-skew");
+    assert_eq!(record.kind, "warning");
+    assert_eq!(record.status, "high");
+    assert_eq!(
+        record.body,
+        "Session clocks can drift enough to reject otherwise valid tokens."
+    );
+    assert_eq!(record.page_id, "team.warnings");
+    assert_eq!(
+        record.fields.get("owner").map(String::as_str),
+        Some("platform")
+    );
+    assert!(!record.fields.contains_key("severity"));
+    assert!(record.relations.depends_on.is_empty());
+    assert!(record.relations.supersedes.is_empty());
+    assert!(record.relations.related_to.is_empty());
+    assert_eq!(record.source_span.line, 3);
+    assert_eq!(record.source_span.column, 1);
+    assert!(
+        artifacts
+            .html
+            .contains("<section class=\"warning\" id=\"auth.session.clock-skew\">"),
+        "warning section missing: {}",
+        artifacts.html
+    );
+    assert!(
+        artifacts
+            .html
+            .contains("<span class=\"warning__kind\">warning</span>"),
+        "warning kind missing: {}",
+        artifacts.html
+    );
+    assert!(
+        artifacts
+            .html
+            .contains("<span class=\"warning__severity\">high</span>"),
+        "warning severity missing: {}",
+        artifacts.html
+    );
+}
+
+#[test]
+fn compile_workspace_rejects_warning_missing_severity() {
+    let workspace = TestWorkspace::new("warning-missing-severity");
+    let source = workspace.write(
+        "warnings.adoc",
+        concat!(
+            "# Warning Guide @doc(team.warnings)\n",
+            "\n",
+            "::warning auth.session.clock-skew\n",
+            "--\n",
+            "Session clocks can drift.\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(result.has_errors(), "missing severity must be rejected");
+    assert!(result.artifacts.is_none(), "errors must block artifacts");
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        DiagnosticCode::SchemaMissingField
+    );
+    assert!(result.diagnostics[0].message.contains("severity"));
+    assert_eq!(
+        result.diagnostics[0].object_id.as_deref(),
+        Some("auth.session.clock-skew")
+    );
+    assert_eq!(
+        result.diagnostics[0]
+            .span
+            .as_ref()
+            .map(|span| (span.start.line, span.start.column)),
+        Some((3, 1))
+    );
+}
+
+#[test]
+fn compile_workspace_rejects_warning_missing_body() {
+    let workspace = TestWorkspace::new("warning-missing-body");
+    let source = workspace.write(
+        "warnings.adoc",
+        concat!(
+            "# Warning Guide @doc(team.warnings)\n",
+            "\n",
+            "::warning auth.session.clock-skew\n",
+            "severity: high\n",
+            "--\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(result.has_errors(), "missing body must be rejected");
+    assert!(result.artifacts.is_none(), "errors must block artifacts");
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        DiagnosticCode::SchemaMissingField
+    );
+    assert!(result.diagnostics[0].message.contains("body"));
+    assert_eq!(
+        result.diagnostics[0].object_id.as_deref(),
+        Some("auth.session.clock-skew")
+    );
+}
+
+#[test]
 fn compile_workspace_rejects_duplicate_decision_id_and_blocks_artifacts() {
     let workspace = TestWorkspace::new("decision-duplicate-id");
     let source = workspace.write(

--- a/docs/V0-DESIGN.md
+++ b/docs/V0-DESIGN.md
@@ -408,6 +408,10 @@ Object record sketch:
 Rules:
 
 - Agent JSON remains flat in V0.
+- Object `status` is the object's kind-primary normalized discriminant. For the
+  current object set, this means claim status, decision status, and warning
+  severity. V0 keeps these values in one slot rather than adding per-kind
+  top-level discriminant fields.
 - Relations are ID arrays, not embedded objects.
 - Diagnostics are included using the same codes and messages as CLI diagnostics.
 - Schema versioning starts immediately, even if the shape is still pre-1.0.


### PR DESCRIPTION
## Summary

- Adds the `warning` Knowledge Object as a complete vertical slice — authored, validated, rendered to HTML, and emitted in `docs.agent.json` — reusing the existing claim/decision pipeline.
- Enforces severity as a closed enum (`low | medium | high | critical`, ASCII-case-strict) at the type level, with `schema.invalid_status` diagnostics for non-canonical values.
- Delivered as two tracer-bullet slices per the issue plan: S1 ships the aggregate end to end with an open-string severity; S2 swaps in the closed enum without touching call sites.

## Slice mapping

### S1 — Warning aggregate end to end (#47, `8ca899e`)
- New `Warning` aggregate (`warning.rs`) with `try_new` / `build_from_parsed`, plus `Severity(NonEmptyText)` newtype and `WarningError { InvalidId, MissingSeverity, MissingBody }`.
- `BlockKind::Warning` and `KnowledgeObject::Warning` extend the shared enums; the parser's data-driven `SUPPORTED_KINDS` table picks up `warning` automatically (propagating through `parse.unclosed_fence` / `parse.malformed_open_fence` / `parse.unknown_block_type`).
- Resolver dispatch arm calls `Warning::build_from_parsed`; failures emit `schema.missing_field` with `object_id` + `span` and drop the block.
- HTML renderer emits `<section class="warning" id="…">` with `warning__kind` / `warning__id` / `warning__severity` / `warning__body` / optional `warning__metadata` footer; all user content escaped.
- Agent JSON places severity in the existing `status` slot — no schema changes to `AgentJsonObject` — with `fields` / `relations` parallel to claim/decision.
- Fixtures: `warning_basic` (positive), `warning_missing_severity`, `warning_missing_body` plus golden HTML + `agent.json`.

### S2 — Closed-enum severity invariant (#48, `6fc5cc5`)
- Replaces the open-string severity with `enum WarningSeverity { Low, Medium, High, Critical }` (ASCII-case-strict, no lenience).
- Adds `WarningError::InvalidSeverity(String)`; resolver emits `schema.invalid_status` with help text `"Valid warning severities are: low, medium, high, critical."` and drops the block (parallels decision's invalid-status path).
- HTML `<section>` now always carries the `warning--{severity}` modifier class — guaranteed by the closed enum and required-severity invariant.
- Fixtures: `warning_invalid_severity` (`severity: panic`) and `warning_severity_casing` (`severity: Critical`); `warning_basic` golden updated for the modifier class.

## Issue #8 acceptance criteria

- [x] Top-level `::warning object.id` blocks parse with fields, body, source file, and source span.
- [x] Warnings require `severity` and body.
- [x] Warning objects render distinctly in HTML with kind, ID, severity, and body.
- [x] Warning objects appear in `docs.agent.json` with kind-specific fields preserved.
- [x] Invalid warnings produce `schema.missing_field` (and `schema.invalid_status` for non-canonical severity values) with source location and object ID where available.
- [x] Tests cover valid warning fixtures and missing severity / missing body / invalid severity / case-variant fixtures.
- [x] The implementation reuses the existing Knowledge Object validation path without duplicating parser or renderer logic.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` — 334 tests, 0 failures
- [x] CLI golden snapshots (`snapshots_cli__check_warning_*`) round-trip cleanly
- [x] `compile_workspace_resolves_warning_into_artifacts` integration test green

## Linked issues

Closes #8
Closes #47
Closes #48