### PR TITLE
feat(core): glossary knowledge object and combined Core Object Set (V0.4)

### DIFF
--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -1373,6 +1373,127 @@ fn build_renders_v0_4_glossary_to_golden_agent_json() {
 }
 
 #[test]
+fn check_accepts_v0_4_core_object_set_fixture() {
+    let workspace = TestWorkspace::new("check-accepts-v0-4-core-object-set");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/core_object_set.adoc"))
+        .expect("core_object_set fixture is readable");
+    workspace.write("core_object_set.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "core_object_set.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected v0.4 core object set fixture to check cleanly\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 errors, 0 warnings"),
+        "expected clean summary, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn build_renders_v0_4_core_object_set_to_golden_html() {
+    let workspace = TestWorkspace::new("build-renders-core-object-set-golden-html");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/core_object_set.adoc"))
+        .expect("core_object_set fixture is readable");
+    workspace.write("core_object_set.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "core_object_set.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
+        .expect("docs.html is written");
+    let golden = fs::read_to_string(fixture_path("v0_4/core_object_set.golden.html"))
+        .expect("golden HTML fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "rendered HTML diverged from core_object_set.golden.html"
+    );
+    assert!(
+        actual
+            .contains("<section class=\"claim claim--verified\" id=\"billing.credits.lifecycle\">"),
+        "verified claim class family missing from HTML"
+    );
+    assert!(
+        actual.contains("<section class=\"decision decision--accepted\" id=\"billing.policy\">"),
+        "accepted decision class family missing from HTML"
+    );
+    assert!(
+        actual.contains("<section class=\"warning warning--high\" id=\"auth.session.clock-skew\">"),
+        "warning severity class family missing from HTML"
+    );
+    assert!(
+        actual.contains("<section class=\"glossary\" id=\"billing.credits\">"),
+        "glossary class family missing from HTML"
+    );
+}
+
+#[test]
+fn build_renders_v0_4_core_object_set_to_golden_agent_json() {
+    let workspace = TestWorkspace::new("build-renders-core-object-set-golden-json");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/core_object_set.adoc"))
+        .expect("core_object_set fixture is readable");
+    workspace.write("core_object_set.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "core_object_set.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.agent.json"))
+        .expect("docs.agent.json is written");
+    let golden = fs::read_to_string(fixture_path("v0_4/core_object_set.golden.agent.json"))
+        .expect("golden agent JSON fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "agent JSON diverged from core_object_set.golden.agent.json"
+    );
+    assert!(
+        actual.contains("\"kind\": \"claim\",\n      \"status\": \"verified\""),
+        "claim agent JSON must include top-level verified status"
+    );
+    assert!(
+        actual.contains("\"kind\": \"decision\",\n      \"status\": \"accepted\""),
+        "decision agent JSON must include top-level accepted status"
+    );
+    assert!(
+        actual.contains("\"kind\": \"warning\",\n      \"status\": \"high\""),
+        "warning agent JSON must map severity to top-level status"
+    );
+    assert!(
+        !actual.contains("\"kind\": \"glossary\",\n      \"status\":"),
+        "glossary agent JSON must omit top-level status"
+    );
+}
+
+#[test]
 fn check_rejects_glossary_with_missing_body() {
     let workspace = TestWorkspace::new("check-rejects-glossary-missing-body");
     let fixture_contents = fs::read_to_string(fixture_path("v0_4/glossary_missing_body.adoc"))

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -1273,6 +1273,134 @@ fn build_renders_v0_4_warning_to_golden_agent_json() {
 }
 
 #[test]
+fn check_accepts_v0_4_glossary_fixture() {
+    let workspace = TestWorkspace::new("check-accepts-v0-4-glossary");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/glossary_basic.adoc"))
+        .expect("glossary_basic fixture is readable");
+    workspace.write("glossary_basic.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "glossary_basic.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected v0.4 glossary fixture to check cleanly\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("0 errors, 0 warnings"),
+        "expected clean summary, got:\n{stdout}"
+    );
+}
+
+#[test]
+fn build_renders_v0_4_glossary_to_golden_html() {
+    let workspace = TestWorkspace::new("build-renders-glossary-golden-html");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/glossary_basic.adoc"))
+        .expect("glossary_basic fixture is readable");
+    workspace.write("glossary_basic.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "glossary_basic.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
+        .expect("docs.html is written");
+    let golden = fs::read_to_string(fixture_path("v0_4/glossary_basic.golden.html"))
+        .expect("golden HTML fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "rendered HTML diverged from glossary_basic.golden.html"
+    );
+    assert!(
+        actual.contains("<section class=\"glossary\" id=\"billing.credits\">"),
+        "glossary section missing from HTML"
+    );
+}
+
+#[test]
+fn build_renders_v0_4_glossary_to_golden_agent_json() {
+    let workspace = TestWorkspace::new("build-renders-glossary-golden-json");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/glossary_basic.adoc"))
+        .expect("glossary_basic fixture is readable");
+    workspace.write("glossary_basic.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["build", "glossary_basic.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let actual = fs::read_to_string(workspace.root.join("dist").join("docs.agent.json"))
+        .expect("docs.agent.json is written");
+    let golden = fs::read_to_string(fixture_path("v0_4/glossary_basic.golden.agent.json"))
+        .expect("golden agent JSON fixture is readable");
+
+    assert_eq!(
+        actual, golden,
+        "agent JSON diverged from glossary_basic.golden.agent.json"
+    );
+    assert!(
+        !actual.contains("\n      \"status\":"),
+        "glossary agent JSON must omit top-level status"
+    );
+    assert!(
+        actual.contains("\"status\": \"draft\""),
+        "glossary fields must preserve status metadata"
+    );
+}
+
+#[test]
+fn check_rejects_glossary_with_missing_body() {
+    let workspace = TestWorkspace::new("check-rejects-glossary-missing-body");
+    let fixture_contents = fs::read_to_string(fixture_path("v0_4/glossary_missing_body.adoc"))
+        .expect("glossary_missing_body fixture is readable");
+    workspace.write("glossary_missing_body.adoc", &fixture_contents);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args(["check", "glossary_missing_body.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected missing-body glossary to fail check"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("error[schema.missing_field]"),
+        "expected schema.missing_field diagnostic, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("body"),
+        "expected message to mention `body`, got:\n{stdout}"
+    );
+}
+
+#[test]
 fn check_rejects_warning_with_missing_severity() {
     let workspace = TestWorkspace::new("check-rejects-warning-missing-severity");
     let fixture_contents = fs::read_to_string(fixture_path("v0_4/warning_missing_severity.adoc"))

--- a/crates/adoc-cli/tests/fixtures/v0_4/core_object_set.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/core_object_set.adoc
@@ -1,0 +1,36 @@
+# Core Object Set @doc(team.core-objects)
+
+Combined v0.4 object coverage for agents and human readers.
+
+::claim billing.credits.lifecycle
+status: verified
+owner: team-billing
+verified_at: 2026-05-05
+source: billing ledger
+test: cargo test billing_credits_lifecycle
+reviewed_by: qa-team
+--
+Credits move from pending to available after settlement completes.
+::
+
+::decision billing.policy
+status: accepted
+decided_by: architecture
+owner: platform
+--
+Use the billing policy document as the contract for account credit behavior.
+::
+
+::warning auth.session.clock-skew
+severity: high
+owner: platform
+--
+Session validation can fail when client and server clocks drift beyond tolerance.
+::
+
+::glossary billing.credits
+status: draft
+owner: team-billing
+--
+Credits are balance adjustments that reduce an account's future invoice amount.
+::

--- a/crates/adoc-cli/tests/fixtures/v0_4/core_object_set.golden.agent.json
+++ b/crates/adoc-cli/tests/fixtures/v0_4/core_object_set.golden.agent.json
@@ -1,0 +1,98 @@
+{
+  "schema_version": "adoc.agent.v0",
+  "pages": [
+    {
+      "id": "team.core-objects",
+      "title": "Core Object Set",
+      "source_path": "core_object_set.adoc"
+    }
+  ],
+  "objects": [
+    {
+      "id": "billing.credits.lifecycle",
+      "kind": "claim",
+      "status": "verified",
+      "body": "Credits move from pending to available after settlement completes.",
+      "page_id": "team.core-objects",
+      "source_span": {
+        "path": "core_object_set.adoc",
+        "line": 5,
+        "column": 1
+      },
+      "fields": {
+        "owner": "team-billing",
+        "reviewed_by": "qa-team",
+        "source": "billing ledger",
+        "test": "cargo test billing_credits_lifecycle",
+        "verified_at": "2026-05-05"
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    },
+    {
+      "id": "billing.policy",
+      "kind": "decision",
+      "status": "accepted",
+      "body": "Use the billing policy document as the contract for account credit behavior.",
+      "page_id": "team.core-objects",
+      "source_span": {
+        "path": "core_object_set.adoc",
+        "line": 16,
+        "column": 1
+      },
+      "fields": {
+        "decided_by": "architecture",
+        "owner": "platform"
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    },
+    {
+      "id": "auth.session.clock-skew",
+      "kind": "warning",
+      "status": "high",
+      "body": "Session validation can fail when client and server clocks drift beyond tolerance.",
+      "page_id": "team.core-objects",
+      "source_span": {
+        "path": "core_object_set.adoc",
+        "line": 24,
+        "column": 1
+      },
+      "fields": {
+        "owner": "platform"
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    },
+    {
+      "id": "billing.credits",
+      "kind": "glossary",
+      "body": "Credits are balance adjustments that reduce an account's future invoice amount.",
+      "page_id": "team.core-objects",
+      "source_span": {
+        "path": "core_object_set.adoc",
+        "line": 31,
+        "column": 1
+      },
+      "fields": {
+        "owner": "team-billing",
+        "status": "draft"
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    }
+  ],
+  "diagnostics": []
+}

--- a/crates/adoc-cli/tests/fixtures/v0_4/core_object_set.golden.html
+++ b/crates/adoc-cli/tests/fixtures/v0_4/core_object_set.golden.html
@@ -1,0 +1,59 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AgentDoc</title>
+</head>
+<body>
+<article data-page-id="team.core-objects">
+<h1>Core Object Set</h1>
+<p>Combined v0.4 object coverage for agents and human readers.</p>
+<section class="claim claim--verified" id="billing.credits.lifecycle">
+<header class="claim__header"><span class="claim__kind">claim</span><code class="claim__id">billing.credits.lifecycle</code><span class="claim__status">verified</span></header>
+<div class="claim__body"><p>Credits move from pending to available after settlement completes.</p></div>
+<div class="claim__verification">
+<dl>
+<div class="claim__verification-item"><dt>owner</dt><dd>team-billing</dd></div>
+<div class="claim__verification-item"><dt>verified_at</dt><dd>2026-05-05</dd></div>
+</dl>
+</div>
+<div class="claim__evidence">
+<dl>
+<div class="claim__evidence-item claim__evidence-item--source"><dt>source</dt><dd>billing ledger</dd></div>
+<div class="claim__evidence-item claim__evidence-item--test"><dt>test</dt><dd>cargo test billing_credits_lifecycle</dd></div>
+<div class="claim__evidence-item claim__evidence-item--reviewed-by"><dt>reviewed_by</dt><dd>qa-team</dd></div>
+</dl>
+</div>
+</section>
+<section class="decision decision--accepted" id="billing.policy">
+<header class="decision__header"><span class="decision__kind">decision</span><code class="decision__id">billing.policy</code><span class="decision__status">accepted</span></header>
+<div class="decision__body"><p>Use the billing policy document as the contract for account credit behavior.</p></div>
+<div class="decision__verdict"><dl><div class="decision__verdict-item"><dt>decided_by</dt><dd>architecture</dd></div></dl></div>
+<footer class="decision__metadata">
+<dl>
+<dt>owner</dt><dd>platform</dd>
+</dl>
+</footer>
+</section>
+<section class="warning warning--high" id="auth.session.clock-skew">
+<header class="warning__header"><span class="warning__kind">warning</span><code class="warning__id">auth.session.clock-skew</code><span class="warning__severity">high</span></header>
+<div class="warning__body"><p>Session validation can fail when client and server clocks drift beyond tolerance.</p></div>
+<footer class="warning__metadata">
+<dl>
+<dt>owner</dt><dd>platform</dd>
+</dl>
+</footer>
+</section>
+<section class="glossary" id="billing.credits">
+<header class="glossary__header"><span class="glossary__kind">glossary</span><code class="glossary__id">billing.credits</code></header>
+<div class="glossary__body"><p>Credits are balance adjustments that reduce an account&#39;s future invoice amount.</p></div>
+<footer class="glossary__metadata">
+<dl>
+<dt>owner</dt><dd>team-billing</dd>
+<dt>status</dt><dd>draft</dd>
+</dl>
+</footer>
+</section>
+</article>
+</body>
+</html>

--- a/crates/adoc-cli/tests/fixtures/v0_4/glossary_basic.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/glossary_basic.adoc
@@ -1,0 +1,10 @@
+# Glossary @doc(team.glossary)
+
+Terms that agents should interpret consistently.
+
+::glossary billing.credits
+status: draft
+owner: team-billing
+--
+Credits are balance adjustments applied to an account.
+::

--- a/crates/adoc-cli/tests/fixtures/v0_4/glossary_basic.golden.agent.json
+++ b/crates/adoc-cli/tests/fixtures/v0_4/glossary_basic.golden.agent.json
@@ -1,0 +1,33 @@
+{
+  "schema_version": "adoc.agent.v0",
+  "pages": [
+    {
+      "id": "team.glossary",
+      "title": "Glossary",
+      "source_path": "glossary_basic.adoc"
+    }
+  ],
+  "objects": [
+    {
+      "id": "billing.credits",
+      "kind": "glossary",
+      "body": "Credits are balance adjustments applied to an account.",
+      "page_id": "team.glossary",
+      "source_span": {
+        "path": "glossary_basic.adoc",
+        "line": 5,
+        "column": 1
+      },
+      "fields": {
+        "owner": "team-billing",
+        "status": "draft"
+      },
+      "relations": {
+        "depends_on": [],
+        "supersedes": [],
+        "related_to": []
+      }
+    }
+  ],
+  "diagnostics": []
+}

--- a/crates/adoc-cli/tests/fixtures/v0_4/glossary_basic.golden.html
+++ b/crates/adoc-cli/tests/fixtures/v0_4/glossary_basic.golden.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>AgentDoc</title>
+</head>
+<body>
+<article data-page-id="team.glossary">
+<h1>Glossary</h1>
+<p>Terms that agents should interpret consistently.</p>
+<section class="glossary" id="billing.credits">
+<header class="glossary__header"><span class="glossary__kind">glossary</span><code class="glossary__id">billing.credits</code></header>
+<div class="glossary__body"><p>Credits are balance adjustments applied to an account.</p></div>
+<footer class="glossary__metadata">
+<dl>
+<dt>owner</dt><dd>team-billing</dd>
+<dt>status</dt><dd>draft</dd>
+</dl>
+</footer>
+</section>
+</article>
+</body>
+</html>

--- a/crates/adoc-cli/tests/fixtures/v0_4/glossary_missing_body.adoc
+++ b/crates/adoc-cli/tests/fixtures/v0_4/glossary_missing_body.adoc
@@ -1,0 +1,5 @@
+# Glossary @doc(team.glossary)
+
+::glossary billing.credits
+status: draft
+::

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_core_object_set_clean.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_core_object_set_clean.snap
@@ -1,0 +1,8 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: true
+---stdout---
+0 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_glossary_clean.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_glossary_clean.snap
@@ -1,0 +1,8 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: true
+---stdout---
+0 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_glossary_missing_body_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_glossary_missing_body_flags.snap
@@ -1,0 +1,9 @@
+---
+source: crates/adoc-cli/tests/snapshots_cli.rs
+expression: combined
+---
+exit-success: false
+---stdout---
+glossary_missing_body.adoc:3:1: error[schema.missing_field] glossary is missing required body
+1 errors, 0 warnings
+---stderr---

--- a/crates/adoc-cli/tests/snapshots_cli.rs
+++ b/crates/adoc-cli/tests/snapshots_cli.rs
@@ -278,6 +278,17 @@ fn snapshot_check_passes_for_v0_4_glossary() {
 }
 
 #[test]
+fn snapshot_check_passes_for_v0_4_core_object_set() {
+    let combined = run_check_in_workspace(
+        "snap-check-core-object-set-clean",
+        "v0_4/core_object_set.adoc",
+        "core_object_set.adoc",
+    );
+
+    insta::assert_snapshot!("check_core_object_set_clean", combined);
+}
+
+#[test]
 fn snapshot_check_flags_glossary_missing_body() {
     let combined = run_check_in_workspace(
         "snap-check-glossary-missing-body",

--- a/crates/adoc-cli/tests/snapshots_cli.rs
+++ b/crates/adoc-cli/tests/snapshots_cli.rs
@@ -265,3 +265,25 @@ fn snapshot_check_flags_warning_severity_casing() {
 
     insta::assert_snapshot!("check_warning_severity_casing_flags", combined);
 }
+
+#[test]
+fn snapshot_check_passes_for_v0_4_glossary() {
+    let combined = run_check_in_workspace(
+        "snap-check-glossary-clean",
+        "v0_4/glossary_basic.adoc",
+        "glossary_basic.adoc",
+    );
+
+    insta::assert_snapshot!("check_glossary_clean", combined);
+}
+
+#[test]
+fn snapshot_check_flags_glossary_missing_body() {
+    let combined = run_check_in_workspace(
+        "snap-check-glossary-missing-body",
+        "v0_4/glossary_missing_body.adoc",
+        "glossary_missing_body.adoc",
+    );
+
+    insta::assert_snapshot!("check_glossary_missing_body_flags", combined);
+}

--- a/crates/adoc-core/src/domain/artifact.rs
+++ b/crates/adoc-core/src/domain/artifact.rs
@@ -41,8 +41,10 @@ pub struct AgentJsonObject {
     pub id: String,
     pub kind: String,
     /// Kind-primary normalized discriminant. For v0 this is the claim status,
-    /// decision status, or warning severity.
-    pub status: String,
+    /// decision status, or warning severity. Objects without such a
+    /// discriminant omit the field from serialized agent JSON.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub status: Option<String>,
     pub body: String,
     pub page_id: String,
     pub source_span: AgentJsonSourceSpan,
@@ -75,7 +77,7 @@ mod tests {
         let obj = AgentJsonObject {
             id: "billing.credits".to_string(),
             kind: "claim".to_string(),
-            status: "verified".to_string(),
+            status: Some("verified".to_string()),
             body: "The system credits users automatically.".to_string(),
             page_id: "team.guide".to_string(),
             source_span: AgentJsonSourceSpan {
@@ -101,5 +103,30 @@ mod tests {
         assert_eq!(value["relations"]["depends_on"], serde_json::json!([]));
         assert_eq!(value["relations"]["supersedes"], serde_json::json!([]));
         assert_eq!(value["relations"]["related_to"], serde_json::json!([]));
+    }
+
+    #[test]
+    fn agent_json_object_omits_status_when_absent() {
+        let obj = AgentJsonObject {
+            id: "billing.note".to_string(),
+            kind: "note".to_string(),
+            status: None,
+            body: "Freeform object without a kind-primary discriminant.".to_string(),
+            page_id: "team.guide".to_string(),
+            source_span: AgentJsonSourceSpan {
+                path: "sample.adoc".to_string(),
+                line: 5,
+                column: 1,
+            },
+            fields: BTreeMap::new(),
+            relations: AgentJsonRelations::default(),
+        };
+
+        let value = serde_json::to_value(&obj).expect("serialization must succeed");
+
+        assert!(
+            value.get("status").is_none(),
+            "absent status must be omitted from agent JSON"
+        );
     }
 }

--- a/crates/adoc-core/src/domain/knowledge_object/claim.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/claim.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::domain::ast::ParsedTypedBlock;
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
@@ -42,21 +42,7 @@ impl Claim {
         parsed: &ParsedTypedBlock,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<Self> {
-        if !parsed.duplicate_keys.is_empty() {
-            let mut emitted_keys = BTreeSet::new();
-            for key in &parsed.duplicate_keys {
-                if emitted_keys.insert(key.as_str()) {
-                    diagnostics.push(
-                        Diagnostic::error(
-                            DiagnosticCode::SchemaDuplicateField,
-                            format!("duplicate field `{key}` in claim"),
-                        )
-                        .with_span(parsed.span.clone()),
-                    );
-                }
-            }
-            // Duplicate fields poison the raw field map: last-value-wins storage
-            // makes missing-field validation ambiguous until the duplicates are fixed.
+        if super::reject_duplicate_fields(parsed, "claim", diagnostics) {
             return None;
         }
 

--- a/crates/adoc-core/src/domain/knowledge_object/decision.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/decision.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::domain::ast::ParsedTypedBlock;
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
@@ -39,21 +39,7 @@ impl Decision {
         parsed: &ParsedTypedBlock,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<Self> {
-        if !parsed.duplicate_keys.is_empty() {
-            let mut emitted_keys = BTreeSet::new();
-            for key in &parsed.duplicate_keys {
-                if emitted_keys.insert(key.as_str()) {
-                    diagnostics.push(
-                        Diagnostic::error(
-                            DiagnosticCode::SchemaDuplicateField,
-                            format!("duplicate field `{key}` in decision"),
-                        )
-                        .with_span(parsed.span.clone()),
-                    );
-                }
-            }
-            // Duplicate fields poison the raw field map: last-value-wins storage
-            // makes missing-field validation ambiguous until the duplicates are fixed.
+        if super::reject_duplicate_fields(parsed, "decision", diagnostics) {
             return None;
         }
 

--- a/crates/adoc-core/src/domain/knowledge_object/glossary.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/glossary.rs
@@ -1,0 +1,258 @@
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::domain::ast::ParsedTypedBlock;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
+use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId, ObjectIdError};
+use crate::domain::values::{BodyText, OptionalFields};
+
+const GLOSSARY_MISSING_BODY_HELP: &str = "Glossary entries require non-empty body text.";
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Glossary {
+    id: ObjectId,
+    body: BodyText,
+    fields: OptionalFields,
+    span: SourceSpan,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum GlossaryError {
+    InvalidId(ObjectIdError),
+    MissingBody,
+}
+
+impl Glossary {
+    pub(crate) fn build_from_parsed(
+        parsed: &ParsedTypedBlock,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Self> {
+        if !parsed.duplicate_keys.is_empty() {
+            let mut emitted_keys = BTreeSet::new();
+            for key in &parsed.duplicate_keys {
+                if emitted_keys.insert(key.as_str()) {
+                    diagnostics.push(
+                        Diagnostic::error(
+                            DiagnosticCode::SchemaDuplicateField,
+                            format!("duplicate field `{key}` in glossary"),
+                        )
+                        .with_span(parsed.span.clone()),
+                    );
+                }
+            }
+            return None;
+        }
+
+        match Self::try_new(
+            &parsed.id_text,
+            &parsed.body_text,
+            parsed.raw_fields.clone(),
+            parsed.span.clone(),
+        ) {
+            Ok(glossary) => Some(glossary),
+            Err(error) => {
+                emit_glossary_error(parsed, error, diagnostics);
+                None
+            }
+        }
+    }
+
+    pub(crate) fn try_new(
+        id_text: &str,
+        body_text: &str,
+        fields: BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> Result<Self, GlossaryError> {
+        let id = ObjectId::new(id_text).map_err(GlossaryError::InvalidId)?;
+        let body = BodyText::try_new(body_text).ok_or(GlossaryError::MissingBody)?;
+        Ok(Self {
+            id,
+            body,
+            fields: OptionalFields::from_map(fields),
+            span,
+        })
+    }
+
+    pub(crate) fn id(&self) -> &ObjectId {
+        &self.id
+    }
+
+    pub(crate) fn body(&self) -> &BodyText {
+        &self.body
+    }
+
+    pub(crate) fn fields(&self) -> &OptionalFields {
+        &self.fields
+    }
+
+    pub(crate) fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+fn emit_glossary_error(
+    parsed: &ParsedTypedBlock,
+    error: GlossaryError,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    match error {
+        GlossaryError::InvalidId(error) => diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::IdInvalid,
+                format!("invalid glossary id `{}`: {error}", parsed.id_text),
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(OBJECT_ID_GRAMMAR_HELP),
+        ),
+        GlossaryError::MissingBody => diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::SchemaMissingField,
+                "glossary is missing required body",
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(GLOSSARY_MISSING_BODY_HELP),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+    use crate::domain::knowledge_object::BlockKind;
+
+    fn span() -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from("test.adoc"),
+            start: SourcePosition {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line: 1,
+                column: 12,
+                offset: 11,
+            },
+        }
+    }
+
+    fn parsed_glossary(
+        id_text: &str,
+        fields: BTreeMap<String, String>,
+        duplicate_keys: Vec<String>,
+        body_text: &str,
+    ) -> ParsedTypedBlock {
+        ParsedTypedBlock {
+            kind: BlockKind::Glossary,
+            id_text: id_text.to_string(),
+            raw_fields: fields,
+            duplicate_keys,
+            body_text: body_text.to_string(),
+            content_spans: Vec::new(),
+            span: span(),
+        }
+    }
+
+    #[test]
+    fn glossary_try_new_accepts_body_and_preserves_all_fields() {
+        let glossary = Glossary::try_new(
+            "billing.credits",
+            "Credits adjust an account balance.",
+            BTreeMap::from([
+                ("status".to_string(), "draft".to_string()),
+                ("owner".to_string(), "team-billing".to_string()),
+            ]),
+            span(),
+        )
+        .expect("valid glossary");
+
+        assert_eq!(glossary.id().as_str(), "billing.credits");
+        assert_eq!(
+            glossary.body().as_str(),
+            "Credits adjust an account balance."
+        );
+        let fields: Vec<(&str, &str)> = glossary
+            .fields()
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect();
+        assert_eq!(fields, vec![("owner", "team-billing"), ("status", "draft")]);
+    }
+
+    #[test]
+    fn glossary_try_new_requires_non_empty_body() {
+        let error = Glossary::try_new("billing.credits", " ", BTreeMap::new(), span())
+            .expect_err("empty body must fail");
+
+        assert_eq!(error, GlossaryError::MissingBody);
+    }
+
+    #[test]
+    fn glossary_try_new_rejects_invalid_id() {
+        let error = Glossary::try_new(
+            "BillingCredits",
+            "Credits adjust an account balance.",
+            BTreeMap::new(),
+            span(),
+        )
+        .expect_err("invalid id must fail");
+
+        assert!(matches!(error, GlossaryError::InvalidId(_)));
+    }
+
+    #[test]
+    fn glossary_build_from_parsed_reports_invalid_id_and_drops_block() {
+        let parsed = parsed_glossary(
+            "BillingCredits",
+            BTreeMap::new(),
+            Vec::new(),
+            "Credits adjust an account balance.",
+        );
+        let mut diagnostics = Vec::new();
+
+        let glossary = Glossary::build_from_parsed(&parsed, &mut diagnostics);
+
+        assert!(glossary.is_none(), "invalid id must drop the block");
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdInvalid);
+        assert_eq!(diagnostics[0].span.as_ref(), Some(&span()));
+        assert_eq!(diagnostics[0].object_id.as_deref(), Some("BillingCredits"));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("invalid glossary id `BillingCredits`"),
+            "diagnostic should name rejected glossary id: {:?}",
+            diagnostics[0]
+        );
+        assert_eq!(diagnostics[0].help.as_deref(), Some(OBJECT_ID_GRAMMAR_HELP));
+    }
+
+    #[test]
+    fn glossary_build_from_parsed_drops_duplicate_fields() {
+        let parsed = parsed_glossary(
+            "billing.credits",
+            BTreeMap::from([("status".to_string(), "reviewed".to_string())]),
+            vec!["status".to_string(), "status".to_string()],
+            "Credits adjust an account balance.",
+        );
+        let mut diagnostics = Vec::new();
+
+        let glossary = Glossary::build_from_parsed(&parsed, &mut diagnostics);
+
+        assert!(glossary.is_none(), "duplicate fields must drop the block");
+        assert_eq!(diagnostics.len(), 1, "duplicate key emitted once");
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaDuplicateField);
+        assert_eq!(diagnostics[0].span.as_ref(), Some(&span()));
+        assert!(
+            diagnostics[0]
+                .message
+                .contains("duplicate field `status` in glossary"),
+            "diagnostic should name duplicate glossary field: {:?}",
+            diagnostics[0]
+        );
+    }
+}

--- a/crates/adoc-core/src/domain/knowledge_object/glossary.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/glossary.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::domain::ast::ParsedTypedBlock;
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
@@ -26,19 +26,7 @@ impl Glossary {
         parsed: &ParsedTypedBlock,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<Self> {
-        if !parsed.duplicate_keys.is_empty() {
-            let mut emitted_keys = BTreeSet::new();
-            for key in &parsed.duplicate_keys {
-                if emitted_keys.insert(key.as_str()) {
-                    diagnostics.push(
-                        Diagnostic::error(
-                            DiagnosticCode::SchemaDuplicateField,
-                            format!("duplicate field `{key}` in glossary"),
-                        )
-                        .with_span(parsed.span.clone()),
-                    );
-                }
-            }
+        if super::reject_duplicate_fields(parsed, "glossary", diagnostics) {
             return None;
         }
 

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -2,27 +2,32 @@
 
 pub(crate) mod claim;
 pub(crate) mod decision;
+pub(crate) mod glossary;
 pub(crate) mod warning;
 
 use claim::Claim;
 use decision::Decision;
+use glossary::Glossary;
 use warning::Warning;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BlockKind {
     Claim,
     Decision,
+    Glossary,
     Warning,
 }
 
 impl BlockKind {
     #[cfg(test)]
-    pub(crate) const ALL: &'static [Self] = &[Self::Claim, Self::Decision, Self::Warning];
+    pub(crate) const ALL: &'static [Self] =
+        &[Self::Claim, Self::Decision, Self::Glossary, Self::Warning];
 
     pub(crate) const fn as_str(self) -> &'static str {
         match self {
             Self::Claim => "claim",
             Self::Decision => "decision",
+            Self::Glossary => "glossary",
             Self::Warning => "warning",
         }
     }
@@ -32,6 +37,7 @@ impl BlockKind {
 pub(crate) enum KnowledgeObject {
     Claim(Claim),
     Decision(Decision),
+    Glossary(Glossary),
     Warning(Warning),
 }
 
@@ -43,6 +49,7 @@ mod tests {
     fn block_kind_labels_match_source_fence_words() {
         assert_eq!(BlockKind::Claim.as_str(), "claim");
         assert_eq!(BlockKind::Decision.as_str(), "decision");
+        assert_eq!(BlockKind::Glossary.as_str(), "glossary");
         assert_eq!(BlockKind::Warning.as_str(), "warning");
     }
 
@@ -50,7 +57,12 @@ mod tests {
     fn block_kind_all_lists_every_supported_kind() {
         assert_eq!(
             BlockKind::ALL,
-            &[BlockKind::Claim, BlockKind::Decision, BlockKind::Warning]
+            &[
+                BlockKind::Claim,
+                BlockKind::Decision,
+                BlockKind::Glossary,
+                BlockKind::Warning
+            ]
         );
     }
 }

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -1,5 +1,10 @@
 //! Aggregate family — populated by Slice 1.
 
+use std::collections::BTreeSet;
+
+use crate::domain::ast::ParsedTypedBlock;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
+
 pub(crate) mod claim;
 pub(crate) mod decision;
 pub(crate) mod glossary;
@@ -9,6 +14,33 @@ use claim::Claim;
 use decision::Decision;
 use glossary::Glossary;
 use warning::Warning;
+
+pub(super) fn reject_duplicate_fields(
+    parsed: &ParsedTypedBlock,
+    kind_word: &str,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> bool {
+    if parsed.duplicate_keys.is_empty() {
+        return false;
+    }
+
+    let mut emitted_keys = BTreeSet::new();
+    for key in &parsed.duplicate_keys {
+        if emitted_keys.insert(key.as_str()) {
+            diagnostics.push(
+                Diagnostic::error(
+                    DiagnosticCode::SchemaDuplicateField,
+                    format!("duplicate field `{key}` in {kind_word}"),
+                )
+                .with_span(parsed.span.clone()),
+            );
+        }
+    }
+
+    // Duplicate fields poison the raw field map: last-value-wins storage makes
+    // missing-field validation ambiguous until the duplicates are fixed.
+    true
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum BlockKind {

--- a/crates/adoc-core/src/domain/knowledge_object/warning.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/warning.rs
@@ -1,4 +1,4 @@
-use std::collections::{BTreeMap, BTreeSet};
+use std::collections::BTreeMap;
 
 use crate::domain::ast::ParsedTypedBlock;
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
@@ -33,19 +33,7 @@ impl Warning {
         parsed: &ParsedTypedBlock,
         diagnostics: &mut Vec<Diagnostic>,
     ) -> Option<Self> {
-        if !parsed.duplicate_keys.is_empty() {
-            let mut emitted_keys = BTreeSet::new();
-            for key in &parsed.duplicate_keys {
-                if emitted_keys.insert(key.as_str()) {
-                    diagnostics.push(
-                        Diagnostic::error(
-                            DiagnosticCode::SchemaDuplicateField,
-                            format!("duplicate field `{key}` in warning"),
-                        )
-                        .with_span(parsed.span.clone()),
-                    );
-                }
-            }
+        if super::reject_duplicate_fields(parsed, "warning", diagnostics) {
             return None;
         }
 

--- a/crates/adoc-core/src/infrastructure/artifact/agent_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/agent_json.rs
@@ -12,6 +12,7 @@ use crate::domain::knowledge_object::{
         VERIFIED_AT_FIELD,
     },
     decision::{DECIDED_BY_FIELD, Decision},
+    glossary::Glossary,
     warning::Warning,
 };
 use crate::domain::ports::artifact_writer::ArtifactWriter;
@@ -33,6 +34,9 @@ impl ArtifactWriter for AgentJsonArtifact {
                         KnowledgeObject::Decision(decision) => {
                             objects.push(decision_to_agent_object(decision, page.id.as_str()));
                         }
+                        KnowledgeObject::Glossary(glossary) => {
+                            objects.push(glossary_to_agent_object(glossary, page.id.as_str()));
+                        }
                         KnowledgeObject::Warning(warning) => {
                             objects.push(warning_to_agent_object(warning, page.id.as_str()));
                         }
@@ -50,6 +54,28 @@ impl ArtifactWriter for AgentJsonArtifact {
             objects,
             diagnostics: diagnostics.to_vec(),
         }
+    }
+}
+
+fn glossary_to_agent_object(glossary: &Glossary, page_id: &str) -> AgentJsonObject {
+    let span = glossary.span();
+    AgentJsonObject {
+        id: glossary.id().as_str().to_string(),
+        kind: "glossary".to_string(),
+        status: None,
+        body: glossary.body().as_str().to_string(),
+        page_id: page_id.to_string(),
+        source_span: AgentJsonSourceSpan {
+            path: span.file.display().to_string(),
+            line: span.start.line,
+            column: span.start.column,
+        },
+        fields: glossary
+            .fields()
+            .iter()
+            .map(|(key, value)| (key.clone(), value.clone()))
+            .collect(),
+        relations: AgentJsonRelations::default(),
     }
 }
 

--- a/crates/adoc-core/src/infrastructure/artifact/agent_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/agent_json.rs
@@ -58,7 +58,7 @@ fn warning_to_agent_object(warning: &Warning, page_id: &str) -> AgentJsonObject 
     AgentJsonObject {
         id: warning.id().as_str().to_string(),
         kind: "warning".to_string(),
-        status: warning.severity().as_str().to_string(),
+        status: Some(warning.severity().as_str().to_string()),
         body: warning.body().as_str().to_string(),
         page_id: page_id.to_string(),
         source_span: AgentJsonSourceSpan {
@@ -81,7 +81,7 @@ fn decision_to_agent_object(decision: &Decision, page_id: &str) -> AgentJsonObje
     AgentJsonObject {
         id: decision.id().as_str().to_string(),
         kind: "decision".to_string(),
-        status: decision.status().as_str().to_string(),
+        status: Some(decision.status().as_str().to_string()),
         body: decision.body().as_str().to_string(),
         page_id: page_id.to_string(),
         source_span: AgentJsonSourceSpan {
@@ -117,7 +117,7 @@ fn claim_to_agent_object(claim: &Claim, page_id: &str) -> AgentJsonObject {
     AgentJsonObject {
         id: claim.id().as_str().to_string(),
         kind: "claim".to_string(),
-        status: claim.status().as_str().to_string(),
+        status: Some(claim.status().as_str().to_string()),
         body: claim.body().as_str().to_string(),
         page_id: page_id.to_string(),
         source_span: AgentJsonSourceSpan {
@@ -286,7 +286,7 @@ mod tests {
         let obj = &doc.objects[0];
         assert_eq!(obj.id, "billing.credits");
         assert_eq!(obj.kind, "claim");
-        assert_eq!(obj.status, "plain");
+        assert_eq!(obj.status.as_deref(), Some("plain"));
         assert_eq!(obj.body, "The system credits users automatically.");
         assert_eq!(obj.page_id, "team.guide");
         assert!(
@@ -385,7 +385,7 @@ mod tests {
 
         let obj = &doc.objects[0];
         assert_eq!(obj.kind, "decision");
-        assert_eq!(obj.status, "accepted");
+        assert_eq!(obj.status.as_deref(), Some("accepted"));
         assert_eq!(
             obj.fields.get(DECIDED_BY_FIELD).map(String::as_str),
             Some("architecture")
@@ -407,7 +407,7 @@ mod tests {
         let doc = artifact.build(&[page], &[]);
 
         let obj = &doc.objects[0];
-        assert_eq!(obj.status, "proposed");
+        assert_eq!(obj.status.as_deref(), Some("proposed"));
         assert_eq!(
             obj.fields.get(DECIDED_BY_FIELD).map(String::as_str),
             Some("architecture")
@@ -432,7 +432,7 @@ mod tests {
         let obj = &doc.objects[0];
         assert_eq!(obj.id, "auth.session.clock-skew");
         assert_eq!(obj.kind, "warning");
-        assert_eq!(obj.status, "critical");
+        assert_eq!(obj.status.as_deref(), Some("critical"));
         assert_eq!(obj.body, "Session clocks can drift.");
         assert_eq!(obj.page_id, "team.warnings");
         assert_eq!(obj.source_span.path, "sample.adoc");

--- a/crates/adoc-core/src/infrastructure/parser/typed_block.rs
+++ b/crates/adoc-core/src/infrastructure/parser/typed_block.rs
@@ -29,6 +29,10 @@ const SUPPORTED_KINDS: &[SupportedKind] = &[
         kind: BlockKind::Decision,
     },
     SupportedKind {
+        word: BlockKind::Glossary.as_str(),
+        kind: BlockKind::Glossary,
+    },
+    SupportedKind {
         word: BlockKind::Warning.as_str(),
         kind: BlockKind::Warning,
     },
@@ -559,7 +563,7 @@ mod tests {
                 );
                 assert!(
                     d.message
-                        .contains("supported kinds: claim, decision, warning"),
+                        .contains("supported kinds: claim, decision, glossary, warning"),
                     "message should list supported kinds from parser metadata: {}",
                     d.message
                 );

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -4,6 +4,7 @@ use crate::domain::knowledge_object::{
     KnowledgeObject,
     claim::{Claim, Evidence},
     decision::{DECIDED_BY_FIELD, Decision},
+    glossary::Glossary,
     warning::Warning,
 };
 use crate::domain::ports::renderer::Renderer;
@@ -82,6 +83,9 @@ fn render_block(block: &BlockAst, html: &mut String) {
             KnowledgeObject::Decision(decision) => {
                 render_decision(decision, html);
             }
+            KnowledgeObject::Glossary(glossary) => {
+                render_glossary(glossary, html);
+            }
             KnowledgeObject::Warning(warning) => {
                 render_warning(warning, html);
             }
@@ -90,6 +94,41 @@ fn render_block(block: &BlockAst, html: &mut String) {
             unreachable!("resolver must replace pending knowledge objects before rendering")
         }
     }
+}
+
+fn render_glossary(glossary: &Glossary, html: &mut String) {
+    html.push_str("<section class=\"glossary\" id=\"");
+    html.push_str(&escape_html(glossary.id().as_str()));
+    html.push_str("\">\n");
+    html.push_str("<header class=\"glossary__header\">");
+    html.push_str("<span class=\"glossary__kind\">glossary</span>");
+    html.push_str("<code class=\"glossary__id\">");
+    html.push_str(&escape_html(glossary.id().as_str()));
+    html.push_str("</code>");
+    html.push_str("</header>\n");
+    html.push_str("<div class=\"glossary__body\"><p>");
+    html.push_str(&escape_html(glossary.body().as_str()));
+    html.push_str("</p></div>\n");
+    render_glossary_metadata(glossary, html);
+    html.push_str("</section>\n");
+}
+
+fn render_glossary_metadata(glossary: &Glossary, html: &mut String) {
+    if glossary.fields().is_empty() {
+        return;
+    }
+
+    html.push_str("<footer class=\"glossary__metadata\">\n");
+    html.push_str("<dl>\n");
+    for (key, value) in glossary.fields().iter() {
+        html.push_str("<dt>");
+        html.push_str(&escape_html(key));
+        html.push_str("</dt><dd>");
+        html.push_str(&escape_html(value));
+        html.push_str("</dd>\n");
+    }
+    html.push_str("</dl>\n");
+    html.push_str("</footer>\n");
 }
 
 fn render_warning(warning: &Warning, html: &mut String) {
@@ -532,6 +571,18 @@ mod tests {
         BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Warning(warning)))
     }
 
+    fn make_glossary(
+        id: &str,
+        body: &str,
+        fields: std::collections::BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> BlockAst {
+        use crate::domain::knowledge_object::{KnowledgeObject, glossary::Glossary};
+        let glossary =
+            Glossary::try_new(id, body, fields, span).expect("test glossary must be valid");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Glossary(glossary)))
+    }
+
     #[test]
     fn claim_renders_to_section_with_kind_id_status_body() {
         let block = make_claim(
@@ -864,6 +915,58 @@ mod tests {
         assert!(
             html.contains("<dt>note</dt><dd>value &#39;x&#39; &amp; &lt;y&gt;</dd>"),
             "metadata not escaped: {html}"
+        );
+    }
+
+    #[test]
+    fn glossary_renders_definition_and_metadata_footer_only_when_fields_are_present() {
+        let block = make_glossary(
+            "billing.credits",
+            "Credits adjust account balances.",
+            std::collections::BTreeMap::new(),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+
+        assert!(
+            html.contains("<section class=\"glossary\" id=\"billing.credits\">"),
+            "missing glossary section: {html}"
+        );
+        assert!(
+            html.contains("<span class=\"glossary__kind\">glossary</span>"),
+            "missing glossary kind: {html}"
+        );
+        assert!(
+            html.contains("<code class=\"glossary__id\">billing.credits</code>"),
+            "missing glossary id: {html}"
+        );
+        assert!(
+            html.contains(
+                "<div class=\"glossary__body\"><p>Credits adjust account balances.</p></div>"
+            ),
+            "missing glossary body: {html}"
+        );
+        assert!(
+            !html.contains("<footer class=\"glossary__metadata\">"),
+            "unexpected metadata footer: {html}"
+        );
+
+        let block = make_glossary(
+            "billing.credits",
+            "Credits adjust account balances.",
+            std::collections::BTreeMap::from([("status".to_string(), "draft".to_string())]),
+            dummy_span(),
+        );
+        let mut html = String::new();
+        render_block(&block, &mut html);
+        assert!(
+            html.contains("<footer class=\"glossary__metadata\">\n<dl>\n"),
+            "missing metadata footer: {html}"
+        );
+        assert!(
+            html.contains("<dt>status</dt><dd>draft</dd>"),
+            "missing preserved status metadata: {html}"
         );
     }
 }

--- a/crates/adoc-core/src/infrastructure/validate/knowledge_object_unique_ids.rs
+++ b/crates/adoc-core/src/infrastructure/validate/knowledge_object_unique_ids.rs
@@ -105,7 +105,9 @@ mod tests {
     use crate::domain::ast::{BlockAst, PageAst};
     use crate::domain::diagnostic::{SourcePosition, SourceSpan};
     use crate::domain::identity::PageId;
-    use crate::domain::knowledge_object::{claim::Claim, decision::Decision, warning::Warning};
+    use crate::domain::knowledge_object::{
+        claim::Claim, decision::Decision, glossary::Glossary, warning::Warning,
+    };
 
     fn span(file: &str, line: u32, column: u32) -> SourceSpan {
         SourceSpan {
@@ -159,6 +161,17 @@ mod tests {
         )
         .expect("valid warning");
         BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Warning(warning)))
+    }
+
+    fn glossary_block(id: &str, span: SourceSpan) -> BlockAst {
+        let glossary = Glossary::try_new(
+            id,
+            "Credits adjust account balances.",
+            BTreeMap::new(),
+            span,
+        )
+        .expect("valid glossary");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Glossary(glossary)))
     }
 
     fn page(source_path: &str, blocks: Vec<BlockAst>) -> PageAst {
@@ -407,6 +420,69 @@ mod tests {
             "duplicate warning id `auth.session`; previously defined at one.adoc:3:1"
         );
         assert_eq!(diagnostics[0].object_id.as_deref(), Some("auth.session"));
+    }
+
+    #[test]
+    fn emits_one_diagnostic_for_duplicate_glossary_id() {
+        let workspace = WorkspaceAst {
+            pages: vec![
+                page(
+                    "one.adoc",
+                    vec![glossary_block("billing.credits", span("one.adoc", 3, 1))],
+                ),
+                page(
+                    "two.adoc",
+                    vec![glossary_block("billing.credits", span("two.adoc", 5, 1))],
+                ),
+            ],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdDuplicate);
+        assert_eq!(
+            diagnostics[0].message,
+            "duplicate glossary id `billing.credits`; previously defined at one.adoc:3:1"
+        );
+        assert_eq!(diagnostics[0].object_id.as_deref(), Some("billing.credits"));
+        assert_eq!(
+            diagnostics[0]
+                .span
+                .as_ref()
+                .map(|span| (span.start.line, span.start.column)),
+            Some((5, 1))
+        );
+    }
+
+    #[test]
+    fn emits_one_diagnostic_for_glossary_id_matching_existing_claim_id() {
+        let workspace = WorkspaceAst {
+            pages: vec![page(
+                "one.adoc",
+                vec![
+                    claim_block("billing.shared", span("one.adoc", 3, 1)),
+                    glossary_block("billing.shared", span("one.adoc", 9, 1)),
+                ],
+            )],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IdDuplicate);
+        assert_eq!(
+            diagnostics[0].message,
+            "duplicate knowledge object id `billing.shared`; previously defined as claim at one.adoc:3:1"
+        );
+        assert_eq!(diagnostics[0].object_id.as_deref(), Some("billing.shared"));
+        assert_eq!(
+            diagnostics[0]
+                .span
+                .as_ref()
+                .map(|span| (span.start.line, span.start.column)),
+            Some((9, 1))
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/infrastructure/validate/knowledge_object_unique_ids.rs
+++ b/crates/adoc-core/src/infrastructure/validate/knowledge_object_unique_ids.rs
@@ -65,6 +65,11 @@ fn knowledge_object_identity(knowledge_object: &KnowledgeObject) -> KnowledgeObj
             id: decision.id(),
             span: decision.span(),
         },
+        KnowledgeObject::Glossary(glossary) => KnowledgeObjectIdentity {
+            kind: BlockKind::Glossary,
+            id: glossary.id(),
+            span: glossary.span(),
+        },
         KnowledgeObject::Warning(warning) => KnowledgeObjectIdentity {
             kind: BlockKind::Warning,
             id: warning.id(),

--- a/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
+++ b/crates/adoc-core/src/infrastructure/validate/resolve_knowledge_objects.rs
@@ -9,7 +9,8 @@
 use crate::domain::ast::{BlockAst, PageAst};
 use crate::domain::diagnostic::Diagnostic;
 use crate::domain::knowledge_object::{
-    BlockKind, KnowledgeObject, claim::Claim, decision::Decision, warning::Warning,
+    BlockKind, KnowledgeObject, claim::Claim, decision::Decision, glossary::Glossary,
+    warning::Warning,
 };
 use crate::domain::source::SourceFile;
 
@@ -44,6 +45,14 @@ fn resolve_page(page: &mut PageAst, diagnostics: &mut Vec<Diagnostic>) {
                         if let Some(decision) = Decision::build_from_parsed(&parsed, diagnostics) {
                             new_blocks.push(BlockAst::KnowledgeObject(Box::new(
                                 KnowledgeObject::Decision(decision),
+                            )));
+                        }
+                        // failure → block dropped; diagnostics already emitted above
+                    }
+                    BlockKind::Glossary => {
+                        if let Some(glossary) = Glossary::build_from_parsed(&parsed, diagnostics) {
+                            new_blocks.push(BlockAst::KnowledgeObject(Box::new(
+                                KnowledgeObject::Glossary(glossary),
                             )));
                         }
                         // failure → block dropped; diagnostics already emitted above
@@ -148,6 +157,18 @@ mod tests {
         ParsedTypedBlock {
             kind: BlockKind::Warning,
             id_text: "auth.session.clock-skew".to_string(),
+            raw_fields: fields,
+            duplicate_keys: Vec::new(),
+            body_text: body_text.to_string(),
+            content_spans: Vec::new(),
+            span: span(),
+        }
+    }
+
+    fn glossary_pending(fields: BTreeMap<String, String>, body_text: &str) -> ParsedTypedBlock {
+        ParsedTypedBlock {
+            kind: BlockKind::Glossary,
+            id_text: "billing.credits".to_string(),
             raw_fields: fields,
             duplicate_keys: Vec::new(),
             body_text: body_text.to_string(),
@@ -649,5 +670,55 @@ mod tests {
             Some("auth.session.clock-skew")
         );
         assert!(pairs[0].1.blocks.is_empty());
+    }
+
+    #[test]
+    fn resolves_glossary_and_preserves_status_as_metadata() {
+        let pending = glossary_pending(
+            BTreeMap::from([
+                ("status".to_string(), "draft".to_string()),
+                ("owner".to_string(), "team-billing".to_string()),
+            ]),
+            "Credits adjust account balances.",
+        );
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert!(diagnostics.is_empty());
+        let BlockAst::KnowledgeObject(ko) = &pairs[0].1.blocks[0] else {
+            panic!("expected KnowledgeObject");
+        };
+        let KnowledgeObject::Glossary(glossary) = ko.as_ref() else {
+            panic!("expected glossary");
+        };
+        let fields: Vec<(&str, &str)> = glossary
+            .fields()
+            .iter()
+            .map(|(key, value)| (key.as_str(), value.as_str()))
+            .collect();
+        assert_eq!(fields, vec![("owner", "team-billing"), ("status", "draft")]);
+    }
+
+    #[test]
+    fn emits_duplicate_field_for_glossary_and_drops_block() {
+        let mut pending = glossary_pending(
+            BTreeMap::from([("status".to_string(), "reviewed".to_string())]),
+            "Credits adjust account balances.",
+        );
+        pending.duplicate_keys = vec!["status".to_string()];
+        let page = page_with_pending(pending);
+        let mut pairs = vec![(source(), page)];
+
+        let diagnostics = resolve_knowledge_objects(&mut pairs);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaDuplicateField);
+        assert!(diagnostics[0].message.contains("glossary"));
+        assert!(
+            pairs[0].1.blocks.is_empty(),
+            "block must be dropped on duplicate field"
+        );
     }
 }

--- a/crates/adoc-core/tests/compile_workspace.rs
+++ b/crates/adoc-core/tests/compile_workspace.rs
@@ -286,6 +286,224 @@ fn compile_workspace_resolves_warning_into_artifacts() {
 }
 
 #[test]
+fn compile_workspace_resolves_glossary_into_artifacts() {
+    let workspace = TestWorkspace::new("resolve-glossary-into-artifacts");
+    let source = workspace.write(
+        "glossary.adoc",
+        concat!(
+            "# Glossary @doc(team.glossary)\n",
+            "\n",
+            "::glossary billing.credits\n",
+            "status: draft\n",
+            "owner: team-billing\n",
+            "--\n",
+            "Credits are balance adjustments applied to an account.\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(
+        !result.has_errors(),
+        "expected glossary to compile, got: {:?}",
+        result.diagnostics
+    );
+    let artifacts = result.artifacts.expect("artifacts must be produced");
+    let record = artifacts
+        .agent_json
+        .objects
+        .first()
+        .expect("glossary object must be emitted");
+    assert_eq!(record.id, "billing.credits");
+    assert_eq!(record.kind, "glossary");
+    assert_eq!(record.status, None);
+    assert_eq!(
+        record.body,
+        "Credits are balance adjustments applied to an account."
+    );
+    assert_eq!(record.page_id, "team.glossary");
+    assert_eq!(
+        record.fields.get("status").map(String::as_str),
+        Some("draft")
+    );
+    assert_eq!(
+        record.fields.get("owner").map(String::as_str),
+        Some("team-billing")
+    );
+    assert!(record.relations.depends_on.is_empty());
+    assert!(record.relations.supersedes.is_empty());
+    assert!(record.relations.related_to.is_empty());
+    assert_eq!(record.source_span.line, 3);
+    assert_eq!(record.source_span.column, 1);
+    assert!(
+        artifacts
+            .html
+            .contains("<section class=\"glossary\" id=\"billing.credits\">"),
+        "glossary section missing: {}",
+        artifacts.html
+    );
+    assert!(
+        artifacts
+            .html
+            .contains("<span class=\"glossary__kind\">glossary</span>"),
+        "glossary kind missing: {}",
+        artifacts.html
+    );
+    assert!(
+        artifacts
+            .html
+            .contains("<code class=\"glossary__id\">billing.credits</code>"),
+        "glossary id missing: {}",
+        artifacts.html
+    );
+    assert!(
+        artifacts
+            .html
+            .contains("<footer class=\"glossary__metadata\">"),
+        "glossary metadata footer missing: {}",
+        artifacts.html
+    );
+}
+
+#[test]
+fn compile_workspace_rejects_glossary_invalid_id() {
+    let workspace = TestWorkspace::new("glossary-invalid-id");
+    let source = workspace.write(
+        "glossary.adoc",
+        concat!(
+            "# Glossary @doc(team.glossary)\n",
+            "\n",
+            "::glossary BillingCredits\n",
+            "--\n",
+            "Credits are balance adjustments applied to an account.\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(result.has_errors(), "invalid glossary id must fail");
+    assert!(result.artifacts.is_none(), "errors must block artifacts");
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == DiagnosticCode::IdInvalid)
+        .expect("id.invalid diagnostic must be emitted");
+    assert_eq!(diagnostic.object_id.as_deref(), Some("BillingCredits"));
+    assert!(
+        diagnostic
+            .message
+            .contains("invalid glossary id `BillingCredits`"),
+        "diagnostic should name rejected glossary id: {:?}",
+        diagnostic
+    );
+    assert!(
+        diagnostic
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("Object IDs must")),
+        "diagnostic should carry object id grammar help: {:?}",
+        diagnostic
+    );
+    assert_eq!(
+        diagnostic
+            .span
+            .as_ref()
+            .map(|span| (span.start.line, span.start.column)),
+        Some((3, 1))
+    );
+}
+
+#[test]
+fn compile_workspace_rejects_glossary_missing_body() {
+    let workspace = TestWorkspace::new("glossary-missing-body");
+    let source = workspace.write(
+        "glossary.adoc",
+        concat!(
+            "# Glossary @doc(team.glossary)\n",
+            "\n",
+            "::glossary billing.credits\n",
+            "status: draft\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(result.has_errors(), "missing glossary body must fail");
+    assert!(result.artifacts.is_none(), "errors must block artifacts");
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == DiagnosticCode::SchemaMissingField)
+        .expect("schema.missing_field diagnostic must be emitted");
+    assert_eq!(diagnostic.object_id.as_deref(), Some("billing.credits"));
+    assert!(
+        diagnostic.message.contains("body"),
+        "diagnostic should mention body: {:?}",
+        diagnostic
+    );
+    assert!(
+        diagnostic
+            .help
+            .as_deref()
+            .is_some_and(|help| help.contains("non-empty body")),
+        "diagnostic should include fix-oriented help: {:?}",
+        diagnostic
+    );
+    assert_eq!(
+        diagnostic
+            .span
+            .as_ref()
+            .map(|span| (span.start.line, span.start.column)),
+        Some((3, 1))
+    );
+}
+
+#[test]
+fn compile_workspace_rejects_glossary_duplicate_field_key_and_drops_block() {
+    let workspace = TestWorkspace::new("glossary-duplicate-field");
+    let source = workspace.write(
+        "glossary.adoc",
+        concat!(
+            "# Glossary @doc(team.glossary)\n",
+            "\n",
+            "::glossary billing.credits\n",
+            "status: draft\n",
+            "status: reviewed\n",
+            "--\n",
+            "Credits are balance adjustments applied to an account.\n",
+            "::\n",
+        ),
+    );
+
+    let result = compile_workspace(CompileInput { root: source });
+
+    assert!(result.has_errors(), "duplicate glossary field must fail");
+    assert!(result.artifacts.is_none(), "errors must block artifacts");
+    let diagnostic = result
+        .diagnostics
+        .iter()
+        .find(|diagnostic| diagnostic.code == DiagnosticCode::SchemaDuplicateField)
+        .expect("schema.duplicate_field diagnostic must be emitted");
+    assert!(
+        diagnostic
+            .message
+            .contains("duplicate field `status` in glossary"),
+        "diagnostic should name duplicate glossary field: {:?}",
+        diagnostic
+    );
+    assert_eq!(
+        diagnostic
+            .span
+            .as_ref()
+            .map(|span| (span.start.line, span.start.column)),
+        Some((3, 1))
+    );
+}
+
+#[test]
 fn compile_workspace_rejects_warning_missing_severity() {
     let workspace = TestWorkspace::new("warning-missing-severity");
     let source = workspace.write(

--- a/crates/adoc-core/tests/compile_workspace.rs
+++ b/crates/adoc-core/tests/compile_workspace.rs
@@ -132,7 +132,7 @@ fn compile_workspace_resolves_claim_into_artifact_record() {
     let record: &AgentJsonObject = &artifacts.agent_json.objects[0];
     assert_eq!(record.id, "billing.credits");
     assert_eq!(record.kind, "claim");
-    assert_eq!(record.status, "draft");
+    assert_eq!(record.status.as_deref(), Some("draft"));
     assert_eq!(
         record.body,
         "The system credits users automatically when a payment fails."
@@ -189,7 +189,7 @@ fn compile_workspace_resolves_clean_decision_into_artifacts() {
         .expect("decision object must be emitted");
     assert_eq!(record.id, "billing.policy");
     assert_eq!(record.kind, "decision");
-    assert_eq!(record.status, "proposed");
+    assert_eq!(record.status.as_deref(), Some("proposed"));
     assert_eq!(record.body, "Use the existing billing policy.");
     assert_eq!(record.page_id, "team.decisions");
     assert!(record.fields.is_empty());
@@ -246,7 +246,7 @@ fn compile_workspace_resolves_warning_into_artifacts() {
         .expect("warning object must be emitted");
     assert_eq!(record.id, "auth.session.clock-skew");
     assert_eq!(record.kind, "warning");
-    assert_eq!(record.status, "high");
+    assert_eq!(record.status.as_deref(), Some("high"));
     assert_eq!(
         record.body,
         "Session clocks can drift enough to reject otherwise valid tokens."
@@ -680,7 +680,7 @@ fn compile_workspace_emits_accepted_decision_with_verdict() {
         .first()
         .expect("decision object must be emitted");
     assert_eq!(record.kind, "decision");
-    assert_eq!(record.status, "accepted");
+    assert_eq!(record.status.as_deref(), Some("accepted"));
     assert_eq!(
         record.fields.get("decided_by").map(String::as_str),
         Some("architecture")
@@ -742,7 +742,7 @@ fn compile_workspace_builds_verified_claim_with_all_v0_evidence() {
         .objects
         .first()
         .expect("claim object must be emitted");
-    assert_eq!(record.status, "verified");
+    assert_eq!(record.status.as_deref(), Some("verified"));
     assert_eq!(
         record.fields.get("owner").map(String::as_str),
         Some("team-billing")
@@ -863,7 +863,10 @@ fn compile_workspace_warns_and_treats_status_casing_variant_as_plain() {
         Some("billing.credits")
     );
     let artifacts = result.artifacts.expect("warnings must not block artifacts");
-    assert_eq!(artifacts.agent_json.objects[0].status, "Verified");
+    assert_eq!(
+        artifacts.agent_json.objects[0].status.as_deref(),
+        Some("Verified")
+    );
     assert!(
         !artifacts.html.contains("claim--verified"),
         "casing variant must not render as verified: {}",

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -34,7 +34,7 @@ fn public_surface_compiles_with_only_documented_imports() {
     let _: AgentJsonObject = AgentJsonObject {
         id: String::new(),
         kind: String::new(),
-        status: String::new(),
+        status: Some(String::new()),
         body: String::new(),
         page_id: String::new(),
         source_span: AgentJsonSourceSpan {

--- a/docs/V0-DESIGN.md
+++ b/docs/V0-DESIGN.md
@@ -412,6 +412,8 @@ Rules:
   current object set, this means claim status, decision status, and warning
   severity. V0 keeps these values in one slot rather than adding per-kind
   top-level discriminant fields.
+- Addendum: object kinds without a kind-primary normalized discriminant omit
+  `status` from Agent JSON rather than emitting `null` or an empty string.
 - Relations are ID arrays, not embedded objects.
 - Diagnostics are included using the same codes and messages as CLI diagnostics.
 - Schema versioning starts immediately, even if the shape is still pre-1.0.

--- a/docs/V0-DESIGN.md
+++ b/docs/V0-DESIGN.md
@@ -414,6 +414,8 @@ Rules:
   top-level discriminant fields.
 - Addendum: object kinds without a kind-primary normalized discriminant omit
   `status` from Agent JSON rather than emitting `null` or an empty string.
+  For glossary, an author-supplied `status` field remains ordinary optional
+  metadata under `fields.status`; it is not promoted to top-level `status`.
 - Relations are ID arrays, not embedded objects.
 - Diagnostics are included using the same codes and messages as CLI diagnostics.
 - Schema versioning starts immediately, even if the shape is still pre-1.0.


### PR DESCRIPTION
## Summary

Closes the V0.4 milestone by landing the `glossary` knowledge object as a complete vertical slice and proving the four core kinds (`claim`, `decision`, `warning`, `glossary`) cohabit in a single workspace.

The work is staged as three reviewable commits:

1. **`refactor(core): allow optional agent json status`** — `AgentJsonObject.status` becomes `Option<String>` with `skip_serializing_if`, so kindless objects emit honest serialized forms. Existing kinds wrap their discriminant in `Some(...)`; existing golden artifacts remain byte-identical. `docs/V0-DESIGN.md` gains an addendum documenting the omit-when-absent semantics.
2. **`feat(core): add glossary knowledge object`** — `Glossary` aggregate, parser kind, resolver dispatch, HTML render (distinct `<section class="glossary">`), agent JSON dispatch, and unique-id participation. Diagnostics: `id.invalid` with shared object-id grammar help; `schema.missing_field` for missing/empty body. CLI fixtures (`glossary_basic.adoc`, `glossary_missing_body.adoc`) plus golden HTML and agent JSON. Unit + integration coverage exercises construction, id rejection, missing body, optional-field pass-through, and duplicate-key gating.
3. **`test(cli): cover combined core object set`** — single multi-kind fixture exercising claim + decision + warning + glossary side by side, with golden HTML and agent JSON proving distinct rendering and correct `status` serialization (present for the first three kinds, omitted for glossary). No new per-kind code branches introduced.

## Cohesion guardrail

Per #50's acceptance criteria, kind-aware code remains confined to: `domain/knowledge_object/`, parser `SUPPORTED_KINDS`, resolver dispatch, render dispatch, agent JSON dispatch, and the `KnowledgeObject` exhaustive match in `knowledge_object_identity` for unique-id detection.

## Validation

CI pipeline run locally before push:
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked` — all suites pass (unit, integration, diagnostic fixtures, CLI snapshots, public surface)
- `cargo build --workspace --locked`
- `RUSTDOCFLAGS=-D warnings cargo doc --workspace --no-deps --locked`

## Issues closed

- Closes #9 (parent: V0.4 — Compile glossary objects end to end)
- Closes #50 (Land glossary knowledge object end to end)
- Closes #51 (Combined Core Object Set fixture)

## Test plan

- [x] Glossary parses with fields, body, source file, source span
- [x] Empty/missing glossary body produces `schema.missing_field` with object id
- [x] Invalid glossary ids produce `id.invalid` with shared grammar help
- [x] Duplicate field keys on a glossary block emit `schema.duplicate_field` and drop the block
- [x] Glossary HTML renders distinctly with kind label, code-formatted id, definition body, optional metadata footer
- [x] Glossary appears in `docs.agent.json` with `kind="glossary"`, no serialized `status`, body present, optional fields preserved verbatim
- [x] Workspace duplicate-id detection covers glossary
- [x] Combined fixture: `adoc check` clean, `adoc build` produces golden HTML + agent JSON proving cohabitation
- [x] Existing claim/decision/warning golden artifacts byte-identical after `status` becomes optional