### PR TITLE
feat: embedding build pipeline emits dist/docs.search.json (V1.3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target/
 examples/*/dist/
+.fastembed_cache/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,6 +19,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
 ]
 
@@ -85,6 +86,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -148,6 +158,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -180,6 +219,16 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -396,6 +445,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -452,6 +512,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +534,12 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wasip2"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "adoc-cli"
 version = "0.1.0"
 dependencies = [
@@ -10,18 +16,66 @@ dependencies = [
  "clap",
  "insta",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "adoc-core"
 version = "0.1.0"
 dependencies = [
+ "fastembed",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
 ]
+
+[[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
+name = "aho-corasick"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "aligned"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee4508988c62edf04abd8d92897fca0c2995d907ce1dfeaf369dac3716a40685"
+dependencies = [
+ "as-slice",
+]
+
+[[package]]
+name = "aligned-vec"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc890384c8602f339876ded803c97ad529f3842aba97f6392b3dba0dd171769b"
+dependencies = [
+ "equator",
+]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "anstream"
@@ -59,7 +113,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -70,7 +124,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -80,10 +134,130 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+
+[[package]]
+name = "arg_enum_proc_macro"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ae92a5119aa49cdbcf6b9f893fe4e1d98b04ccbf82ee0584ad948a44a734dea"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
+name = "as-slice"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "516b6b4f0e40d50dcda9365d53964ec74560ad4284da2e7fc97122cd83174516"
+dependencies = [
+ "stable_deref_trait",
+]
+
+[[package]]
+name = "atomic-waker"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "av-scenechange"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f321d77c20e19b92c39e7471cf986812cbb46659d2af674adc4331ef3f18394"
+dependencies = [
+ "aligned",
+ "anyhow",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "log",
+ "num-rational",
+ "num-traits",
+ "pastey",
+ "rayon",
+ "thiserror 2.0.18",
+ "v_frame",
+ "y4m",
+]
+
+[[package]]
+name = "av1-grain"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8cfddb07216410377231960af4fcab838eaa12e013417781b78bd95ee22077f8"
+dependencies = [
+ "anyhow",
+ "arrayvec",
+ "log",
+ "nom 8.0.0",
+ "num-rational",
+ "v_frame",
+]
+
+[[package]]
+name = "avif-serialize"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7178fe5f7d460b13895ebb9dcb28a3a6216d2df2574a0806cb51b555d297f38"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
+name = "base64"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
+
+[[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
+name = "bit_field"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "bitstream-io"
+version = "4.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7eff00be299a18769011411c9def0d827e8f2d7bf0c3dbf53633147a8867fd1f"
+dependencies = [
+ "no_std_io2",
+]
 
 [[package]]
 name = "block-buffer"
@@ -92,6 +266,63 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
+]
+
+[[package]]
+name = "built"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4ad8f11f288f48ca24471bbd51ac257aaeaaa07adae295591266b792902ae64"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
+name = "byteorder-lite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f1fe948ff07f4bd06c30984e69f5b4899c516a3ef74f34df92a2df2ab535495"
+
+[[package]]
+name = "bytes"
+version = "1.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+
+[[package]]
+name = "castaway"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dec551ab6e7578819132c713a93c022a05d60159dc86e7a7050223577484c55a"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "cc"
+version = "1.2.61"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+dependencies = [
+ "find-msvc-tools",
+ "jobserver",
+ "libc",
+ "shlex",
 ]
 
 [[package]]
@@ -141,10 +372,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "color_quant"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d7b894f5411737b7867f4827955924d7c254fc9f4d91a6aad6b097804b1018b"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "compact_str"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+dependencies = [
+ "castaway",
+ "cfg-if",
+ "itoa",
+ "rustversion",
+ "ryu",
+ "serde",
+ "static_assertions",
+]
 
 [[package]]
 name = "console"
@@ -154,8 +406,64 @@ checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
 dependencies = [
  "encode_unicode",
  "libc",
- "windows-sys",
+ "unicode-width",
+ "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -167,6 +475,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crossbeam-deque"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "crypto-common"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -174,6 +522,100 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "darling"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.20.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "dary_heap"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b1e3a325bc115f096c8b77bbf027a7c2592230e70be2d985be950d3d5e60ebe"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "der"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fd89660b2dc699704064e59e9dba0147b903e85319429e131620d022be411b"
+dependencies = [
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "derive_builder"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
+dependencies = [
+ "derive_builder_macro",
+]
+
+[[package]]
+name = "derive_builder_core"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "derive_builder_macro"
+version = "0.20.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
+dependencies = [
+ "derive_builder_core",
+ "syn",
 ]
 
 [[package]]
@@ -187,10 +629,86 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
+]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
 name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "equator"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4711b213838dfee0117e3be6ac926007d7f433d7bbe33595975d4190cb07e6fc"
+dependencies = [
+ "equator-macro",
+]
+
+[[package]]
+name = "equator-macro"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44f23cf4b44bfce11a86ace86f8a73ffdec849c9fd00a386a53d278bd9e81fb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "equivalent"
@@ -205,7 +723,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "esaxx-rs"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d817e038c30374a4bcb22f94d0a8a0e216958d4c3dcde369b1439fec4bdda6e6"
+
+[[package]]
+name = "exr"
+version = "1.74.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4300e043a56aa2cb633c01af81ca8f699a321879a7854d3896a0ba89056363be"
+dependencies = [
+ "bit_field",
+ "half",
+ "lebe",
+ "miniz_oxide",
+ "rayon-core",
+ "smallvec",
+ "zune-inflate",
+]
+
+[[package]]
+name = "fastembed"
+version = "5.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0112bd54a5d1903b19c85609c282949523bb8bb39f1614d4db0017e0ef3b0ff"
+dependencies = [
+ "anyhow",
+ "hf-hub",
+ "image",
+ "ndarray",
+ "ort",
+ "safetensors",
+ "serde",
+ "serde_json",
+ "tokenizers",
 ]
 
 [[package]]
@@ -215,10 +771,137 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
+
+[[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
+name = "form_urlencoded"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+dependencies = [
+ "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-macro"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "slab",
+]
 
 [[package]]
 name = "generic-array"
@@ -232,15 +915,78 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+]
+
+[[package]]
+name = "getrandom"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "gif"
+version = "0.14.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee8cfcc411d9adbbaba82fb72661cc1bcca13e8bba98b364e62b2dba8f960159"
+dependencies = [
+ "color_quant",
+ "weezl",
+]
+
+[[package]]
+name = "h2"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
 ]
 
 [[package]]
@@ -249,7 +995,20 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -265,10 +1024,302 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hf-hub"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef3982638978efa195ff11b305f51f1f22f4f0a6cabee7af79b383ebee6a213"
+dependencies = [
+ "dirs",
+ "http",
+ "indicatif",
+ "libc",
+ "log",
+ "native-tls",
+ "rand",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "ureq",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "hmac-sha256"
+version = "1.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec9d92d097f4749b64e8cc33d924d9f40a2d4eb91402b458014b781f5733d60f"
+
+[[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
+dependencies = [
+ "bytes",
+ "http",
+]
+
+[[package]]
+name = "http-body-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "hyper"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "itoa",
+ "pin-project-lite",
+ "smallvec",
+ "tokio",
+ "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
+name = "hyper-util"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "http",
+ "http-body",
+ "hyper",
+ "ipnet",
+ "libc",
+ "percent-encoding",
+ "pin-project-lite",
+ "socket2",
+ "system-configuration",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "windows-registry",
+]
+
+[[package]]
+name = "icu_collections"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+dependencies = [
+ "displaydoc",
+ "potential_utf",
+ "utf8_iter",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locale_core"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+dependencies = [
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+
+[[package]]
+name = "icu_properties"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+dependencies = [
+ "icu_collections",
+ "icu_locale_core",
+ "icu_properties_data",
+ "icu_provider",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+
+[[package]]
+name = "icu_provider"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+dependencies = [
+ "displaydoc",
+ "icu_locale_core",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerotrie",
+ "zerovec",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
+name = "idna"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+dependencies = [
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
+]
+
+[[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "color_quant",
+ "exr",
+ "gif",
+ "image-webp",
+ "moxcms",
+ "num-traits",
+ "png",
+ "qoi",
+ "ravif",
+ "rayon",
+ "rgb",
+ "tiff",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "image-webp"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
+dependencies = [
+ "byteorder-lite",
+ "quick-error",
+]
+
+[[package]]
+name = "imgref"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40fac9d56ed6437b198fddba683305e8e2d651aa42647f00f5ae542e7f5c94a2"
 
 [[package]]
 name = "indexmap"
@@ -280,6 +1331,19 @@ dependencies = [
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "indicatif"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
+dependencies = [
+ "console",
+ "portable-atomic",
+ "unicode-width",
+ "unit-prefix",
+ "web-time",
 ]
 
 [[package]]
@@ -295,10 +1359,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "interpolate_name"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c34819042dc3d3971c46c2190835914dfbe0c3c13f61449b2997f4e9722dfa60"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+
+[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -307,10 +1397,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
+name = "js-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "once_cell",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "lebe"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a79a3332a6609480d7d0c9eab957bca6b455b91bb84e66d19f5ff66294b85b8"
 
 [[package]]
 name = "libc"
@@ -319,10 +1437,41 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
+name = "libfuzzer-sys"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f12a681b7dd8ce12bff52488013ba614b869148d54dd79836ab85aafdd53f08d"
+dependencies = [
+ "arbitrary",
+ "cc",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
+name = "litemap"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "log"
@@ -331,10 +1480,263 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "loop9"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fae87c125b03c1d2c0150c90365d7d6bcc53fb73a9acaef207d2d065860f062"
+dependencies = [
+ "imgref",
+]
+
+[[package]]
+name = "lzma-rust2"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1670343e58806300d87950e3401e820b519b9384281bbabfb15e3636689ffd69"
+
+[[package]]
+name = "macro_rules_attribute"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65049d7923698040cd0b1ddcced9b0eb14dd22c5f86ae59c3740eab64a676520"
+dependencies = [
+ "macro_rules_attribute-proc_macro",
+ "paste",
+]
+
+[[package]]
+name = "macro_rules_attribute-proc_macro"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
+
+[[package]]
+name = "matrixmultiply"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a06de3016e9fae57a36fd14dba131fccf49f74b40b7fbdb472f96e361ec71a08"
+dependencies = [
+ "autocfg",
+ "rawpointer",
+]
+
+[[package]]
+name = "maybe-rayon"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ea1f30cedd69f0a2954655f7188c6a834246d2bcf1e315e2ac40c4b24dc9519"
+dependencies = [
+ "cfg-if",
+ "rayon",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
+name = "mio"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+dependencies = [
+ "libc",
+ "wasi",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "monostate"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3341a273f6c9d5bef1908f17b7267bbab0e95c9bf69a0d4dcf8e9e1b2c76ef67"
+dependencies = [
+ "monostate-impl",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "monostate-impl"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4db6d5580af57bf992f59068d4ea26fd518574ff48d7639b255a36f9de6e7e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ndarray"
+version = "0.17.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
+dependencies = [
+ "matrixmultiply",
+ "num-complex",
+ "num-integer",
+ "num-traits",
+ "portable-atomic",
+ "portable-atomic-util",
+ "rawpointer",
+]
+
+[[package]]
+name = "new_debug_unreachable"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
+
+[[package]]
+name = "no_std_io2"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "418abd1b6d34fbf6cae440dc874771b0525a604428704c76e48b29a5e67b8003"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
+name = "nom"
+version = "8.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df9761775871bdef83bee530e60050f7e54b1105350d6884eb0fb4f46c2f9405"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "noop_proc_macro"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0676bb32a98c1a483ce53e500a81ad9c3d5b3f7c920c28c24e9cb0980d0b5bc8"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5e44f723f1133c9deac646763579fdb3ac745e418f2a7af9cd0c431da1f20b9"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -347,6 +1749,192 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "onig"
+version = "6.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
+dependencies = [
+ "bitflags",
+ "libc",
+ "once_cell",
+ "onig_sys",
+]
+
+[[package]]
+name = "onig_sys"
+version = "69.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "openssl"
+version = "0.10.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "foreign-types",
+ "libc",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.115"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ort"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7de3af33d24a745ffb8fab904b13478438d1cd52868e6f17735ef6e1f8bf133"
+dependencies = [
+ "ndarray",
+ "ort-sys",
+ "smallvec",
+ "tracing",
+ "ureq",
+]
+
+[[package]]
+name = "ort-sys"
+version = "2.0.0-rc.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7b497d21a8b6fbb4b5a544f8fadb77e801a09ae0add9e411d31c6f89e3c1e90"
+dependencies = [
+ "hmac-sha256",
+ "lzma-rust2",
+ "ureq",
+]
+
+[[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
+
+[[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
+name = "potential_utf"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+dependencies = [
+ "zerovec",
+]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
+]
 
 [[package]]
 name = "prettyplease"
@@ -368,6 +1956,46 @@ dependencies = [
 ]
 
 [[package]]
+name = "profiling"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d595e54a326bc53c1c197b32d295e14b169e3cfeaa8dc82b529f947fba6bcf5"
+dependencies = [
+ "profiling-procmacros",
+]
+
+[[package]]
+name = "profiling-procmacros"
+version = "1.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4488a4a36b9a4ba6b9334a32a39971f77c1436ec82c38707bce707699cc3bbcb"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "qoi"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f6d64c71eb498fe9eae14ce4ec935c555749aef511cca85b5568910d6e48001"
+dependencies = [
+ "bytemuck",
+]
+
+[[package]]
+name = "quick-error"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -378,9 +2006,234 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
+]
+
+[[package]]
+name = "rav1e"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43b6dd56e85d9483277cde964fd1bdb0428de4fec5ebba7540995639a21cb32b"
+dependencies = [
+ "aligned-vec",
+ "arbitrary",
+ "arg_enum_proc_macro",
+ "arrayvec",
+ "av-scenechange",
+ "av1-grain",
+ "bitstream-io",
+ "built",
+ "cfg-if",
+ "interpolate_name",
+ "itertools",
+ "libc",
+ "libfuzzer-sys",
+ "log",
+ "maybe-rayon",
+ "new_debug_unreachable",
+ "noop_proc_macro",
+ "num-derive",
+ "num-traits",
+ "paste",
+ "profiling",
+ "rand",
+ "rand_chacha",
+ "simd_helpers",
+ "thiserror 2.0.18",
+ "v_frame",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "ravif"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e52310197d971b0f5be7fe6b57530dcd27beb35c1b013f29d66c1ad73fbbcc45"
+dependencies = [
+ "avif-serialize",
+ "imgref",
+ "loop9",
+ "quick-error",
+ "rav1e",
+ "rayon",
+ "rgb",
+]
+
+[[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-cond"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
+dependencies = [
+ "either",
+ "itertools",
+ "rayon",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "regex"
+version = "1.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+dependencies = [
+ "aho-corasick",
+ "memchr",
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-tls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams",
+ "web-sys",
+]
+
+[[package]]
+name = "rgb"
+version = "0.8.53"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b34b781b31e5d73e9fbc8689c70551fd1ade9a19e3e28cfec8580a79290cc4"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
 
 [[package]]
 name = "rustix"
@@ -392,7 +2245,97 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.10.1",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -445,6 +2388,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,16 +2411,100 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "simd_helpers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95890f873bec569a0362c235787f3aca6e1e887302ba4840839bcc6459c42da6"
+dependencies = [
+ "quote",
+]
+
+[[package]]
 name = "similar"
 version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "socket2"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "socks"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0c3dbbd9ae980613c6dd8e28a9407b50509d3803b57624d5dfe8315218cd58b"
+dependencies = [
+ "byteorder",
+ "libc",
+ "winapi",
+]
+
+[[package]]
+name = "spm_precompiled"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5851699c4033c63636f7ea4cf7b7c1f1bf06d0cc03cfb42e711de5a5c46cf326"
+dependencies = [
+ "base64 0.13.1",
+ "nom 7.1.3",
+ "serde",
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -479,16 +2518,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "sync_wrapper"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "synstructure"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
 name = "tempfile"
 version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -497,7 +2577,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+dependencies = [
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -512,6 +2601,222 @@ dependencies = [
 ]
 
 [[package]]
+name = "thiserror-impl"
+version = "2.0.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "itoa",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+ "time-macros",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
+
+[[package]]
+name = "tinystr"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
+name = "tokenizers"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
+dependencies = [
+ "ahash",
+ "aho-corasick",
+ "compact_str",
+ "dary_heap",
+ "derive_builder",
+ "esaxx-rs",
+ "getrandom 0.3.4",
+ "itertools",
+ "log",
+ "macro_rules_attribute",
+ "monostate",
+ "onig",
+ "paste",
+ "rand",
+ "rayon",
+ "rayon-cond",
+ "regex",
+ "regex-syntax",
+ "serde",
+ "serde_json",
+ "spm_precompiled",
+ "thiserror 2.0.18",
+ "unicode-normalization-alignments",
+ "unicode-segmentation",
+ "unicode_categories",
+]
+
+[[package]]
+name = "tokio"
+version = "1.52.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+dependencies = [
+ "bytes",
+ "libc",
+ "mio",
+ "pin-project-lite",
+ "socket2",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+dependencies = [
+ "futures-core",
+ "futures-util",
+ "pin-project-lite",
+ "sync_wrapper",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "pin-project-lite",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "url",
+]
+
+[[package]]
+name = "tower-layer"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "121c2a6cda46980bb0fcd1647ffaf6cd3fc79a013de288782836f6df9c48780e"
+
+[[package]]
+name = "tower-service"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
 name = "typenum"
 version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -524,10 +2829,109 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-normalization-alignments"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43f613e4fa046e69818dd287fdc4bc78175ff20331479dab6e1b0f98d57062de"
+dependencies = [
+ "smallvec",
+]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "unicode_categories"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
+
+[[package]]
+name = "unit-prefix"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "cookie_store",
+ "der",
+ "flate2",
+ "log",
+ "native-tls",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "socks",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-root-certs",
+ "webpki-roots",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
+name = "url"
+version = "2.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+dependencies = [
+ "form_urlencoded",
+ "idna",
+ "percent-encoding",
+ "serde",
+]
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -536,10 +2940,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "v_frame"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "666b7727c8875d6ab5db9533418d7c764233ac9c0cff1d469aec8fa127597be2"
+dependencies = [
+ "aligned-vec",
+ "num-traits",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "want"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa7760aed19e106de2c7c0b581b509f2f25d3dacaf737cb82ac61bc6d760b0e"
+dependencies = [
+ "try-lock",
+]
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
@@ -557,6 +2993,61 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
+dependencies = [
+ "cfg-if",
+ "once_cell",
+ "rustversion",
+ "wasm-bindgen-macro",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.71"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
+dependencies = [
+ "bumpalo",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.121"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
+dependencies = [
+ "unicode-ident",
 ]
 
 [[package]]
@@ -582,6 +3073,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "wasmparser"
 version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,10 +3098,114 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-sys"
+version = "0.3.98"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "weezl"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28ac98ddc8b9274cb41bb4d9d4d5c425b6020c50c46f25559911905610b4a88"
+
+[[package]]
+name = "winapi"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+dependencies = [
+ "winapi-i686-pc-windows-gnu",
+ "winapi-x86_64-pc-windows-gnu",
+]
+
+[[package]]
+name = "winapi-i686-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-x86_64-pc-windows-gnu"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
 
 [[package]]
 name = "windows-sys"
@@ -607,6 +3215,70 @@ checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -703,7 +3375,146 @@ dependencies = [
 ]
 
 [[package]]
+name = "writeable"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "y4m"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
+
+[[package]]
+name = "yoke"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+dependencies = [
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "synstructure",
+]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
+name = "zerotrie"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+]
+
+[[package]]
+name = "zerovec"
+version = "0.11.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+dependencies = [
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
+]
+
+[[package]]
+name = "zerovec-derive"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-inflate"
+version = "0.2.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73ab332fe2f6680068f3582b16a24f90ad7096d5d39b974d1c0aff0125116f02"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/README.md
+++ b/README.md
@@ -186,9 +186,10 @@ adoc search <query> [--artifact <path>] [--kind <value>] [--status <value>] [--o
 - runs the same compile path as `check`
 - creates the output directory when it does not exist
 - fails if the output path exists as a file
-- writes `docs.html`, `docs.agent.json`, and `docs.search.json` only when there are no errors
-- loads the local FastEmbed `bge-small-en-v1.5` model by default; first run may download model weights into the platform cache
-- reads the prior output directory's `docs.search.json` when present and reuses vectors whose model header and content hash still match
+- writes `docs.html` and `docs.agent.json` when source compilation is clean
+- loads the local FastEmbed `bge-small-en-v1.5` model by default through the default-on `embeddings` feature; first run may download model weights into the platform cache
+- reads the prior output directory's `docs.search.json` when present and reuses vectors whose model header and content hash still match, reported as `info[build.embeddings_cached] embeddings: cached N, computed M`
+- if embedding model load, compute, or dimension validation fails after clean source compilation, exits `1`, still writes `docs.html` and `docs.agent.json`, omits a new `docs.search.json`, and leaves any prior `docs.search.json` untouched
 - accepts `--no-embeddings` to skip model loading and search artifact writes; any existing `docs.search.json` is left untouched and an info diagnostic `build.embeddings_skipped` is emitted
 
 `adoc explain`:
@@ -314,7 +315,7 @@ Examples:
 - unreadable directories emit `error[io.unreadable_directory]`
 - unsupported single-file source extensions emit `error[io.unsupported_source_extension]`
 
-`adoc build` writes `docs.html`, `docs.agent.json`, and `docs.search.json` only when there are no error diagnostics. Embedding failures emit `embed.model_load_failed`, `embed.compute_failed`, or `embed.unexpected_dim` and block artifact writes.
+`adoc build` writes nothing when source compilation has error diagnostics. Embedding failures do not block `docs.html` or `docs.agent.json`: they emit `embed.model_load_failed`, `embed.compute_failed`, or `embed.unexpected_dim`, omit the new search sidecar, preserve any prior `docs.search.json`, and exit `1`.
 
 ## Smoke Tests
 
@@ -436,7 +437,9 @@ cargo run -p adoc-cli --bin adoc -- check <path>
 cargo run -p adoc-cli --bin adoc -- build <path> --out dist
 ```
 
-Hermetic CLI/core tests use the deterministic in-memory embedding provider through the `test-embedding-provider` feature. FastEmbed end-to-end coverage is gated behind `fastembed-it` so default tests do not download model weights:
+The `embeddings` feature is default-on and enables the FastEmbed dependency. Build without it with `cargo test -p adoc-core --no-default-features` or equivalent no-default build commands when embedding support is intentionally excluded.
+
+Hermetic CLI/core tests use the deterministic in-memory embedding provider through the `test-embedding-provider` feature only when `ADOC_TEST_EMBEDDING_PROVIDER=in-memory` is set. With that feature enabled, unset `ADOC_TEST_EMBEDDING_PROVIDER` and `ADOC_TEST_EMBEDDING_PROVIDER=fastembed` both use FastEmbed. FastEmbed end-to-end coverage is gated behind `fastembed-it`:
 
 ```bash
 cargo test -p adoc-core --features fastembed-it --no-run --locked

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The current implementation is a pre-release Rust CLI named `adoc`. It compiles n
 
 - `docs.html` for humans
 - `docs.agent.json` for agents and tooling
+- `docs.search.json` for local embedding-backed retrieval
 - source-located diagnostics for invalid input
 
 It also provides local, read-only retrieval over `docs.agent.json` with `adoc explain` and lexical-only `adoc search`.
@@ -31,7 +32,15 @@ AgentDoc is pre-release compiler and retrieval infrastructure. The source-to-art
 - relation fields `depends_on`, `supersedes`, and `related_to`
 - strict diagnostics for raw HTML, unsafe links, unclosed fenced code blocks, malformed typed blocks, malformed page annotations, invalid or duplicate Object IDs, invalid verified claims, broken references, and unsupported single-file source extensions
 - diagnostic metadata with source location, severity, code, message, and `object_id`/`help` when available
-- HTML and agent JSON artifact emission when no error diagnostics exist
+- HTML, agent JSON, and search artifact emission when no error diagnostics exist
+
+V1.3 build embeddings support:
+
+- `adoc build <path> --out <directory>` emits `docs.search.json` by default
+- local FastEmbed embeddings using `bge-small-en-v1.5` (`provider: "fastembed"`, `dim: 384`)
+- first-run model download through `fastembed-rs`, then local cache reuse on later builds
+- per-Object-ID vector reuse when the model header and content hash match the prior `docs.search.json`
+- `--no-embeddings` to skip search artifact generation and leave any prior `docs.search.json` untouched
 
 V1.2 local retrieval supports:
 
@@ -40,7 +49,7 @@ V1.2 local retrieval supports:
 - text and JSON retrieval output
 - search filters for kind, status, owner, and source path
 
-V1.2 search is lexical-only. It reads `docs.agent.json` only; it does not read `docs.search.json`, build or load embeddings, run semantic mode, or perform hybrid ranking yet.
+V1.2 search is lexical-only. It reads `docs.agent.json` only; it does not read `docs.search.json`, run semantic mode, or perform hybrid ranking yet.
 
 Config files, includes, custom schemas, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, a web app, and permissioned governance are deferred beyond the current V0 compiler loop. See [docs/ROADMAP.md](docs/ROADMAP.md).
 
@@ -106,6 +115,7 @@ Inspect the generated files:
 ls -la /tmp/adoc-example/dist
 cat /tmp/adoc-example/dist/docs.html
 cat /tmp/adoc-example/dist/docs.agent.json
+cat /tmp/adoc-example/dist/docs.search.json
 ```
 
 Expected files:
@@ -113,6 +123,7 @@ Expected files:
 ```text
 docs.html
 docs.agent.json
+docs.search.json
 ```
 
 ### Try The Billing Pilot
@@ -131,6 +142,7 @@ Expected files:
 ```text
 docs.html
 docs.agent.json
+docs.search.json
 ```
 
 ### Install Locally
@@ -152,7 +164,7 @@ adoc build /tmp/adoc-example/guide.adoc --out /tmp/adoc-example/dist
 
 ```bash
 adoc check <path>
-adoc build <path> --out <directory>
+adoc build <path> --out <directory> [--no-embeddings]
 adoc explain <object-id> [--artifact <path>] [--format text|json]
 adoc search <query> [--artifact <path>] [--kind <value>] [--status <value>] [--owner <value>] [--source-path <value>] [--top <n>] [--format text|json]
 ```
@@ -174,7 +186,10 @@ adoc search <query> [--artifact <path>] [--kind <value>] [--status <value>] [--o
 - runs the same compile path as `check`
 - creates the output directory when it does not exist
 - fails if the output path exists as a file
-- writes `docs.html` and `docs.agent.json` only when there are no errors
+- writes `docs.html`, `docs.agent.json`, and `docs.search.json` only when there are no errors
+- loads the local FastEmbed `bge-small-en-v1.5` model by default; first run may download model weights into the platform cache
+- reads the prior output directory's `docs.search.json` when present and reuses vectors whose model header and content hash still match
+- accepts `--no-embeddings` to skip model loading and search artifact writes; any existing `docs.search.json` is left untouched and an info diagnostic `build.embeddings_skipped` is emitted
 
 `adoc explain`:
 
@@ -193,7 +208,7 @@ adoc search <query> [--artifact <path>] [--kind <value>] [--status <value>] [--o
 - limits results with `--top`, defaulting to `10`
 - supports `--format text|json`
 
-V1.2 `adoc search` does not use `docs.search.json`, embeddings, semantic search, or hybrid ranking.
+V1.2 `adoc search` does not use `docs.search.json`, semantic search, or hybrid ranking.
 
 ## AgentDoc Source
 
@@ -283,7 +298,7 @@ fn main() {}
 Current limitations:
 
 - `adoc search` is lexical-only and reads `docs.agent.json` only
-- `adoc init`, custom schemas, includes, config files, search index artifacts, embeddings, semantic search, hybrid ranking, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, web app, and permissions are deferred
+- `adoc init`, custom schemas, includes, config files, semantic search, hybrid ranking, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, web app, and permissions are deferred
 
 ## Diagnostics
 
@@ -299,7 +314,7 @@ Examples:
 - unreadable directories emit `error[io.unreadable_directory]`
 - unsupported single-file source extensions emit `error[io.unsupported_source_extension]`
 
-`adoc build` writes `docs.html` and `docs.agent.json` only when there are no error diagnostics.
+`adoc build` writes `docs.html`, `docs.agent.json`, and `docs.search.json` only when there are no error diagnostics. Embedding failures emit `embed.model_load_failed`, `embed.compute_failed`, or `embed.unexpected_dim` and block artifact writes.
 
 ## Smoke Tests
 
@@ -333,6 +348,7 @@ Expected:
 - `build` exits `0`
 - `docs.html` exists
 - `docs.agent.json` exists
+- `docs.search.json` exists
 - agent JSON includes `schema_version`, `pages`, `"objects": []`, and `"diagnostics": []`
 
 Run strict-mode failure checks:
@@ -420,6 +436,12 @@ cargo run -p adoc-cli --bin adoc -- check <path>
 cargo run -p adoc-cli --bin adoc -- build <path> --out dist
 ```
 
+Hermetic CLI/core tests use the deterministic in-memory embedding provider through the `test-embedding-provider` feature. FastEmbed end-to-end coverage is gated behind `fastembed-it` so default tests do not download model weights:
+
+```bash
+cargo test -p adoc-core --features fastembed-it --no-run --locked
+```
+
 Format code before committing:
 
 ```bash
@@ -465,6 +487,7 @@ The public Rust API is deliberately small:
 
 ```rust
 pub fn compile_workspace(input: CompileInput) -> CompileResult;
+pub fn build_workspace(input: BuildInput) -> CompileResult;
 ```
 
 Parser, validation, renderer, and artifact internals stay private until another real consumer needs lower-level APIs.
@@ -491,8 +514,9 @@ Current V1 retrieval focuses on the existing flat agent artifact:
 - support `adoc explain <object-id>` for object lookup and citation
 - support `adoc search <query>` for deterministic lexical local search
 - prove retrieval against the billing pilot
+- build `docs.search.json` with local FastEmbed embeddings for the next semantic retrieval slice
 
-Later milestones cover `docs.search.json`, embeddings, semantic and hybrid search, project ergonomics, migration, review workflows, patch safety, expanded schema, graph exports, composition, and team surfaces.
+Later milestones cover semantic and hybrid search, project ergonomics, migration, review workflows, patch safety, expanded schema, graph exports, composition, and team surfaces.
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full sequence.
 

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -16,4 +16,5 @@ serde_json = "1"
 thiserror = "1"
 
 [dev-dependencies]
+adoc-core = { path = "../adoc-core", features = ["test-embedding-provider"] }
 insta = "1"

--- a/crates/adoc-cli/src/error.rs
+++ b/crates/adoc-cli/src/error.rs
@@ -25,6 +25,12 @@ pub(crate) enum CliError {
         source: serde_json::Error,
     },
 
+    #[error("error[artifact.search_json] could not serialize search JSON: {source}")]
+    SearchJsonSerialize {
+        #[source]
+        source: serde_json::Error,
+    },
+
     #[error("build did not produce artifacts")]
     BuildMissingArtifacts,
 

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -6,10 +6,11 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use adoc_core::{
-    AgentJsonDocument, CompileInput, Diagnostic, DiagnosticCode, ExplainResult,
-    JsonRetrievalFormatter, RetrievalEnvelope, RetrievalFormatter, RetrievalInput,
+    AgentJsonDocument, BuildEmbeddingMode, BuildInput, CompileInput, Diagnostic, DiagnosticCode,
+    ExplainResult, JsonRetrievalFormatter, RetrievalEnvelope, RetrievalFormatter, RetrievalInput,
     RetrievalLoadResult, SearchFilters, SearchMode, SearchQuery, SearchResult, Severity,
-    TextRetrievalFormatter, compile_workspace, explain_object, load_retrieval_session, search,
+    TextRetrievalFormatter, build_workspace, compile_workspace, explain_object,
+    load_retrieval_session, search,
 };
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 
@@ -23,7 +24,11 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
     match Cli::try_parse_from(arguments) {
         Ok(cli) => match cli.command {
             Commands::Check { path } => check(path),
-            Commands::Build { path, out } => build(path, out),
+            Commands::Build {
+                path,
+                out,
+                no_embeddings,
+            } => build(path, out, no_embeddings),
             Commands::Explain {
                 object_id,
                 artifact,
@@ -85,6 +90,8 @@ enum Commands {
         path: PathBuf,
         #[arg(long)]
         out: PathBuf,
+        #[arg(long)]
+        no_embeddings: bool,
     },
     Explain {
         object_id: String,
@@ -120,8 +127,16 @@ fn check(path: PathBuf) -> i32 {
     if result.has_errors() { 1 } else { 0 }
 }
 
-fn build(path: PathBuf, out: PathBuf) -> i32 {
-    let result = compile_workspace(CompileInput { root: path });
+fn build(path: PathBuf, out: PathBuf, no_embeddings: bool) -> i32 {
+    let result = if no_embeddings {
+        build_workspace(BuildInput {
+            root: path,
+            embeddings: BuildEmbeddingMode::Skipped,
+            prior_search_artifact_path: Some(out.join("docs.search.json")),
+        })
+    } else {
+        compile_workspace(CompileInput { root: path })
+    };
     print_diagnostics(&result.diagnostics);
     print_summary(&result.diagnostics);
 

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -6,11 +6,11 @@ use std::path::{Path, PathBuf};
 use std::process::ExitCode;
 
 use adoc_core::{
-    AgentJsonDocument, BuildEmbeddingMode, BuildInput, CompileInput, Diagnostic, DiagnosticCode,
-    ExplainResult, JsonRetrievalFormatter, RetrievalEnvelope, RetrievalFormatter, RetrievalInput,
-    RetrievalLoadResult, SearchArtifactDocument, SearchFilters, SearchMode, SearchQuery,
-    SearchResult, Severity, TextRetrievalFormatter, build_workspace, compile_workspace,
-    explain_object, load_retrieval_session, search,
+    AgentJsonDocument, BuildEmbeddingMode, BuildInput, CompileInput, CompileResult, Diagnostic,
+    DiagnosticCode, ExplainResult, JsonRetrievalFormatter, RetrievalEnvelope, RetrievalFormatter,
+    RetrievalInput, RetrievalLoadResult, SearchArtifactDocument, SearchFilters, SearchMode,
+    SearchQuery, SearchResult, Severity, TextRetrievalFormatter, build_workspace,
+    compile_workspace, explain_object, load_retrieval_session, search,
 };
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 
@@ -141,21 +141,25 @@ fn build(path: PathBuf, out: PathBuf, no_embeddings: bool) -> i32 {
     print_diagnostics(&result.diagnostics);
     print_summary(&result.diagnostics);
 
-    if result.has_errors() {
-        return 1;
-    }
+    finish_build_result(result, &out)
+}
+
+fn finish_build_result(result: CompileResult, out: &Path) -> i32 {
+    let has_errors = result.has_errors();
 
     let artifacts = match result.artifacts {
         Some(artifacts) => artifacts,
+        None if has_errors => return 1,
         None => return report(CliError::BuildMissingArtifacts),
     };
 
     match write_artifacts(
-        &out,
+        out,
         &artifacts.html,
         &artifacts.agent_json,
         artifacts.search_json.as_ref(),
     ) {
+        Ok(()) if has_errors => 1,
         Ok(()) => 0,
         Err(error) => report(error),
     }
@@ -484,10 +488,71 @@ impl RetrievalOutputFormat {
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
-    use adoc_core::{AgentJsonRelations, RetrievalRecord, RetrievalSource};
+    use adoc_core::{
+        AgentJsonDocument, AgentJsonRelations, BuildArtifacts, CompileResult, RetrievalRecord,
+        RetrievalSource,
+    };
 
     use super::*;
+
+    #[test]
+    fn finish_build_result_writes_v0_artifacts_and_preserves_prior_search_on_embedding_error() {
+        let output_directory = unique_temp_dir("embedding-error-output");
+        fs::create_dir_all(&output_directory).expect("output directory can be created");
+        fs::write(
+            output_directory.join("docs.search.json"),
+            "prior search artifact",
+        )
+        .expect("prior search artifact can be written");
+        let result = CompileResult {
+            diagnostics: vec![Diagnostic {
+                code: DiagnosticCode::EmbedComputeFailed,
+                severity: Severity::Error,
+                message: "embedding computation failed: encoder failed".to_string(),
+                span: None,
+                object_id: None,
+                help: None,
+            }],
+            artifacts: Some(BuildArtifacts {
+                html: "<h1>Guide</h1>".to_string(),
+                agent_json: AgentJsonDocument {
+                    schema_version: "adoc.agent.v0".to_string(),
+                    pages: Vec::new(),
+                    objects: Vec::new(),
+                    diagnostics: Vec::new(),
+                },
+                search_json: None,
+            }),
+        };
+
+        let exit_code = finish_build_result(result, &output_directory);
+
+        assert_eq!(exit_code, 1);
+        assert_eq!(
+            fs::read_to_string(output_directory.join("docs.html")).expect("HTML is written"),
+            "<h1>Guide</h1>"
+        );
+        assert!(
+            fs::read_to_string(output_directory.join("docs.agent.json"))
+                .expect("agent JSON is written")
+                .contains("\"schema_version\": \"adoc.agent.v0\"")
+        );
+        assert_eq!(
+            fs::read_to_string(output_directory.join("docs.search.json"))
+                .expect("prior search artifact remains readable"),
+            "prior search artifact"
+        );
+    }
+
+    fn unique_temp_dir(name: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system time after Unix epoch")
+            .as_nanos();
+        std::env::temp_dir().join(format!("adoc-cli-{name}-{}-{nanos}", std::process::id()))
+    }
 
     #[test]
     fn explain_exit_code_allows_warning_diagnostics_when_record_is_present() {

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -8,9 +8,9 @@ use std::process::ExitCode;
 use adoc_core::{
     AgentJsonDocument, BuildEmbeddingMode, BuildInput, CompileInput, Diagnostic, DiagnosticCode,
     ExplainResult, JsonRetrievalFormatter, RetrievalEnvelope, RetrievalFormatter, RetrievalInput,
-    RetrievalLoadResult, SearchFilters, SearchMode, SearchQuery, SearchResult, Severity,
-    TextRetrievalFormatter, build_workspace, compile_workspace, explain_object,
-    load_retrieval_session, search,
+    RetrievalLoadResult, SearchArtifactDocument, SearchFilters, SearchMode, SearchQuery,
+    SearchResult, Severity, TextRetrievalFormatter, build_workspace, compile_workspace,
+    explain_object, load_retrieval_session, search,
 };
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 
@@ -128,15 +128,16 @@ fn check(path: PathBuf) -> i32 {
 }
 
 fn build(path: PathBuf, out: PathBuf, no_embeddings: bool) -> i32 {
-    let result = if no_embeddings {
-        build_workspace(BuildInput {
-            root: path,
-            embeddings: BuildEmbeddingMode::Skipped,
-            prior_search_artifact_path: Some(out.join("docs.search.json")),
-        })
+    let embedding_mode = if no_embeddings {
+        BuildEmbeddingMode::Skipped
     } else {
-        compile_workspace(CompileInput { root: path })
+        BuildEmbeddingMode::Enabled
     };
+    let result = build_workspace(BuildInput {
+        root: path,
+        embeddings: embedding_mode,
+        prior_search_artifact_path: Some(out.join("docs.search.json")),
+    });
     print_diagnostics(&result.diagnostics);
     print_summary(&result.diagnostics);
 
@@ -149,7 +150,12 @@ fn build(path: PathBuf, out: PathBuf, no_embeddings: bool) -> i32 {
         None => return report(CliError::BuildMissingArtifacts),
     };
 
-    match write_artifacts(&out, &artifacts.html, &artifacts.agent_json) {
+    match write_artifacts(
+        &out,
+        &artifacts.html,
+        &artifacts.agent_json,
+        artifacts.search_json.as_ref(),
+    ) {
         Ok(()) => 0,
         Err(error) => report(error),
     }
@@ -350,7 +356,12 @@ fn report(error: CliError) -> i32 {
     error.exit_code()
 }
 
-fn write_artifacts(out: &Path, html: &str, agent_json: &AgentJsonDocument) -> Result<(), CliError> {
+fn write_artifacts(
+    out: &Path,
+    html: &str,
+    agent_json: &AgentJsonDocument,
+    search_json: Option<&SearchArtifactDocument>,
+) -> Result<(), CliError> {
     if out.exists() && !out.is_dir() {
         return Err(CliError::OutputPathIsFile {
             path: out.to_path_buf(),
@@ -376,6 +387,17 @@ fn write_artifacts(out: &Path, html: &str, agent_json: &AgentJsonDocument) -> Re
         path: agent_json_path,
         source,
     })?;
+
+    if let Some(search_json) = search_json {
+        let search_json_text = search_json
+            .to_pretty_json()
+            .map_err(|source| CliError::SearchJsonSerialize { source })?;
+        let search_json_path = out.join("docs.search.json");
+        fs::write(&search_json_path, search_json_text).map_err(|source| CliError::WriteFailed {
+            path: search_json_path,
+            source,
+        })?;
+    }
 
     Ok(())
 }

--- a/crates/adoc-cli/tests/billing_pilot.rs
+++ b/crates/adoc-cli/tests/billing_pilot.rs
@@ -49,6 +49,7 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
     let output_directory = workspace.root.join("dist");
     let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&repo_root)
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
         .args([
             "build",
             example_path,
@@ -136,6 +137,23 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
     assert_eq!(
         decrement_claim["relations"]["depends_on"],
         serde_json::json!(["billing.credits.ledger-source"])
+    );
+
+    let search_json_text = std::fs::read_to_string(output_directory.join("docs.search.json"))
+        .expect("billing pilot search JSON is written");
+    let search_json: Value =
+        serde_json::from_str(&search_json_text).expect("search JSON is valid JSON");
+    assert_eq!(search_json["schema_version"], "adoc.search.v0");
+    assert_eq!(search_json["model"]["id"], "in-memory");
+    assert_eq!(search_json["model"]["provider"], "test");
+    assert_eq!(search_json["model"]["dim"], 384);
+    assert_eq!(
+        search_json["embeddings"]
+            .as_array()
+            .expect("search embeddings is an array")
+            .len(),
+        objects.len(),
+        "search artifact should carry one embedding per Knowledge Object"
     );
 
     let artifact_path = output_directory.join("docs.agent.json");

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -8,6 +8,12 @@ use std::process::Command;
 
 use support::{TestWorkspace, fixture_path};
 
+fn adoc_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+    command.env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory");
+    command
+}
+
 fn write_fixture_to_workspace(
     workspace: &TestWorkspace,
     fixture_relative: &str,
@@ -28,7 +34,7 @@ fn assert_fixture_build_matches_golden(
     let workspace = TestWorkspace::new(workspace_name);
     write_fixture_to_workspace(&workspace, fixture_relative, source_file);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", source_file, "--out", "dist"])
         .output()
@@ -87,7 +93,7 @@ fn assert_fixture_directory_build_matches_golden(
     let workspace = TestWorkspace::new(workspace_name);
     copy_fixture_directory_to_workspace(&workspace, fixture_relative, source_dir);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", source_dir, "--out", "dist"])
         .output()
@@ -116,7 +122,7 @@ fn assert_fixture_directory_build_matches_golden(
 fn check_accepts_v0_1_prose_fixture_with_all_inline_syntax() {
     let fixture = fixture_path("v0_1/prose_page.adoc");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", fixture.to_str().expect("fixture path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -141,7 +147,7 @@ fn check_unclosed_fence_diagnostic_surfaces_all_six_fields() {
         .expect("unclosed_fence fixture is readable");
     let source = workspace.write("unclosed_fence.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -177,7 +183,7 @@ fn check_rejects_unsafe_link_with_source_location() {
         .expect("unsafe_link fixture is readable");
     let source = workspace.write("unsafe_link.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -211,7 +217,7 @@ fn build_renders_v0_1_prose_fixture_to_golden_agent_json() {
 
     // Run with cwd=workspace so the recorded source_path is "prose_page.adoc"
     // rather than a host-specific absolute path.
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "prose_page.adoc", "--out", "dist"])
         .output()
@@ -242,7 +248,7 @@ fn build_renders_v0_1_prose_fixture_to_golden_html() {
     let fixture = fixture_path("v0_1/prose_page.adoc");
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             fixture.to_str().expect("fixture path is utf-8"),
@@ -281,7 +287,7 @@ fn check_accepts_minimal_prose_page() {
         "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -317,7 +323,7 @@ fn build_creates_missing_output_directory_and_writes_artifacts() {
     );
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
         .args([
             "build",
@@ -380,7 +386,7 @@ fn build_no_embeddings_emits_info_and_leaves_prior_search_artifact_untouched() {
     fs::write(&search_artifact_path, "existing search artifact")
         .expect("prior search artifact can be written");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -429,7 +435,7 @@ fn build_reuses_search_artifact_cache_for_unchanged_source() {
     let output_directory = workspace.root.join("dist");
 
     for _ in 0..2 {
-        let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        let output = adoc_command()
             .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
             .args([
                 "build",
@@ -455,7 +461,7 @@ fn build_reuses_search_artifact_cache_for_unchanged_source() {
     .expect("search artifact is valid");
     let first_vector = first_search["embeddings"][0]["vector"].clone();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
         .args([
             "build",
@@ -485,7 +491,7 @@ fn build_missing_out_exits_1_with_parse_error() {
         "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["build", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc build runs");
@@ -515,7 +521,7 @@ fn build_unknown_out_flag_exits_1_with_parse_error() {
         "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -551,7 +557,7 @@ fn build_groups_contiguous_list_items_by_list_kind() {
     );
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -584,7 +590,7 @@ fn build_derives_distinct_page_ids_from_directory_relative_paths() {
     workspace.write("b/guide.adoc", "# Beta Guide\n\nBeta content.\n");
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             workspace.root.to_str().expect("workspace path is utf-8"),
@@ -622,7 +628,7 @@ fn build_keeps_page_identity_from_first_heading_annotation() {
     );
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -660,7 +666,7 @@ fn build_uses_first_top_level_heading_annotation_for_page_identity() {
     );
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -698,7 +704,7 @@ fn build_fails_clearly_when_output_path_is_a_file() {
     );
     let output_path = workspace.write("dist", "not a directory");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -727,7 +733,7 @@ fn check_rejects_raw_html_with_source_location() {
         "# Unsafe Input @doc(docs.unsafe-input)\n\n<div>raw html</div>\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -748,7 +754,7 @@ fn check_rejects_unknown_raw_html_tag() {
         "# Unsafe Input @doc(docs.unsafe-input)\n\n<foo>bar</foo>\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -771,7 +777,7 @@ fn check_rejects_custom_element_tag() {
         "# Unsafe Input @doc(docs.unsafe-input)\n\n<my-component>x</my-component>\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -793,7 +799,7 @@ fn check_does_not_flag_angle_brackets_in_prose() {
         "# Technical Prose @doc(docs.technical-prose)\n\nUse Vec<String> for a list.\n\nSet x < 5 here.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -816,7 +822,7 @@ fn check_rejects_adjacent_inline_raw_html_tag() {
         "# Unsafe Input @doc(docs.unsafe-input)\n\nKeep<span>raw html</span> out.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -837,7 +843,7 @@ fn check_rejects_single_file_with_non_adoc_extension() {
         "# Guide\n\n<div>This must not compile as AgentDoc Source.</div>\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -867,7 +873,7 @@ fn build_rejects_inline_raw_html_and_writes_no_artifacts() {
     );
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -901,7 +907,7 @@ fn duplicate_claim_ids_fail_check_and_block_build_artifacts() {
         "# Billing Extra @doc(billing.extra-page)\n\n::claim billing.credits.foo\nstatus: draft\n--\nCredits are also described here.\n::\n",
     );
 
-    let check_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let check_output = adoc_command()
         .args([
             "check",
             workspace.root.to_str().expect("root path is utf-8"),
@@ -921,7 +927,7 @@ fn duplicate_claim_ids_fail_check_and_block_build_artifacts() {
     assert!(check_stdout.contains("1 errors"));
 
     let output_directory = workspace.root.join("dist");
-    let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let build_output = adoc_command()
         .args([
             "build",
             workspace.root.to_str().expect("root path is utf-8"),
@@ -954,7 +960,7 @@ fn broken_prose_reference_fails_check_and_blocks_build_artifacts() {
         "# Guide @doc(team.guide)\n\nSee [[missing.object]] for details.\n",
     );
 
-    let check_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let check_output = adoc_command()
         .args([
             "check",
             workspace.root.to_str().expect("root path is utf-8"),
@@ -973,7 +979,7 @@ fn broken_prose_reference_fails_check_and_blocks_build_artifacts() {
     );
 
     let output_directory = workspace.root.join("dist");
-    let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let build_output = adoc_command()
         .args([
             "build",
             workspace.root.to_str().expect("root path is utf-8"),
@@ -1001,7 +1007,7 @@ fn check_allows_raw_html_inside_closed_fenced_code_block() {
         "# Fenced HTML Sample @doc(docs.fenced-html)\n\n```html\n<div>example</div>\n<script>alert(1)</script>\n```\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -1029,7 +1035,7 @@ fn build_writes_artifacts_for_raw_html_inside_fenced_code_block() {
     );
     let output_directory = workspace.root.join("dist");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -1063,7 +1069,7 @@ fn check_rejects_unclosed_fenced_code_with_source_location() {
         "# Broken Code @doc(docs.broken-code)\n\n```rust\nfn main() {}\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -1087,7 +1093,7 @@ fn check_rejects_malformed_page_annotation_with_source_location() {
         "# Broken Annotation @doc(broken-page\n\nContent.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -1108,7 +1114,7 @@ fn check_reports_malformed_annotation_with_indented_heading() {
     let workspace = TestWorkspace::new("check-reports-malformed-annotation-indented");
     let source = workspace.write("guide.adoc", "  # Broken @doc(\n\nContent.\n");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -1134,7 +1140,7 @@ fn check_reports_trailing_content_malformed_with_indent() {
         "   # Notes (per @doc(thing) sidebar)\n\nContent.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args(["check", source.to_str().expect("source path is utf-8")])
         .output()
         .expect("adoc check runs");
@@ -1159,7 +1165,7 @@ fn check_accepts_at_doc_without_parentheses_as_heading_text() {
         "# Broken Annotation @doc product.area\n\nContent.\n",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "check",
             workspace.root.to_str().expect("workspace path is utf-8"),
@@ -1184,7 +1190,7 @@ fn check_accepts_v0_2_claim_fixture() {
         .expect("claim_basic fixture is readable");
     workspace.write("claim_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "claim_basic.adoc"])
         .output()
@@ -1210,7 +1216,7 @@ fn check_rejects_claim_with_missing_status() {
         .expect("claim_missing_status fixture is readable");
     workspace.write("claim_missing_status.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "claim_missing_status.adoc"])
         .output()
@@ -1250,7 +1256,7 @@ fn build_renders_v0_2_claim_fixture_to_golden_html() {
         .expect("claim_basic fixture is readable");
     workspace.write("claim_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "claim_basic.adoc", "--out", "dist"])
         .output()
@@ -1282,7 +1288,7 @@ fn build_renders_v0_2_claim_fixture_to_golden_agent_json() {
         .expect("claim_basic fixture is readable");
     workspace.write("claim_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "claim_basic.adoc", "--out", "dist"])
         .output()
@@ -1314,7 +1320,7 @@ fn check_accepts_v0_3_verified_claims_pilot_fixture() {
         .expect("verified pilot fixture is readable");
     workspace.write("verified_claims_pilot.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "verified_claims_pilot.adoc"])
         .output()
@@ -1341,7 +1347,7 @@ fn check_rejects_verified_claim_without_evidence() {
             .expect("verified missing evidence fixture is readable");
     workspace.write("verified_claim_missing_evidence.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "verified_claim_missing_evidence.adoc"])
         .output()
@@ -1369,7 +1375,7 @@ fn build_renders_v0_3_verified_claims_pilot_to_golden_html() {
         .expect("verified pilot fixture is readable");
     workspace.write("verified_claims_pilot.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "verified_claims_pilot.adoc", "--out", "dist"])
         .output()
@@ -1400,7 +1406,7 @@ fn build_renders_v0_3_verified_claims_pilot_to_golden_agent_json() {
         .expect("verified pilot fixture is readable");
     workspace.write("verified_claims_pilot.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "verified_claims_pilot.adoc", "--out", "dist"])
         .output()
@@ -1431,7 +1437,7 @@ fn check_accepts_v0_4_proposed_decision_fixture() {
         .expect("decision_proposed fixture is readable");
     workspace.write("decision_proposed.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "decision_proposed.adoc"])
         .output()
@@ -1457,7 +1463,7 @@ fn build_renders_v0_4_proposed_decision_to_golden_html() {
         .expect("decision_proposed fixture is readable");
     workspace.write("decision_proposed.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "decision_proposed.adoc", "--out", "dist"])
         .output()
@@ -1488,7 +1494,7 @@ fn build_renders_v0_4_proposed_decision_to_golden_agent_json() {
         .expect("decision_proposed fixture is readable");
     workspace.write("decision_proposed.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "decision_proposed.adoc", "--out", "dist"])
         .output()
@@ -1519,7 +1525,7 @@ fn build_renders_v0_4_accepted_decision_to_golden_html() {
         .expect("decision_accepted fixture is readable");
     workspace.write("decision_accepted.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "decision_accepted.adoc", "--out", "dist"])
         .output()
@@ -1558,7 +1564,7 @@ fn build_renders_v0_4_accepted_decision_to_golden_agent_json() {
         .expect("decision_accepted fixture is readable");
     workspace.write("decision_accepted.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "decision_accepted.adoc", "--out", "dist"])
         .output()
@@ -1593,7 +1599,7 @@ fn check_accepts_v0_4_warning_fixture() {
         .expect("warning_basic fixture is readable");
     workspace.write("warning_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "warning_basic.adoc"])
         .output()
@@ -1619,7 +1625,7 @@ fn build_renders_v0_4_warning_to_golden_html() {
         .expect("warning_basic fixture is readable");
     workspace.write("warning_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "warning_basic.adoc", "--out", "dist"])
         .output()
@@ -1654,7 +1660,7 @@ fn build_renders_v0_4_warning_to_golden_agent_json() {
         .expect("warning_basic fixture is readable");
     workspace.write("warning_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "warning_basic.adoc", "--out", "dist"])
         .output()
@@ -1693,7 +1699,7 @@ fn check_accepts_v0_4_glossary_fixture() {
         .expect("glossary_basic fixture is readable");
     workspace.write("glossary_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "glossary_basic.adoc"])
         .output()
@@ -1719,7 +1725,7 @@ fn build_renders_v0_4_glossary_to_golden_html() {
         .expect("glossary_basic fixture is readable");
     workspace.write("glossary_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "glossary_basic.adoc", "--out", "dist"])
         .output()
@@ -1754,7 +1760,7 @@ fn build_renders_v0_4_glossary_to_golden_agent_json() {
         .expect("glossary_basic fixture is readable");
     workspace.write("glossary_basic.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "glossary_basic.adoc", "--out", "dist"])
         .output()
@@ -1793,7 +1799,7 @@ fn check_accepts_v0_4_core_object_set_fixture() {
         .expect("core_object_set fixture is readable");
     workspace.write("core_object_set.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "core_object_set.adoc"])
         .output()
@@ -1819,7 +1825,7 @@ fn build_renders_v0_4_core_object_set_to_golden_html() {
         .expect("core_object_set fixture is readable");
     workspace.write("core_object_set.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "core_object_set.adoc", "--out", "dist"])
         .output()
@@ -1867,7 +1873,7 @@ fn build_renders_v0_4_core_object_set_to_golden_agent_json() {
         .expect("core_object_set fixture is readable");
     workspace.write("core_object_set.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["build", "core_object_set.adoc", "--out", "dist"])
         .output()
@@ -1982,7 +1988,7 @@ fn check_rejects_v0_5_broken_relation_fixture() {
         "relation_broken.adoc",
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "relation_broken.adoc"])
         .output()
@@ -2056,7 +2062,7 @@ fn check_rejects_v0_6_duplicate_id_across_files() {
     let workspace = TestWorkspace::new("check-rejects-v0-6-duplicate-id");
     copy_fixture_directory_to_workspace(&workspace, "v0_6/duplicate_id", "duplicate_id");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "duplicate_id"])
         .output()
@@ -2088,7 +2094,7 @@ fn check_rejects_unknown_typed_block_kind() {
         .expect("unknown_kind fixture is readable");
     workspace.write("unknown_kind.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "unknown_kind.adoc"])
         .output()
@@ -2121,7 +2127,7 @@ fn check_rejects_unknown_typed_block_kind_without_field_cascade() {
         .expect("unknown_kind_freeform fixture is readable");
     workspace.write("unknown_kind_freeform.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "unknown_kind_freeform.adoc"])
         .output()
@@ -2155,7 +2161,7 @@ fn check_rejects_nested_typed_block_in_fields() {
             .expect("nested fields fixture is readable");
     workspace.write("nested_typed_block_in_fields.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "nested_typed_block_in_fields.adoc"])
         .output()
@@ -2184,7 +2190,7 @@ fn check_rejects_nested_typed_block_in_body() {
         .expect("nested body fixture is readable");
     workspace.write("nested_typed_block_in_body.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "nested_typed_block_in_body.adoc"])
         .output()
@@ -2213,7 +2219,7 @@ fn check_rejects_glossary_with_missing_body() {
         .expect("glossary_missing_body fixture is readable");
     workspace.write("glossary_missing_body.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "glossary_missing_body.adoc"])
         .output()
@@ -2241,7 +2247,7 @@ fn check_rejects_warning_with_missing_severity() {
         .expect("warning_missing_severity fixture is readable");
     workspace.write("warning_missing_severity.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "warning_missing_severity.adoc"])
         .output()
@@ -2269,7 +2275,7 @@ fn check_rejects_warning_with_missing_body() {
         .expect("warning_missing_body fixture is readable");
     workspace.write("warning_missing_body.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "warning_missing_body.adoc"])
         .output()
@@ -2297,7 +2303,7 @@ fn check_rejects_warning_with_invalid_severity() {
         .expect("warning_invalid_severity fixture is readable");
     workspace.write("warning_invalid_severity.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "warning_invalid_severity.adoc"])
         .output()
@@ -2325,7 +2331,7 @@ fn check_rejects_warning_with_severity_casing() {
         .expect("warning_severity_casing fixture is readable");
     workspace.write("warning_severity_casing.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "warning_severity_casing.adoc"])
         .output()
@@ -2353,7 +2359,7 @@ fn check_rejects_decision_with_missing_status() {
         .expect("decision_missing_status fixture is readable");
     workspace.write("decision_missing_status.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "decision_missing_status.adoc"])
         .output()
@@ -2390,7 +2396,7 @@ fn check_rejects_accepted_decision_with_missing_decided_by() {
         &fixture_contents,
     );
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "decision_accepted_missing_decided_by.adoc"])
         .output()
@@ -2419,7 +2425,7 @@ fn check_rejects_accepted_decision_with_empty_decided_by() {
             .expect("decision_accepted_empty_decided_by fixture is readable");
     workspace.write("decision_accepted_empty_decided_by.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "decision_accepted_empty_decided_by.adoc"])
         .output()
@@ -2447,7 +2453,7 @@ fn check_rejects_decision_with_invalid_status() {
         .expect("decision_invalid_status fixture is readable");
     workspace.write("decision_invalid_status.adoc", &fixture_contents);
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .current_dir(&workspace.root)
         .args(["check", "decision_invalid_status.adoc"])
         .output()
@@ -2479,7 +2485,7 @@ fn check_reports_unreadable_source_path() {
     permissions.set_mode(0o000);
     fs::set_permissions(&source, permissions).expect("source can be made unreadable");
 
-    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let output = adoc_command()
         .args([
             "check",
             workspace.root.to_str().expect("root path is utf-8"),

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -303,11 +303,22 @@ fn build_creates_missing_output_directory_and_writes_artifacts() {
     let workspace = TestWorkspace::new("build-writes-artifacts");
     let source = workspace.write(
         "guide.adoc",
-        "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
+        concat!(
+            "# Getting Started @doc(docs.getting-started)\n",
+            "\n",
+            "AgentDoc keeps knowledge readable.\n",
+            "\n",
+            "::claim docs.search-ready\n",
+            "status: draft\n",
+            "--\n",
+            "Default build writes a search artifact.\n",
+            "::\n",
+        ),
     );
     let output_directory = workspace.root.join("dist");
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
@@ -334,12 +345,22 @@ fn build_creates_missing_output_directory_and_writes_artifacts() {
         .expect("agent JSON is written");
     assert!(agent_json.contains("\"schema_version\": \"adoc.agent.v0\""));
     assert!(agent_json.contains("\"pages\""));
-    assert!(agent_json.contains("\"objects\": []"));
+    assert!(agent_json.contains("\"id\": \"docs.search-ready\""));
     assert!(agent_json.contains("\"diagnostics\": []"));
+
+    let search_json_text = fs::read_to_string(output_directory.join("docs.search.json"))
+        .expect("search JSON is written");
+    let search_json: serde_json::Value =
+        serde_json::from_str(&search_json_text).expect("search JSON is valid");
+    assert_eq!(search_json["schema_version"], "adoc.search.v0");
+    assert_eq!(search_json["model"]["id"], "in-memory");
+    assert_eq!(search_json["model"]["provider"], "test");
+    assert_eq!(search_json["model"]["dim"], 384);
+    assert_eq!(search_json["embeddings"][0]["id"], "docs.search-ready");
 }
 
 #[test]
-fn build_no_embeddings_emits_info_and_skips_search_artifact() {
+fn build_no_embeddings_emits_info_and_leaves_prior_search_artifact_untouched() {
     let workspace = TestWorkspace::new("build-no-embeddings");
     let source = workspace.write(
         "guide.adoc",
@@ -353,17 +374,18 @@ fn build_no_embeddings_emits_info_and_skips_search_artifact() {
             "::\n",
         ),
     );
+    let output_directory = workspace.root.join("dist");
+    fs::create_dir_all(&output_directory).expect("output directory can be created");
+    let search_artifact_path = output_directory.join("docs.search.json");
+    fs::write(&search_artifact_path, "existing search artifact")
+        .expect("prior search artifact can be written");
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .args([
             "build",
             source.to_str().expect("source path is utf-8"),
             "--out",
-            workspace
-                .root
-                .join("dist")
-                .to_str()
-                .expect("output path is utf-8"),
+            output_directory.to_str().expect("output path is utf-8"),
             "--no-embeddings",
         ])
         .output()
@@ -382,10 +404,77 @@ fn build_no_embeddings_emits_info_and_skips_search_artifact() {
     );
     assert!(workspace.root.join("dist/docs.html").is_file());
     assert!(workspace.root.join("dist/docs.agent.json").is_file());
-    assert!(
-        !workspace.root.join("dist/docs.search.json").exists(),
-        "--no-embeddings must not write docs.search.json"
+    assert_eq!(
+        fs::read_to_string(search_artifact_path).expect("prior search artifact remains readable"),
+        "existing search artifact",
+        "--no-embeddings must leave prior docs.search.json untouched"
     );
+}
+
+#[test]
+fn build_reuses_search_artifact_cache_for_unchanged_source() {
+    let workspace = TestWorkspace::new("build-search-cache");
+    let source = workspace.write(
+        "guide.adoc",
+        concat!(
+            "# Guide @doc(team.guide)\n",
+            "\n",
+            "::claim billing.credits\n",
+            "status: draft\n",
+            "--\n",
+            "Credits apply after successful payment.\n",
+            "::\n",
+        ),
+    );
+    let output_directory = workspace.root.join("dist");
+
+    for _ in 0..2 {
+        let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
+            .args([
+                "build",
+                source.to_str().expect("source path is utf-8"),
+                "--out",
+                output_directory.to_str().expect("output path is utf-8"),
+            ])
+            .output()
+            .expect("adoc build runs");
+
+        assert!(
+            output.status.success(),
+            "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    let first_search: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(output_directory.join("docs.search.json"))
+            .expect("search artifact is readable"),
+    )
+    .expect("search artifact is valid");
+    let first_vector = first_search["embeddings"][0]["vector"].clone();
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
+        .args([
+            "build",
+            source.to_str().expect("source path is utf-8"),
+            "--out",
+            output_directory.to_str().expect("output path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+    assert!(output.status.success());
+
+    let second_search: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(output_directory.join("docs.search.json"))
+            .expect("search artifact is readable"),
+    )
+    .expect("search artifact is valid");
+
+    assert_eq!(second_search["embeddings"][0]["id"], "billing.credits");
+    assert_eq!(second_search["embeddings"][0]["vector"], first_vector);
 }
 
 #[test]

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -339,6 +339,56 @@ fn build_creates_missing_output_directory_and_writes_artifacts() {
 }
 
 #[test]
+fn build_no_embeddings_emits_info_and_skips_search_artifact() {
+    let workspace = TestWorkspace::new("build-no-embeddings");
+    let source = workspace.write(
+        "guide.adoc",
+        concat!(
+            "# Guide @doc(team.guide)\n",
+            "\n",
+            "::claim billing.credits\n",
+            "status: draft\n",
+            "--\n",
+            "Credits apply after successful payment.\n",
+            "::\n",
+        ),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "build",
+            source.to_str().expect("source path is utf-8"),
+            "--out",
+            workspace
+                .root
+                .join("dist")
+                .to_str()
+                .expect("output path is utf-8"),
+            "--no-embeddings",
+        ])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("info[build.embeddings_skipped]"),
+        "expected skipped embedding info diagnostic in stdout:\n{stdout}"
+    );
+    assert!(workspace.root.join("dist/docs.html").is_file());
+    assert!(workspace.root.join("dist/docs.agent.json").is_file());
+    assert!(
+        !workspace.root.join("dist/docs.search.json").exists(),
+        "--no-embeddings must not write docs.search.json"
+    );
+}
+
+#[test]
 fn build_missing_out_exits_1_with_parse_error() {
     let workspace = TestWorkspace::new("build-invalid-usage-missing-out");
     let source = workspace.write(

--- a/crates/adoc-core/Cargo.toml
+++ b/crates/adoc-core/Cargo.toml
@@ -7,6 +7,7 @@ rust-version.workspace = true
 
 [features]
 fastembed-it = []
+test-embedding-provider = []
 
 [dependencies]
 fastembed = "5"

--- a/crates/adoc-core/Cargo.toml
+++ b/crates/adoc-core/Cargo.toml
@@ -6,11 +6,13 @@ license.workspace = true
 rust-version.workspace = true
 
 [features]
-fastembed-it = []
+default = ["embeddings"]
+embeddings = ["dep:fastembed"]
+fastembed-it = ["embeddings"]
 test-embedding-provider = []
 
 [dependencies]
-fastembed = "5"
+fastembed = { version = "5", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/adoc-core/Cargo.toml
+++ b/crates/adoc-core/Cargo.toml
@@ -5,7 +5,11 @@ edition.workspace = true
 license.workspace = true
 rust-version.workspace = true
 
+[features]
+fastembed-it = []
+
 [dependencies]
+fastembed = "5"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/adoc-core/Cargo.toml
+++ b/crates/adoc-core/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -129,15 +129,7 @@ fn run_compile_pipeline<P: SourceProvider>(
     }
     let artifact_result =
         build_artifacts_for_build(&workspace, &diagnostics, build_options.as_mut());
-    let artifacts = if artifact_result
-        .diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.severity == Severity::Error)
-    {
-        None
-    } else {
-        artifact_result.artifacts
-    };
+    let artifacts = artifact_result.artifacts;
     diagnostics.extend(artifact_result.diagnostics);
     sort_diagnostics_by_source(&mut diagnostics);
     CompileResult {
@@ -263,6 +255,7 @@ fn build_artifacts_for_build(
         };
     }
 
+    let html = HtmlRenderer.render(&workspace.pages);
     let agent_json = AgentJsonArtifact.build(&workspace.pages, diagnostics);
     let prior_search_artifact_path = build_options
         .as_ref()
@@ -281,7 +274,11 @@ fn build_artifacts_for_build(
             Ok(search_artifact) => Some(search_artifact),
             Err(diagnostics) => {
                 return ArtifactBuildResult {
-                    artifacts: None,
+                    artifacts: Some(BuildArtifacts {
+                        html,
+                        agent_json,
+                        search_json: None,
+                    }),
                     diagnostics,
                 };
             }
@@ -291,7 +288,11 @@ fn build_artifacts_for_build(
                 Ok(provider) => provider,
                 Err(error) => {
                     return ArtifactBuildResult {
-                        artifacts: None,
+                        artifacts: Some(BuildArtifacts {
+                            html,
+                            agent_json,
+                            search_json: None,
+                        }),
                         diagnostics: vec![embedding_error_diagnostic(error)],
                     };
                 }
@@ -305,7 +306,11 @@ fn build_artifacts_for_build(
                 Ok(search_artifact) => Some(search_artifact),
                 Err(diagnostics) => {
                     return ArtifactBuildResult {
-                        artifacts: None,
+                        artifacts: Some(BuildArtifacts {
+                            html,
+                            agent_json,
+                            search_json: None,
+                        }),
                         diagnostics,
                     };
                 }
@@ -316,7 +321,7 @@ fn build_artifacts_for_build(
 
     ArtifactBuildResult {
         artifacts: Some(BuildArtifacts {
-            html: HtmlRenderer.render(&workspace.pages),
+            html,
             agent_json,
             search_json,
         }),
@@ -1060,9 +1065,13 @@ mod tests {
             "build should fail: {:?}",
             result.diagnostics
         );
+        let artifacts = result
+            .artifacts
+            .as_ref()
+            .expect("embedding failures preserve V0 artifacts");
         assert!(
-            result.artifacts.is_none(),
-            "embedding failures must block all artifacts"
+            artifacts.search_json.is_none(),
+            "embedding failures must suppress only search artifacts"
         );
         let diagnostic = result
             .diagnostics

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -453,14 +453,13 @@ fn validate_embedding_vectors(
         )]);
     }
 
-    for (index, vector) in vectors.iter().enumerate() {
+    for vector in vectors {
         if vector.len() != expected_dim {
-            return Err(vec![Diagnostic::error(
-                DiagnosticCode::EmbedUnexpectedDimension,
-                format!(
-                    "embedding provider returned vector {index} with dimension {}; expected {expected_dim}",
-                    vector.len()
-                ),
+            return Err(vec![embedding_error_diagnostic(
+                EmbeddingError::DimensionMismatch {
+                    expected: expected_dim,
+                    actual: vector.len(),
+                },
             )]);
         }
     }
@@ -1399,6 +1398,15 @@ mod tests {
         );
 
         assert_embedding_error_result(&result, DiagnosticCode::EmbedUnexpectedDimension);
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::EmbedUnexpectedDimension)
+            .expect("dimension diagnostic");
+        assert_eq!(
+            diagnostic.message,
+            "embedding provider returned dimension 3; expected 4"
+        );
     }
 
     fn assert_embedding_error_result(result: &CompileResult, expected_code: DiagnosticCode) {

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -788,6 +788,50 @@ mod tests {
     }
 
     #[test]
+    fn build_with_provider_matches_v1_3_in_memory_search_fixture() {
+        let source_text = fs::read_to_string(repo_fixture_path("v1_3_embed/input.adoc"))
+            .expect("fixture source is readable");
+        let source_provider = InMemorySourceProvider::new()
+            .with_source(source_file("v1_3_embed/input.adoc", &source_text));
+        let embedding_provider = InMemoryProvider::new(4);
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert!(
+            !result.has_errors(),
+            "fixture build should pass: {:?}",
+            result.diagnostics
+        );
+        let actual = result
+            .artifacts
+            .expect("artifacts are built")
+            .search_json
+            .expect("search artifact is built");
+        let actual_json = actual.to_pretty_json().expect("actual serializes");
+        let expected_text = fs::read_to_string(repo_fixture_path(
+            "v1_3_embed/in_memory_baseline.search.json",
+        ))
+        .expect("baseline fixture is readable");
+        let expected: SearchArtifactDocument =
+            serde_json::from_str(&expected_text).unwrap_or_else(|error| {
+                panic!("baseline fixture parse failed: {error}\nactual:\n{actual_json}")
+            });
+
+        assert_eq!(
+            actual, expected,
+            "in-memory search artifact fixture drifted"
+        );
+    }
+
+    #[test]
     fn build_with_provider_reuses_cached_vectors_by_model_id_and_content_hash() {
         let first_source = InMemorySourceProvider::new().with_source(source_file(
             "billing.adoc",
@@ -1023,6 +1067,13 @@ mod tests {
             credits_body = credits_body,
             refunds_body = refunds_body
         )
+    }
+
+    fn repo_fixture_path(relative: &str) -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .join("tests/fixtures")
+            .join(relative)
     }
 
     #[derive(Debug)]

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -273,6 +273,7 @@ fn build_artifacts_for_build(
             prior_search_artifact_path.as_ref(),
         ) {
             Ok(search_build) => {
+                artifact_diagnostics.extend(search_build.diagnostics);
                 artifact_diagnostics.push(cache_count_diagnostic(
                     search_build.cached_count,
                     search_build.computed_count,
@@ -311,6 +312,7 @@ fn build_artifacts_for_build(
                 prior_search_artifact_path.as_ref(),
             ) {
                 Ok(search_build) => {
+                    artifact_diagnostics.extend(search_build.diagnostics);
                     artifact_diagnostics.push(cache_count_diagnostic(
                         search_build.cached_count,
                         search_build.computed_count,
@@ -346,6 +348,21 @@ struct SearchArtifactBuild {
     document: SearchArtifactDocument,
     cached_count: usize,
     computed_count: usize,
+    diagnostics: Vec<Diagnostic>,
+}
+
+struct SearchCacheLoad {
+    embeddings: BTreeMap<String, SearchEmbedding>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+impl SearchCacheLoad {
+    fn empty() -> Self {
+        Self {
+            embeddings: BTreeMap::new(),
+            diagnostics: Vec::new(),
+        }
+    }
 }
 
 fn build_search_artifact(
@@ -355,7 +372,8 @@ fn build_search_artifact(
     prior_search_artifact_path: Option<&PathBuf>,
 ) -> Result<SearchArtifactBuild, Vec<Diagnostic>> {
     let model = search_model_header(provider);
-    let cached_embeddings = load_matching_search_cache(prior_search_artifact_path, &model);
+    let cache_load = load_matching_search_cache(prior_search_artifact_path, &model);
+    let cached_embeddings = cache_load.embeddings;
     let agent_artifact_hash = sha256_prefixed(
         agent_json
             .to_pretty_json()
@@ -409,6 +427,7 @@ fn build_search_artifact(
         },
         cached_count,
         computed_count,
+        diagnostics: cache_load.diagnostics,
     })
 }
 
@@ -477,25 +496,49 @@ fn search_model_header(provider: &dyn EmbeddingProvider) -> SearchModelHeader {
 fn load_matching_search_cache(
     path: Option<&PathBuf>,
     model: &SearchModelHeader,
-) -> BTreeMap<String, SearchEmbedding> {
+) -> SearchCacheLoad {
     let Some(path) = path else {
-        return BTreeMap::new();
+        return SearchCacheLoad::empty();
     };
     if !path.exists() {
-        return BTreeMap::new();
+        return SearchCacheLoad::empty();
     }
-    let Ok(document) = read_search_artifact_document(path) else {
-        return BTreeMap::new();
+    let document = match read_search_artifact_document(path) {
+        Ok(document) => document,
+        Err(diagnostics) => {
+            return SearchCacheLoad {
+                embeddings: BTreeMap::new(),
+                diagnostics: diagnostics
+                    .into_iter()
+                    .map(ignored_search_cache_read_diagnostic)
+                    .collect(),
+            };
+        }
     };
     if document.model != *model {
-        return BTreeMap::new();
+        return SearchCacheLoad::empty();
     }
 
-    document
+    let embeddings = document
         .embeddings
         .into_iter()
         .map(|embedding| (embedding.id.clone(), embedding))
-        .collect()
+        .collect();
+    SearchCacheLoad {
+        embeddings,
+        diagnostics: Vec::new(),
+    }
+}
+
+fn ignored_search_cache_read_diagnostic(mut diagnostic: Diagnostic) -> Diagnostic {
+    diagnostic.severity = Severity::Warning;
+    diagnostic.message = format!(
+        "Ignoring prior search artifact cache: {}",
+        diagnostic.message
+    );
+    diagnostic.help =
+        Some("The cache will be recomputed and rewritten if embedding generation succeeds.".into());
+    diagnostic
 }
 
 fn workspace_knowledge_objects(workspace: &WorkspaceAst) -> impl Iterator<Item = &KnowledgeObject> {
@@ -1067,6 +1110,106 @@ mod tests {
     }
 
     #[test]
+    fn build_with_provider_warns_and_recomputes_for_malformed_prior_search_cache() {
+        let source_provider = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require audit review.",
+            ),
+        ));
+        let prior = tempfile::Builder::new()
+            .prefix("adoc-cache-")
+            .suffix(".search.json")
+            .tempfile()
+            .expect("cache file");
+        fs::write(prior.path(), "{not valid json").expect("malformed cache write");
+        let embedding_provider = RecordingEmbeddingProvider::new(4);
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: Some(prior.path().to_path_buf()),
+            },
+        );
+
+        assert!(
+            !result.has_errors(),
+            "malformed prior cache should not fail build: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(
+            embedding_provider.recorded_inputs().len(),
+            2,
+            "malformed cache should be ignored and all objects recomputed"
+        );
+        assert_cache_ignored_diagnostic(
+            &result,
+            DiagnosticCode::IoArtifactMalformed,
+            "Ignoring prior search artifact cache",
+        );
+        assert_cache_count_diagnostic(&result, 0, 2);
+    }
+
+    #[test]
+    fn build_with_provider_warns_and_recomputes_for_unsupported_prior_search_cache_schema() {
+        let source_provider = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require audit review.",
+            ),
+        ));
+        let prior = tempfile::Builder::new()
+            .prefix("adoc-cache-")
+            .suffix(".search.json")
+            .tempfile()
+            .expect("cache file");
+        fs::write(
+            prior.path(),
+            serde_json::json!({
+                "schema_version": "adoc.search.v99",
+                "model": { "id": "recording", "provider": "test", "dim": 4 },
+                "agent_artifact_hash": "sha256:agent",
+                "embeddings": []
+            })
+            .to_string(),
+        )
+        .expect("unsupported schema cache write");
+        let embedding_provider = RecordingEmbeddingProvider::new(4);
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: Some(prior.path().to_path_buf()),
+            },
+        );
+
+        assert!(
+            !result.has_errors(),
+            "unsupported prior cache schema should not fail build: {:?}",
+            result.diagnostics
+        );
+        assert_eq!(
+            embedding_provider.recorded_inputs().len(),
+            2,
+            "unsupported cache should be ignored and all objects recomputed"
+        );
+        assert_cache_ignored_diagnostic(
+            &result,
+            DiagnosticCode::SchemaUnsupportedVersion,
+            "Ignoring prior search artifact cache",
+        );
+        assert_cache_count_diagnostic(&result, 0, 2);
+    }
+
+    #[test]
     fn build_with_provider_maps_embedding_compute_error_and_blocks_artifacts() {
         let source_provider = InMemorySourceProvider::new()
             .with_source(source_file("billing.adoc", &one_claim_source()));
@@ -1199,6 +1342,32 @@ mod tests {
         assert_eq!(
             diagnostic.message,
             format!("embeddings: cached {expected_cached}, computed {expected_computed}")
+        );
+    }
+
+    fn assert_cache_ignored_diagnostic(
+        result: &CompileResult,
+        expected_code: DiagnosticCode,
+        expected_message: &str,
+    ) {
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == expected_code)
+            .expect("cache ignored diagnostic");
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert!(
+            diagnostic.message.contains(expected_message),
+            "message should explain ignored cache: {}",
+            diagnostic.message
+        );
+        assert!(
+            diagnostic
+                .help
+                .as_deref()
+                .expect("help")
+                .contains("recomputed"),
+            "help should explain recompute behavior"
         );
     }
 

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -260,6 +260,7 @@ fn build_artifacts_for_build(
     let prior_search_artifact_path = build_options
         .as_ref()
         .and_then(|options| options.prior_search_artifact_path.clone());
+    let mut artifact_diagnostics = Vec::new();
     let search_json = match build_options
         .as_mut()
         .map(|options| &mut options.embeddings)
@@ -271,7 +272,13 @@ fn build_artifacts_for_build(
             *provider,
             prior_search_artifact_path.as_ref(),
         ) {
-            Ok(search_artifact) => Some(search_artifact),
+            Ok(search_build) => {
+                artifact_diagnostics.push(cache_count_diagnostic(
+                    search_build.cached_count,
+                    search_build.computed_count,
+                ));
+                Some(search_build.document)
+            }
             Err(diagnostics) => {
                 return ArtifactBuildResult {
                     artifacts: Some(BuildArtifacts {
@@ -303,7 +310,13 @@ fn build_artifacts_for_build(
                 provider.as_ref(),
                 prior_search_artifact_path.as_ref(),
             ) {
-                Ok(search_artifact) => Some(search_artifact),
+                Ok(search_build) => {
+                    artifact_diagnostics.push(cache_count_diagnostic(
+                        search_build.cached_count,
+                        search_build.computed_count,
+                    ));
+                    Some(search_build.document)
+                }
                 Err(diagnostics) => {
                     return ArtifactBuildResult {
                         artifacts: Some(BuildArtifacts {
@@ -325,8 +338,14 @@ fn build_artifacts_for_build(
             agent_json,
             search_json,
         }),
-        diagnostics: Vec::new(),
+        diagnostics: artifact_diagnostics,
     }
+}
+
+struct SearchArtifactBuild {
+    document: SearchArtifactDocument,
+    cached_count: usize,
+    computed_count: usize,
 }
 
 fn build_search_artifact(
@@ -334,7 +353,7 @@ fn build_search_artifact(
     agent_json: &AgentJsonDocument,
     provider: &dyn EmbeddingProvider,
     prior_search_artifact_path: Option<&PathBuf>,
-) -> Result<SearchArtifactDocument, Vec<Diagnostic>> {
+) -> Result<SearchArtifactBuild, Vec<Diagnostic>> {
     let model = search_model_header(provider);
     let cached_embeddings = load_matching_search_cache(prior_search_artifact_path, &model);
     let agent_artifact_hash = sha256_prefixed(
@@ -345,6 +364,7 @@ fn build_search_artifact(
     );
     let mut embeddings = Vec::new();
     let mut misses = Vec::new();
+    let mut cached_count = 0;
 
     for knowledge_object in workspace_knowledge_objects(workspace) {
         let input = knowledge_object.embedding_input();
@@ -355,6 +375,7 @@ fn build_search_artifact(
             && cached.vector.len() == provider.dim()
         {
             embeddings.push(cached.clone());
+            cached_count += 1;
             continue;
         }
 
@@ -367,6 +388,7 @@ fn build_search_artifact(
         misses.push((index, input));
     }
 
+    let computed_count = misses.len();
     if !misses.is_empty() {
         let inputs: Vec<String> = misses.iter().map(|(_, input)| input.clone()).collect();
         let vectors = provider
@@ -378,12 +400,23 @@ fn build_search_artifact(
         }
     }
 
-    Ok(SearchArtifactDocument {
-        schema_version: SUPPORTED_SEARCH_SCHEMA_VERSION.to_string(),
-        model,
-        agent_artifact_hash,
-        embeddings,
+    Ok(SearchArtifactBuild {
+        document: SearchArtifactDocument {
+            schema_version: SUPPORTED_SEARCH_SCHEMA_VERSION.to_string(),
+            model,
+            agent_artifact_hash,
+            embeddings,
+        },
+        cached_count,
+        computed_count,
     })
+}
+
+fn cache_count_diagnostic(cached_count: usize, computed_count: usize) -> Diagnostic {
+    Diagnostic::info(
+        DiagnosticCode::BuildEmbeddingsCached,
+        format!("embeddings: cached {cached_count}, computed {computed_count}"),
+    )
 }
 
 fn validate_embedding_vectors(
@@ -937,8 +970,10 @@ mod tests {
         );
         let second_search = second_result
             .artifacts
+            .as_ref()
             .expect("second artifacts")
             .search_json
+            .as_ref()
             .expect("second search artifact");
         let recorded_inputs = second_provider.recorded_inputs();
         assert_eq!(
@@ -960,6 +995,75 @@ mod tests {
             second_search.embeddings[1].vector, first_search.embeddings[1].vector,
             "changed object vector should be recomputed"
         );
+        assert_cache_count_diagnostic(&second_result, 1, 1);
+    }
+
+    #[test]
+    fn build_with_provider_reports_all_cached_vectors_when_sources_are_unchanged() {
+        let first_source = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require audit review.",
+            ),
+        ));
+        let first_provider = RecordingEmbeddingProvider::new(4);
+        let first_result = build_with_provider(
+            &first_source,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &first_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+        let first_search = first_result
+            .artifacts
+            .expect("first artifacts")
+            .search_json
+            .expect("first search artifact");
+        let prior = tempfile::Builder::new()
+            .prefix("adoc-cache-")
+            .suffix(".search.json")
+            .tempfile()
+            .expect("cache file");
+        fs::write(
+            prior.path(),
+            first_search
+                .to_pretty_json()
+                .expect("search artifact serializes"),
+        )
+        .expect("cache write");
+
+        let second_source = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require audit review.",
+            ),
+        ));
+        let second_provider = RecordingEmbeddingProvider::new(4);
+
+        let second_result = build_with_provider(
+            &second_source,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &second_provider,
+                },
+                prior_search_artifact_path: Some(prior.path().to_path_buf()),
+            },
+        );
+
+        assert!(
+            !second_result.has_errors(),
+            "second build should pass: {:?}",
+            second_result.diagnostics
+        );
+        assert!(
+            second_provider.recorded_inputs().is_empty(),
+            "unchanged objects should be served entirely from cache"
+        );
+        assert_cache_count_diagnostic(&second_result, 2, 0);
     }
 
     #[test]
@@ -1079,6 +1183,23 @@ mod tests {
             .find(|diagnostic| diagnostic.code == expected_code)
             .expect("expected embedding diagnostic");
         assert_eq!(diagnostic.severity, Severity::Error);
+    }
+
+    fn assert_cache_count_diagnostic(
+        result: &CompileResult,
+        expected_cached: usize,
+        expected_computed: usize,
+    ) {
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::BuildEmbeddingsCached)
+            .expect("cache count diagnostic");
+        assert_eq!(diagnostic.severity, Severity::Info);
+        assert_eq!(
+            diagnostic.message,
+            format!("embeddings: cached {expected_cached}, computed {expected_computed}")
+        );
     }
 
     fn one_claim_source() -> String {

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -14,7 +14,7 @@ use crate::domain::ast::{BlockAst, PageAst, WorkspaceAst};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 use crate::domain::knowledge_object::KnowledgeObject;
 use crate::domain::ports::artifact_writer::ArtifactWriter;
-use crate::domain::ports::embedding_provider::EmbeddingProvider;
+use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider};
 use crate::domain::ports::renderer::Renderer;
 use crate::domain::ports::source_provider::{SourceLoadError, SourceLoadErrorKind, SourceProvider};
 use crate::domain::source::SourceFile;
@@ -259,12 +259,20 @@ fn build_artifacts_for_build(
 
     let agent_json = AgentJsonArtifact.build(&workspace.pages, diagnostics);
     let search_json = match build_options.map(|options| options.embeddings) {
-        Some(BuildEmbeddingBehavior::Enabled { provider }) => Some(build_search_artifact(
+        Some(BuildEmbeddingBehavior::Enabled { provider }) => match build_search_artifact(
             workspace,
             &agent_json,
             provider,
             build_options.and_then(|options| options.prior_search_artifact_path.as_ref()),
-        )),
+        ) {
+            Ok(search_artifact) => Some(search_artifact),
+            Err(diagnostics) => {
+                return ArtifactBuildResult {
+                    artifacts: None,
+                    diagnostics,
+                };
+            }
+        },
         Some(BuildEmbeddingBehavior::Skipped) | None => None,
     };
 
@@ -283,7 +291,7 @@ fn build_search_artifact(
     agent_json: &AgentJsonDocument,
     provider: &dyn EmbeddingProvider,
     prior_search_artifact_path: Option<&PathBuf>,
-) -> SearchArtifactDocument {
+) -> Result<SearchArtifactDocument, Vec<Diagnostic>> {
     let model = search_model_header(provider);
     let cached_embeddings = load_matching_search_cache(prior_search_artifact_path, &model);
     let agent_artifact_hash = sha256_prefixed(
@@ -320,22 +328,65 @@ fn build_search_artifact(
         let inputs: Vec<String> = misses.iter().map(|(_, input)| input.clone()).collect();
         let vectors = provider
             .embed_passages(&inputs)
-            .expect("embedding diagnostics are mapped in a later tracer");
-        assert_eq!(
-            vectors.len(),
-            misses.len(),
-            "embedding provider returned an unexpected vector count"
-        );
+            .map_err(|error| vec![embedding_error_diagnostic(error)])?;
+        validate_embedding_vectors(&vectors, misses.len(), provider.dim())?;
         for ((index, _), vector) in misses.into_iter().zip(vectors) {
             embeddings[index].vector = vector;
         }
     }
 
-    SearchArtifactDocument {
+    Ok(SearchArtifactDocument {
         schema_version: SUPPORTED_SEARCH_SCHEMA_VERSION.to_string(),
         model,
         agent_artifact_hash,
         embeddings,
+    })
+}
+
+fn validate_embedding_vectors(
+    vectors: &[Vec<f32>],
+    expected_count: usize,
+    expected_dim: usize,
+) -> Result<(), Vec<Diagnostic>> {
+    if vectors.len() != expected_count {
+        return Err(vec![Diagnostic::error(
+            DiagnosticCode::EmbedUnexpectedDimension,
+            format!(
+                "embedding provider returned {} vectors for {expected_count} inputs",
+                vectors.len()
+            ),
+        )]);
+    }
+
+    for (index, vector) in vectors.iter().enumerate() {
+        if vector.len() != expected_dim {
+            return Err(vec![Diagnostic::error(
+                DiagnosticCode::EmbedUnexpectedDimension,
+                format!(
+                    "embedding provider returned vector {index} with dimension {}; expected {expected_dim}",
+                    vector.len()
+                ),
+            )]);
+        }
+    }
+
+    Ok(())
+}
+
+fn embedding_error_diagnostic(error: EmbeddingError) -> Diagnostic {
+    match error {
+        EmbeddingError::ModelLoad(message) => Diagnostic::error(
+            DiagnosticCode::EmbedModelLoadFailed,
+            format!("embedding model could not be loaded: {message}"),
+        ),
+        EmbeddingError::Compute(message) => Diagnostic::error(
+            DiagnosticCode::EmbedComputeFailed,
+            format!("embedding computation failed: {message}"),
+        ),
+        EmbeddingError::DimensionMismatch { expected, actual } => Diagnostic::error(
+            DiagnosticCode::EmbedUnexpectedDimension,
+            format!("embedding provider returned dimension {actual}; expected {expected}"),
+        ),
     }
 }
 
@@ -824,6 +875,134 @@ mod tests {
         );
     }
 
+    #[test]
+    fn build_with_provider_maps_embedding_compute_error_and_blocks_artifacts() {
+        let source_provider = InMemorySourceProvider::new()
+            .with_source(source_file("billing.adoc", &one_claim_source()));
+        let embedding_provider = ControlledEmbeddingProvider::new(
+            4,
+            Err(EmbeddingError::Compute("encoder failed".to_string())),
+        );
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert_embedding_error_result(&result, DiagnosticCode::EmbedComputeFailed);
+    }
+
+    #[test]
+    fn build_with_provider_maps_embedding_model_load_error_and_blocks_artifacts() {
+        let source_provider = InMemorySourceProvider::new()
+            .with_source(source_file("billing.adoc", &one_claim_source()));
+        let embedding_provider = ControlledEmbeddingProvider::new(
+            4,
+            Err(EmbeddingError::ModelLoad(
+                "model cache unavailable".to_string(),
+            )),
+        );
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert_embedding_error_result(&result, DiagnosticCode::EmbedModelLoadFailed);
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::EmbedModelLoadFailed)
+            .expect("model load diagnostic");
+        assert!(
+            diagnostic
+                .help
+                .as_deref()
+                .expect("help")
+                .contains("adoc build"),
+            "model load help should tell user how to retry/fix"
+        );
+    }
+
+    #[test]
+    fn build_with_provider_rejects_wrong_embedding_vector_count_and_blocks_artifacts() {
+        let source_provider = InMemorySourceProvider::new()
+            .with_source(source_file("billing.adoc", &one_claim_source()));
+        let embedding_provider = ControlledEmbeddingProvider::new(4, Ok(Vec::new()));
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert_embedding_error_result(&result, DiagnosticCode::EmbedUnexpectedDimension);
+    }
+
+    #[test]
+    fn build_with_provider_rejects_bad_embedding_vector_dim_and_blocks_artifacts() {
+        let source_provider = InMemorySourceProvider::new()
+            .with_source(source_file("billing.adoc", &one_claim_source()));
+        let embedding_provider = ControlledEmbeddingProvider::new(4, Ok(vec![vec![1.0, 2.0, 3.0]]));
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert_embedding_error_result(&result, DiagnosticCode::EmbedUnexpectedDimension);
+    }
+
+    fn assert_embedding_error_result(result: &CompileResult, expected_code: DiagnosticCode) {
+        assert!(
+            result.has_errors(),
+            "build should fail: {:?}",
+            result.diagnostics
+        );
+        assert!(
+            result.artifacts.is_none(),
+            "embedding failures must block all artifacts"
+        );
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == expected_code)
+            .expect("expected embedding diagnostic");
+        assert_eq!(diagnostic.severity, Severity::Error);
+    }
+
+    fn one_claim_source() -> String {
+        concat!(
+            "# Billing @doc(team.billing)\n",
+            "\n",
+            "::claim billing.credits\n",
+            "status: draft\n",
+            "--\n",
+            "Credits apply after successful payment.\n",
+            "::\n",
+        )
+        .to_string()
+    }
+
     fn two_claim_source(credits_body: &str, refunds_body: &str) -> String {
         format!(
             concat!(
@@ -844,6 +1023,41 @@ mod tests {
             credits_body = credits_body,
             refunds_body = refunds_body
         )
+    }
+
+    #[derive(Debug)]
+    struct ControlledEmbeddingProvider {
+        model_id: ModelId,
+        dim: usize,
+        result: Result<Vec<Vec<f32>>, EmbeddingError>,
+    }
+
+    impl ControlledEmbeddingProvider {
+        fn new(dim: usize, result: Result<Vec<Vec<f32>>, EmbeddingError>) -> Self {
+            Self {
+                model_id: ModelId::new("controlled", "test"),
+                dim,
+                result,
+            }
+        }
+    }
+
+    impl EmbeddingProvider for ControlledEmbeddingProvider {
+        fn model_id(&self) -> &ModelId {
+            &self.model_id
+        }
+
+        fn dim(&self) -> usize {
+            self.dim
+        }
+
+        fn embed_passages(&self, _inputs: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+            self.result.clone()
+        }
+
+        fn embed_query(&self, _query: &str) -> Result<Vec<f32>, EmbeddingError> {
+            Ok(vec![0.0; self.dim])
+        }
     }
 
     #[derive(Debug)]

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -274,10 +274,12 @@ fn build_artifacts_for_build(
         ) {
             Ok(search_build) => {
                 artifact_diagnostics.extend(search_build.diagnostics);
-                artifact_diagnostics.push(cache_count_diagnostic(
-                    search_build.cached_count,
-                    search_build.computed_count,
-                ));
+                if search_build.cached_count != 0 || search_build.computed_count != 0 {
+                    artifact_diagnostics.push(cache_count_diagnostic(
+                        search_build.cached_count,
+                        search_build.computed_count,
+                    ));
+                }
                 Some(search_build.document)
             }
             Err(diagnostics) => {
@@ -313,10 +315,12 @@ fn build_artifacts_for_build(
             ) {
                 Ok(search_build) => {
                     artifact_diagnostics.extend(search_build.diagnostics);
-                    artifact_diagnostics.push(cache_count_diagnostic(
-                        search_build.cached_count,
-                        search_build.computed_count,
-                    ));
+                    if search_build.cached_count != 0 || search_build.computed_count != 0 {
+                        artifact_diagnostics.push(cache_count_diagnostic(
+                            search_build.cached_count,
+                            search_build.computed_count,
+                        ));
+                    }
                     Some(search_build.document)
                 }
                 Err(diagnostics) => {
@@ -978,6 +982,44 @@ mod tests {
     }
 
     #[test]
+    fn build_with_provider_omits_cache_count_diagnostic_when_no_knowledge_objects() {
+        let source_provider = InMemorySourceProvider::new().with_source(source_file(
+            "guide.adoc",
+            "# Guide @doc(team.guide)\n\nProse without Knowledge Objects.\n",
+        ));
+        let embedding_provider = RecordingEmbeddingProvider::new(4);
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert!(
+            !result.has_errors(),
+            "build should pass: {:?}",
+            result.diagnostics
+        );
+        assert!(
+            embedding_provider.recorded_inputs().is_empty(),
+            "no Knowledge Objects should skip provider computation"
+        );
+        let search = result
+            .artifacts
+            .as_ref()
+            .expect("artifacts are built")
+            .search_json
+            .as_ref()
+            .expect("search artifact is built");
+        assert!(search.embeddings.is_empty());
+        assert_no_cache_count_diagnostic(&result);
+    }
+
+    #[test]
     fn build_with_provider_reuses_cached_vectors_by_model_id_and_content_hash() {
         let first_source = InMemorySourceProvider::new().with_source(source_file(
             "billing.adoc",
@@ -1445,6 +1487,17 @@ mod tests {
         assert_eq!(
             diagnostic.message,
             format!("embeddings: cached {expected_cached}, computed {expected_computed}")
+        );
+    }
+
+    fn assert_no_cache_count_diagnostic(result: &CompileResult) {
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .all(|diagnostic| diagnostic.code != DiagnosticCode::BuildEmbeddingsCached),
+            "cache count diagnostic should be omitted: {:?}",
+            result.diagnostics
         );
     }
 

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -1,7 +1,7 @@
 use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::fmt::Write as _;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::application::resolve_knowledge_objects::{
     resolve_knowledge_objects, suppress_unknown_kind_shape_diagnostics,
@@ -516,7 +516,14 @@ fn load_matching_search_cache(
         }
     };
     if document.model != *model {
-        return SearchCacheLoad::empty();
+        return SearchCacheLoad {
+            embeddings: BTreeMap::new(),
+            diagnostics: vec![ignored_search_cache_model_diagnostic(
+                path,
+                &document.model,
+                model,
+            )],
+        };
     }
 
     let embeddings = document
@@ -539,6 +546,27 @@ fn ignored_search_cache_read_diagnostic(mut diagnostic: Diagnostic) -> Diagnosti
     diagnostic.help =
         Some("The cache will be recomputed and rewritten if embedding generation succeeds.".into());
     diagnostic
+}
+
+fn ignored_search_cache_model_diagnostic(
+    path: &Path,
+    cached_model: &SearchModelHeader,
+    current_model: &SearchModelHeader,
+) -> Diagnostic {
+    Diagnostic::warning(
+        DiagnosticCode::BuildEmbeddingsCacheIgnored,
+        format!(
+            "Ignoring prior search artifact cache '{}': cache model {} differs from current model {}.",
+            path.display(),
+            format_search_model(cached_model),
+            format_search_model(current_model)
+        ),
+    )
+    .with_help("The cache will be recomputed and rewritten if embedding generation succeeds.")
+}
+
+fn format_search_model(model: &SearchModelHeader) -> String {
+    format!("{}:{}:{}", model.provider, model.id, model.dim)
 }
 
 fn workspace_knowledge_objects(workspace: &WorkspaceAst) -> impl Iterator<Item = &KnowledgeObject> {
@@ -1207,6 +1235,73 @@ mod tests {
             "Ignoring prior search artifact cache",
         );
         assert_cache_count_diagnostic(&result, 0, 2);
+    }
+
+    #[test]
+    fn build_with_provider_warns_and_recomputes_for_prior_search_cache_model_mismatch() {
+        let source_provider = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require audit review.",
+            ),
+        ));
+        let first_provider = RecordingEmbeddingProvider::new(4);
+        let first_result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &first_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+        let mut prior_search = first_result
+            .artifacts
+            .expect("first artifacts")
+            .search_json
+            .expect("first search artifact");
+        prior_search.model.id = "other-model".to_string();
+        let prior = tempfile::Builder::new()
+            .prefix("adoc-cache-")
+            .suffix(".search.json")
+            .tempfile()
+            .expect("cache file");
+        fs::write(
+            prior.path(),
+            prior_search
+                .to_pretty_json()
+                .expect("search artifact serializes"),
+        )
+        .expect("mismatched cache write");
+        let second_provider = RecordingEmbeddingProvider::new(4);
+
+        let second_result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &second_provider,
+                },
+                prior_search_artifact_path: Some(prior.path().to_path_buf()),
+            },
+        );
+
+        assert!(
+            !second_result.has_errors(),
+            "model-mismatched prior cache should not fail build: {:?}",
+            second_result.diagnostics
+        );
+        assert_eq!(
+            second_provider.recorded_inputs().len(),
+            2,
+            "model-mismatched cache should be ignored and all objects recomputed"
+        );
+        assert_cache_ignored_diagnostic(
+            &second_result,
+            DiagnosticCode::BuildEmbeddingsCacheIgnored,
+            "Ignoring prior search artifact cache",
+        );
+        assert_cache_count_diagnostic(&second_result, 0, 2);
     }
 
     #[test]

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -5,7 +5,7 @@ use crate::application::resolve_knowledge_objects::{
     resolve_knowledge_objects, suppress_unknown_kind_shape_diagnostics,
 };
 use crate::application::resolve_object_references::resolve_object_references;
-use crate::domain::artifact::AgentJsonDocument;
+use crate::domain::artifact::{AgentJsonDocument, SearchArtifactDocument};
 use crate::domain::ast::{PageAst, WorkspaceAst};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 use crate::domain::ports::artifact_writer::ArtifactWriter;
@@ -27,6 +27,24 @@ pub struct CompileInput {
 }
 
 #[derive(Debug, Clone)]
+pub struct BuildInput {
+    /// Input path for compilation: either one `.adoc` file or a directory that
+    /// will be scanned recursively for `.adoc` files.
+    pub root: PathBuf,
+    /// Build-time embedding behavior. `adoc check` never uses this path.
+    pub embeddings: BuildEmbeddingMode,
+    /// Existing `docs.search.json` from the output directory, used by later
+    /// embedding slices for vector reuse.
+    pub prior_search_artifact_path: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BuildEmbeddingMode {
+    Enabled,
+    Skipped,
+}
+
+#[derive(Debug, Clone)]
 pub struct CompileResult {
     pub diagnostics: Vec<Diagnostic>,
     pub artifacts: Option<BuildArtifacts>,
@@ -44,9 +62,30 @@ impl CompileResult {
 pub struct BuildArtifacts {
     pub html: String,
     pub agent_json: AgentJsonDocument,
+    pub search_json: Option<SearchArtifactDocument>,
 }
 
 pub(crate) fn compile_with_provider<P: SourceProvider>(provider: &P) -> CompileResult {
+    run_compile_pipeline(provider, None)
+}
+
+pub(crate) fn build_with_provider<P: SourceProvider>(
+    provider: &P,
+    options: BuildOptions,
+) -> CompileResult {
+    run_compile_pipeline(provider, Some(options))
+}
+
+#[derive(Debug, Clone)]
+pub(crate) struct BuildOptions {
+    pub(crate) embeddings: BuildEmbeddingMode,
+    pub(crate) prior_search_artifact_path: Option<PathBuf>,
+}
+
+fn run_compile_pipeline<P: SourceProvider>(
+    provider: &P,
+    build_options: Option<BuildOptions>,
+) -> CompileResult {
     // Pipeline stages: load → validate-source-pages → resolve-KOs →
     // resolve-object-references → validate-resolved-pages → assemble →
     // validate-workspace → build. Each stage is a separate function below so
@@ -65,11 +104,25 @@ pub(crate) fn compile_with_provider<P: SourceProvider>(provider: &P) -> CompileR
     diagnostics.extend(validate_resolved_pages(&parsed));
     let workspace = assemble_workspace(parsed);
     diagnostics.extend(validate_workspace(&workspace));
+    if let Some(options) = build_options {
+        diagnostics.extend(build_embedding_diagnostics(&options));
+    }
     sort_diagnostics_by_source(&mut diagnostics);
     let artifacts = build_artifacts(&workspace, &diagnostics);
     CompileResult {
         diagnostics,
         artifacts,
+    }
+}
+
+fn build_embedding_diagnostics(options: &BuildOptions) -> Vec<Diagnostic> {
+    let _prior_search_artifact_path = &options.prior_search_artifact_path;
+    match options.embeddings {
+        BuildEmbeddingMode::Enabled => Vec::new(),
+        BuildEmbeddingMode::Skipped => vec![Diagnostic::info(
+            DiagnosticCode::BuildEmbeddingsSkipped,
+            "Embedding generation skipped; docs.search.json was not written.",
+        )],
     }
 }
 
@@ -159,6 +212,7 @@ fn build_artifacts(workspace: &WorkspaceAst, diagnostics: &[Diagnostic]) -> Opti
         .then(|| BuildArtifacts {
             html: HtmlRenderer.render(&workspace.pages),
             agent_json: AgentJsonArtifact.build(&workspace.pages, diagnostics),
+            search_json: None,
         })
 }
 

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -86,21 +86,25 @@ pub(crate) fn build_with_provider<P: SourceProvider>(
     run_compile_pipeline(provider, Some(options))
 }
 
-#[derive(Clone)]
 pub(crate) struct BuildOptions<'a> {
     pub(crate) embeddings: BuildEmbeddingBehavior<'a>,
     pub(crate) prior_search_artifact_path: Option<PathBuf>,
 }
 
-#[derive(Clone, Copy)]
 pub(crate) enum BuildEmbeddingBehavior<'a> {
-    Enabled { provider: &'a dyn EmbeddingProvider },
+    #[cfg(test)]
+    Enabled {
+        provider: &'a dyn EmbeddingProvider,
+    },
+    EnabledFactory {
+        provider_factory: &'a mut dyn FnMut() -> Result<Box<dyn EmbeddingProvider>, EmbeddingError>,
+    },
     Skipped,
 }
 
 fn run_compile_pipeline<P: SourceProvider>(
     provider: &P,
-    build_options: Option<BuildOptions<'_>>,
+    mut build_options: Option<BuildOptions<'_>>,
 ) -> CompileResult {
     // Pipeline stages: load → validate-source-pages → resolve-KOs →
     // resolve-object-references → validate-resolved-pages → assemble →
@@ -124,7 +128,7 @@ fn run_compile_pipeline<P: SourceProvider>(
         diagnostics.extend(build_embedding_diagnostics(options));
     }
     let artifact_result =
-        build_artifacts_for_build(&workspace, &diagnostics, build_options.as_ref());
+        build_artifacts_for_build(&workspace, &diagnostics, build_options.as_mut());
     let artifacts = if artifact_result
         .diagnostics
         .iter()
@@ -145,7 +149,9 @@ fn run_compile_pipeline<P: SourceProvider>(
 fn build_embedding_diagnostics(options: &BuildOptions<'_>) -> Vec<Diagnostic> {
     let _prior_search_artifact_path = &options.prior_search_artifact_path;
     match options.embeddings {
+        #[cfg(test)]
         BuildEmbeddingBehavior::Enabled { .. } => Vec::new(),
+        BuildEmbeddingBehavior::EnabledFactory { .. } => Vec::new(),
         BuildEmbeddingBehavior::Skipped => vec![Diagnostic::info(
             DiagnosticCode::BuildEmbeddingsSkipped,
             "Embedding generation skipped; docs.search.json was not written.",
@@ -245,7 +251,7 @@ struct ArtifactBuildResult {
 fn build_artifacts_for_build(
     workspace: &WorkspaceAst,
     diagnostics: &[Diagnostic],
-    build_options: Option<&BuildOptions<'_>>,
+    mut build_options: Option<&mut BuildOptions<'_>>,
 ) -> ArtifactBuildResult {
     if diagnostics
         .iter()
@@ -258,12 +264,19 @@ fn build_artifacts_for_build(
     }
 
     let agent_json = AgentJsonArtifact.build(&workspace.pages, diagnostics);
-    let search_json = match build_options.map(|options| options.embeddings) {
+    let prior_search_artifact_path = build_options
+        .as_ref()
+        .and_then(|options| options.prior_search_artifact_path.clone());
+    let search_json = match build_options
+        .as_mut()
+        .map(|options| &mut options.embeddings)
+    {
+        #[cfg(test)]
         Some(BuildEmbeddingBehavior::Enabled { provider }) => match build_search_artifact(
             workspace,
             &agent_json,
-            provider,
-            build_options.and_then(|options| options.prior_search_artifact_path.as_ref()),
+            *provider,
+            prior_search_artifact_path.as_ref(),
         ) {
             Ok(search_artifact) => Some(search_artifact),
             Err(diagnostics) => {
@@ -273,6 +286,31 @@ fn build_artifacts_for_build(
                 };
             }
         },
+        Some(BuildEmbeddingBehavior::EnabledFactory { provider_factory }) => {
+            let provider = match provider_factory() {
+                Ok(provider) => provider,
+                Err(error) => {
+                    return ArtifactBuildResult {
+                        artifacts: None,
+                        diagnostics: vec![embedding_error_diagnostic(error)],
+                    };
+                }
+            };
+            match build_search_artifact(
+                workspace,
+                &agent_json,
+                provider.as_ref(),
+                prior_search_artifact_path.as_ref(),
+            ) {
+                Ok(search_artifact) => Some(search_artifact),
+                Err(diagnostics) => {
+                    return ArtifactBuildResult {
+                        artifacts: None,
+                        diagnostics,
+                    };
+                }
+            }
+        }
         Some(BuildEmbeddingBehavior::Skipped) | None => None,
     };
 

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -373,7 +373,7 @@ fn validate_embedding_vectors(
     Ok(())
 }
 
-fn embedding_error_diagnostic(error: EmbeddingError) -> Diagnostic {
+pub(crate) fn embedding_error_diagnostic(error: EmbeddingError) -> Diagnostic {
     match error {
         EmbeddingError::ModelLoad(message) => Diagnostic::error(
             DiagnosticCode::EmbedModelLoadFailed,

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -1,23 +1,33 @@
 use std::cmp::Ordering;
+use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::path::PathBuf;
 
 use crate::application::resolve_knowledge_objects::{
     resolve_knowledge_objects, suppress_unknown_kind_shape_diagnostics,
 };
 use crate::application::resolve_object_references::resolve_object_references;
-use crate::domain::artifact::{AgentJsonDocument, SearchArtifactDocument};
-use crate::domain::ast::{PageAst, WorkspaceAst};
+use crate::domain::artifact::{
+    AgentJsonDocument, SearchArtifactDocument, SearchEmbedding, SearchModelHeader,
+};
+use crate::domain::ast::{BlockAst, PageAst, WorkspaceAst};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
+use crate::domain::knowledge_object::KnowledgeObject;
 use crate::domain::ports::artifact_writer::ArtifactWriter;
+use crate::domain::ports::embedding_provider::EmbeddingProvider;
 use crate::domain::ports::renderer::Renderer;
 use crate::domain::ports::source_provider::{SourceLoadError, SourceLoadErrorKind, SourceProvider};
 use crate::domain::source::SourceFile;
 use crate::infrastructure::artifact::AgentJsonArtifact;
+use crate::infrastructure::artifact::search_json::{
+    SUPPORTED_SEARCH_SCHEMA_VERSION, read_search_artifact_document,
+};
 use crate::infrastructure::parser::parse_page;
 use crate::infrastructure::render::HtmlRenderer;
 use crate::infrastructure::validate::{
     validate_resolved_page, validate_source_page, validate_workspace,
 };
+use sha2::{Digest, Sha256};
 
 #[derive(Debug, Clone)]
 pub struct CompileInput {
@@ -71,20 +81,26 @@ pub(crate) fn compile_with_provider<P: SourceProvider>(provider: &P) -> CompileR
 
 pub(crate) fn build_with_provider<P: SourceProvider>(
     provider: &P,
-    options: BuildOptions,
+    options: BuildOptions<'_>,
 ) -> CompileResult {
     run_compile_pipeline(provider, Some(options))
 }
 
-#[derive(Debug, Clone)]
-pub(crate) struct BuildOptions {
-    pub(crate) embeddings: BuildEmbeddingMode,
+#[derive(Clone)]
+pub(crate) struct BuildOptions<'a> {
+    pub(crate) embeddings: BuildEmbeddingBehavior<'a>,
     pub(crate) prior_search_artifact_path: Option<PathBuf>,
+}
+
+#[derive(Clone, Copy)]
+pub(crate) enum BuildEmbeddingBehavior<'a> {
+    Enabled { provider: &'a dyn EmbeddingProvider },
+    Skipped,
 }
 
 fn run_compile_pipeline<P: SourceProvider>(
     provider: &P,
-    build_options: Option<BuildOptions>,
+    build_options: Option<BuildOptions<'_>>,
 ) -> CompileResult {
     // Pipeline stages: load → validate-source-pages → resolve-KOs →
     // resolve-object-references → validate-resolved-pages → assemble →
@@ -104,22 +120,33 @@ fn run_compile_pipeline<P: SourceProvider>(
     diagnostics.extend(validate_resolved_pages(&parsed));
     let workspace = assemble_workspace(parsed);
     diagnostics.extend(validate_workspace(&workspace));
-    if let Some(options) = build_options {
-        diagnostics.extend(build_embedding_diagnostics(&options));
+    if let Some(options) = &build_options {
+        diagnostics.extend(build_embedding_diagnostics(options));
     }
+    let artifact_result =
+        build_artifacts_for_build(&workspace, &diagnostics, build_options.as_ref());
+    let artifacts = if artifact_result
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == Severity::Error)
+    {
+        None
+    } else {
+        artifact_result.artifacts
+    };
+    diagnostics.extend(artifact_result.diagnostics);
     sort_diagnostics_by_source(&mut diagnostics);
-    let artifacts = build_artifacts(&workspace, &diagnostics);
     CompileResult {
         diagnostics,
         artifacts,
     }
 }
 
-fn build_embedding_diagnostics(options: &BuildOptions) -> Vec<Diagnostic> {
+fn build_embedding_diagnostics(options: &BuildOptions<'_>) -> Vec<Diagnostic> {
     let _prior_search_artifact_path = &options.prior_search_artifact_path;
     match options.embeddings {
-        BuildEmbeddingMode::Enabled => Vec::new(),
-        BuildEmbeddingMode::Skipped => vec![Diagnostic::info(
+        BuildEmbeddingBehavior::Enabled { .. } => Vec::new(),
+        BuildEmbeddingBehavior::Skipped => vec![Diagnostic::info(
             DiagnosticCode::BuildEmbeddingsSkipped,
             "Embedding generation skipped; docs.search.json was not written.",
         )],
@@ -205,15 +232,167 @@ fn assemble_workspace(parsed: Vec<(SourceFile, PageAst)>) -> WorkspaceAst {
 /// Gate artifacts on diagnostic severity: produce an HTML + agent JSON pair
 /// only when no diagnostic has `Severity::Error`. Renderer and ArtifactWriter
 /// ports are statically dispatched per ADR-0006.
+#[cfg(test)]
 fn build_artifacts(workspace: &WorkspaceAst, diagnostics: &[Diagnostic]) -> Option<BuildArtifacts> {
-    diagnostics
+    build_artifacts_for_build(workspace, diagnostics, None).artifacts
+}
+
+struct ArtifactBuildResult {
+    artifacts: Option<BuildArtifacts>,
+    diagnostics: Vec<Diagnostic>,
+}
+
+fn build_artifacts_for_build(
+    workspace: &WorkspaceAst,
+    diagnostics: &[Diagnostic],
+    build_options: Option<&BuildOptions<'_>>,
+) -> ArtifactBuildResult {
+    if diagnostics
         .iter()
-        .all(|diagnostic| diagnostic.severity != Severity::Error)
-        .then(|| BuildArtifacts {
+        .any(|diagnostic| diagnostic.severity == Severity::Error)
+    {
+        return ArtifactBuildResult {
+            artifacts: None,
+            diagnostics: Vec::new(),
+        };
+    }
+
+    let agent_json = AgentJsonArtifact.build(&workspace.pages, diagnostics);
+    let search_json = match build_options.map(|options| options.embeddings) {
+        Some(BuildEmbeddingBehavior::Enabled { provider }) => Some(build_search_artifact(
+            workspace,
+            &agent_json,
+            provider,
+            build_options.and_then(|options| options.prior_search_artifact_path.as_ref()),
+        )),
+        Some(BuildEmbeddingBehavior::Skipped) | None => None,
+    };
+
+    ArtifactBuildResult {
+        artifacts: Some(BuildArtifacts {
             html: HtmlRenderer.render(&workspace.pages),
-            agent_json: AgentJsonArtifact.build(&workspace.pages, diagnostics),
-            search_json: None,
+            agent_json,
+            search_json,
+        }),
+        diagnostics: Vec::new(),
+    }
+}
+
+fn build_search_artifact(
+    workspace: &WorkspaceAst,
+    agent_json: &AgentJsonDocument,
+    provider: &dyn EmbeddingProvider,
+    prior_search_artifact_path: Option<&PathBuf>,
+) -> SearchArtifactDocument {
+    let model = search_model_header(provider);
+    let cached_embeddings = load_matching_search_cache(prior_search_artifact_path, &model);
+    let agent_artifact_hash = sha256_prefixed(
+        agent_json
+            .to_pretty_json()
+            .expect("agent artifact serialization should not fail")
+            .as_bytes(),
+    );
+    let mut embeddings = Vec::new();
+    let mut misses = Vec::new();
+
+    for knowledge_object in workspace_knowledge_objects(workspace) {
+        let input = knowledge_object.embedding_input();
+        let content_hash = sha256_prefixed(input.as_bytes());
+        let id = knowledge_object.id().as_str().to_string();
+        if let Some(cached) = cached_embeddings.get(&id)
+            && cached.content_hash == content_hash
+            && cached.vector.len() == provider.dim()
+        {
+            embeddings.push(cached.clone());
+            continue;
+        }
+
+        let index = embeddings.len();
+        embeddings.push(SearchEmbedding {
+            id,
+            content_hash,
+            vector: Vec::new(),
+        });
+        misses.push((index, input));
+    }
+
+    if !misses.is_empty() {
+        let inputs: Vec<String> = misses.iter().map(|(_, input)| input.clone()).collect();
+        let vectors = provider
+            .embed_passages(&inputs)
+            .expect("embedding diagnostics are mapped in a later tracer");
+        assert_eq!(
+            vectors.len(),
+            misses.len(),
+            "embedding provider returned an unexpected vector count"
+        );
+        for ((index, _), vector) in misses.into_iter().zip(vectors) {
+            embeddings[index].vector = vector;
+        }
+    }
+
+    SearchArtifactDocument {
+        schema_version: SUPPORTED_SEARCH_SCHEMA_VERSION.to_string(),
+        model,
+        agent_artifact_hash,
+        embeddings,
+    }
+}
+
+fn search_model_header(provider: &dyn EmbeddingProvider) -> SearchModelHeader {
+    SearchModelHeader {
+        id: provider.model_id().id.clone(),
+        provider: provider.model_id().provider.clone(),
+        dim: provider.dim(),
+    }
+}
+
+fn load_matching_search_cache(
+    path: Option<&PathBuf>,
+    model: &SearchModelHeader,
+) -> BTreeMap<String, SearchEmbedding> {
+    let Some(path) = path else {
+        return BTreeMap::new();
+    };
+    if !path.exists() {
+        return BTreeMap::new();
+    }
+    let Ok(document) = read_search_artifact_document(path) else {
+        return BTreeMap::new();
+    };
+    if document.model != *model {
+        return BTreeMap::new();
+    }
+
+    document
+        .embeddings
+        .into_iter()
+        .map(|embedding| (embedding.id.clone(), embedding))
+        .collect()
+}
+
+fn workspace_knowledge_objects(workspace: &WorkspaceAst) -> impl Iterator<Item = &KnowledgeObject> {
+    workspace
+        .pages
+        .iter()
+        .flat_map(|page| page.blocks.iter())
+        .filter_map(|block| match block {
+            BlockAst::KnowledgeObject(knowledge_object) => Some(knowledge_object.as_ref()),
+            BlockAst::KnowledgeObjectPending(_) => unreachable!(
+                "resolver must replace pending knowledge objects before artifact emission"
+            ),
+            _ => None,
         })
+}
+
+fn sha256_prefixed(bytes: &[u8]) -> String {
+    let digest = Sha256::digest(bytes);
+    let mut output = String::with_capacity("sha256:".len() + digest.len() * 2);
+    output.push_str("sha256:");
+    for byte in digest {
+        write!(&mut output, "{byte:02x}").expect("writing to String cannot fail");
+    }
+    output
 }
 
 fn sort_diagnostics_by_source(diagnostics: &mut [Diagnostic]) {
@@ -233,8 +412,13 @@ fn sort_diagnostics_by_source(diagnostics: &mut [Diagnostic]) {
 mod tests {
     use super::*;
     use crate::domain::ast::BlockAst;
+    use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider, ModelId};
     use crate::domain::source::SourceFile;
+    use crate::infrastructure::artifact::search_json::SUPPORTED_SEARCH_SCHEMA_VERSION;
+    use crate::infrastructure::embedding::in_memory::InMemoryProvider;
     use crate::infrastructure::source::in_memory::InMemorySourceProvider;
+    use std::cell::RefCell;
+    use std::fs;
 
     fn source_file(identity: &str, text: &str) -> SourceFile {
         SourceFile::new_with_identity_path(
@@ -496,5 +680,220 @@ mod tests {
             DiagnosticCode::SchemaMissingField,
             "expected SchemaMissingField"
         );
+    }
+
+    #[test]
+    fn build_with_provider_embeds_knowledge_objects_into_search_artifact() {
+        let source_provider = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            concat!(
+                "# Billing @doc(team.billing)\n",
+                "\n",
+                "::claim billing.credits\n",
+                "status: draft\n",
+                "owner: team-billing\n",
+                "--\n",
+                "Credits apply after successful payment.\n",
+                "::\n",
+            ),
+        ));
+        let embedding_provider = InMemoryProvider::new(4);
+
+        let result = build_with_provider(
+            &source_provider,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &embedding_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+
+        assert!(
+            !result.has_errors(),
+            "embedding build should pass: {:?}",
+            result.diagnostics
+        );
+        let artifacts = result.artifacts.expect("artifacts are built");
+        let search = artifacts.search_json.expect("search artifact is built");
+        let expected_vector = embedding_provider
+            .embed_passages(&[concat!(
+                "claim: Credits apply after successful payment.\n",
+                "[id: billing.credits] [status: draft] [owner: team-billing]"
+            )
+            .to_string()])
+            .expect("test embedding succeeds")
+            .remove(0);
+
+        assert_eq!(search.schema_version, SUPPORTED_SEARCH_SCHEMA_VERSION);
+        assert_eq!(search.model.id, "in-memory");
+        assert_eq!(search.model.provider, "test");
+        assert_eq!(search.model.dim, 4);
+        assert!(search.agent_artifact_hash.starts_with("sha256:"));
+        assert_eq!(search.embeddings.len(), 1);
+        assert_eq!(search.embeddings[0].id, "billing.credits");
+        assert!(search.embeddings[0].content_hash.starts_with("sha256:"));
+        assert_eq!(search.embeddings[0].vector, expected_vector);
+    }
+
+    #[test]
+    fn build_with_provider_reuses_cached_vectors_by_model_id_and_content_hash() {
+        let first_source = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require audit review.",
+            ),
+        ));
+        let first_provider = RecordingEmbeddingProvider::new(4);
+        let first_result = build_with_provider(
+            &first_source,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &first_provider,
+                },
+                prior_search_artifact_path: None,
+            },
+        );
+        let first_search = first_result
+            .artifacts
+            .expect("first artifacts")
+            .search_json
+            .expect("first search artifact");
+        let prior = tempfile::Builder::new()
+            .prefix("adoc-cache-")
+            .suffix(".search.json")
+            .tempfile()
+            .expect("cache file");
+        fs::write(
+            prior.path(),
+            first_search
+                .to_pretty_json()
+                .expect("search artifact serializes"),
+        )
+        .expect("cache write");
+
+        let second_source = InMemorySourceProvider::new().with_source(source_file(
+            "billing.adoc",
+            &two_claim_source(
+                "Credits apply after successful payment.",
+                "Refunds require manual audit review.",
+            ),
+        ));
+        let second_provider = RecordingEmbeddingProvider::new(4);
+
+        let second_result = build_with_provider(
+            &second_source,
+            BuildOptions {
+                embeddings: BuildEmbeddingBehavior::Enabled {
+                    provider: &second_provider,
+                },
+                prior_search_artifact_path: Some(prior.path().to_path_buf()),
+            },
+        );
+
+        assert!(
+            !second_result.has_errors(),
+            "second build should pass: {:?}",
+            second_result.diagnostics
+        );
+        let second_search = second_result
+            .artifacts
+            .expect("second artifacts")
+            .search_json
+            .expect("second search artifact");
+        let recorded_inputs = second_provider.recorded_inputs();
+        assert_eq!(
+            recorded_inputs,
+            vec![
+                concat!(
+                    "claim: Refunds require manual audit review.\n",
+                    "[id: billing.refunds] [status: draft] [owner: unknown]"
+                )
+                .to_string()
+            ],
+            "only the changed object should be embedded"
+        );
+        assert_eq!(
+            second_search.embeddings[0].vector, first_search.embeddings[0].vector,
+            "unchanged object vector should be reused"
+        );
+        assert_ne!(
+            second_search.embeddings[1].vector, first_search.embeddings[1].vector,
+            "changed object vector should be recomputed"
+        );
+    }
+
+    fn two_claim_source(credits_body: &str, refunds_body: &str) -> String {
+        format!(
+            concat!(
+                "# Billing @doc(team.billing)\n",
+                "\n",
+                "::claim billing.credits\n",
+                "status: draft\n",
+                "--\n",
+                "{credits_body}\n",
+                "::\n",
+                "\n",
+                "::claim billing.refunds\n",
+                "status: draft\n",
+                "--\n",
+                "{refunds_body}\n",
+                "::\n",
+            ),
+            credits_body = credits_body,
+            refunds_body = refunds_body
+        )
+    }
+
+    #[derive(Debug)]
+    struct RecordingEmbeddingProvider {
+        model_id: ModelId,
+        dim: usize,
+        recorded_inputs: RefCell<Vec<String>>,
+    }
+
+    impl RecordingEmbeddingProvider {
+        fn new(dim: usize) -> Self {
+            Self {
+                model_id: ModelId::new("recording", "test"),
+                dim,
+                recorded_inputs: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn recorded_inputs(&self) -> Vec<String> {
+            self.recorded_inputs.borrow().clone()
+        }
+    }
+
+    impl EmbeddingProvider for RecordingEmbeddingProvider {
+        fn model_id(&self) -> &ModelId {
+            &self.model_id
+        }
+
+        fn dim(&self) -> usize {
+            self.dim
+        }
+
+        fn embed_passages(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+            self.recorded_inputs
+                .borrow_mut()
+                .extend(inputs.iter().cloned());
+            Ok(inputs
+                .iter()
+                .map(|input| {
+                    (0..self.dim)
+                        .map(|index| (input.len() + index) as f32)
+                        .collect()
+                })
+                .collect())
+        }
+
+        fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbeddingError> {
+            Ok((0..self.dim)
+                .map(|index| (query.len() + index) as f32)
+                .collect())
+        }
     }
 }

--- a/crates/adoc-core/src/domain/artifact.rs
+++ b/crates/adoc-core/src/domain/artifact.rs
@@ -66,8 +66,33 @@ pub struct AgentJsonRelations {
     pub related_to: Vec<String>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct SearchArtifactDocument;
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchArtifactDocument {
+    pub schema_version: String,
+    pub model: SearchModelHeader,
+    pub agent_artifact_hash: String,
+    pub embeddings: Vec<SearchEmbedding>,
+}
+
+impl SearchArtifactDocument {
+    pub fn to_pretty_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct SearchModelHeader {
+    pub id: String,
+    pub provider: String,
+    pub dim: usize,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SearchEmbedding {
+    pub id: String,
+    pub content_hash: String,
+    pub vector: Vec<f32>,
+}
 
 #[cfg(test)]
 mod tests {
@@ -130,6 +155,38 @@ mod tests {
         assert!(
             value.get("status").is_none(),
             "absent status must be omitted from agent JSON"
+        );
+    }
+
+    #[test]
+    fn search_artifact_serializes_with_v1_3_shape() {
+        let artifact = SearchArtifactDocument {
+            schema_version: "adoc.search.v0".to_string(),
+            model: SearchModelHeader {
+                id: "bge-small-en-v1.5".to_string(),
+                provider: "fastembed".to_string(),
+                dim: 384,
+            },
+            agent_artifact_hash: "sha256:agent".to_string(),
+            embeddings: vec![SearchEmbedding {
+                id: "billing.credits".to_string(),
+                content_hash: "sha256:content".to_string(),
+                vector: vec![0.25, -0.5],
+            }],
+        };
+
+        let value = serde_json::to_value(&artifact).expect("search artifact serializes");
+
+        assert_eq!(value["schema_version"], "adoc.search.v0");
+        assert_eq!(value["model"]["id"], "bge-small-en-v1.5");
+        assert_eq!(value["model"]["provider"], "fastembed");
+        assert_eq!(value["model"]["dim"], 384);
+        assert_eq!(value["agent_artifact_hash"], "sha256:agent");
+        assert_eq!(value["embeddings"][0]["id"], "billing.credits");
+        assert_eq!(value["embeddings"][0]["content_hash"], "sha256:content");
+        assert_eq!(
+            value["embeddings"][0]["vector"],
+            serde_json::json!([0.25, -0.5])
         );
     }
 }

--- a/crates/adoc-core/src/domain/artifact.rs
+++ b/crates/adoc-core/src/domain/artifact.rs
@@ -66,6 +66,9 @@ pub struct AgentJsonRelations {
     pub related_to: Vec<String>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SearchArtifactDocument;
+
 #[cfg(test)]
 mod tests {
     use std::collections::BTreeMap;

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -52,6 +52,7 @@ pub enum DiagnosticCode {
     EmbedModelLoadFailed,
     EmbedComputeFailed,
     EmbedUnexpectedDimension,
+    BuildEmbeddingsCached,
     BuildEmbeddingsSkipped,
 }
 
@@ -87,6 +88,7 @@ impl DiagnosticCode {
             DiagnosticCode::EmbedModelLoadFailed,
             DiagnosticCode::EmbedComputeFailed,
             DiagnosticCode::EmbedUnexpectedDimension,
+            DiagnosticCode::BuildEmbeddingsCached,
             DiagnosticCode::BuildEmbeddingsSkipped,
         ]
     }
@@ -122,6 +124,7 @@ impl DiagnosticCode {
             DiagnosticCode::EmbedModelLoadFailed => "embed.model_load_failed",
             DiagnosticCode::EmbedComputeFailed => "embed.compute_failed",
             DiagnosticCode::EmbedUnexpectedDimension => "embed.unexpected_dim",
+            DiagnosticCode::BuildEmbeddingsCached => "build.embeddings_cached",
             DiagnosticCode::BuildEmbeddingsSkipped => "build.embeddings_skipped",
         }
     }
@@ -211,6 +214,9 @@ impl DiagnosticCode {
             DiagnosticCode::EmbedUnexpectedDimension => {
                 "Use an embedding provider that returns exactly one vector per input and the configured vector dimension."
             }
+            DiagnosticCode::BuildEmbeddingsCached => {
+                "No action is required; this reports search artifact embedding cache reuse."
+            }
             DiagnosticCode::BuildEmbeddingsSkipped => {
                 "Run `adoc build` without `--no-embeddings` to emit docs.search.json."
             }
@@ -275,6 +281,7 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "embed.model_load_failed",
     "embed.compute_failed",
     "embed.unexpected_dim",
+    "build.embeddings_cached",
     "build.embeddings_skipped",
 ];
 

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -53,6 +53,7 @@ pub enum DiagnosticCode {
     EmbedComputeFailed,
     EmbedUnexpectedDimension,
     BuildEmbeddingsCached,
+    BuildEmbeddingsCacheIgnored,
     BuildEmbeddingsSkipped,
 }
 
@@ -89,6 +90,7 @@ impl DiagnosticCode {
             DiagnosticCode::EmbedComputeFailed,
             DiagnosticCode::EmbedUnexpectedDimension,
             DiagnosticCode::BuildEmbeddingsCached,
+            DiagnosticCode::BuildEmbeddingsCacheIgnored,
             DiagnosticCode::BuildEmbeddingsSkipped,
         ]
     }
@@ -125,6 +127,7 @@ impl DiagnosticCode {
             DiagnosticCode::EmbedComputeFailed => "embed.compute_failed",
             DiagnosticCode::EmbedUnexpectedDimension => "embed.unexpected_dim",
             DiagnosticCode::BuildEmbeddingsCached => "build.embeddings_cached",
+            DiagnosticCode::BuildEmbeddingsCacheIgnored => "build.embeddings_cache_ignored",
             DiagnosticCode::BuildEmbeddingsSkipped => "build.embeddings_skipped",
         }
     }
@@ -217,6 +220,9 @@ impl DiagnosticCode {
             DiagnosticCode::BuildEmbeddingsCached => {
                 "No action is required; this reports search artifact embedding cache reuse."
             }
+            DiagnosticCode::BuildEmbeddingsCacheIgnored => {
+                "No action is required; the search cache will be recomputed for the current embedding model."
+            }
             DiagnosticCode::BuildEmbeddingsSkipped => {
                 "Run `adoc build` without `--no-embeddings` to emit docs.search.json."
             }
@@ -282,6 +288,7 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "embed.compute_failed",
     "embed.unexpected_dim",
     "build.embeddings_cached",
+    "build.embeddings_cache_ignored",
     "build.embeddings_skipped",
 ];
 

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -206,7 +206,7 @@ impl DiagnosticCode {
                 "Change or remove the filter so it matches at least one object field in the artifact."
             }
             DiagnosticCode::EmbedModelLoadFailed => {
-                "Check network access for the first model download, verify the local model cache is readable, then rerun `adoc build`."
+                "Check network access for the first model download, verify the local model cache is readable, ensure the binary was built with the `embeddings` feature, or rerun `adoc build --no-embeddings`."
             }
             DiagnosticCode::EmbedComputeFailed => {
                 "Retry `adoc build`; if the error repeats, rebuild with `--no-embeddings` while investigating the embedding provider."

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -49,6 +49,9 @@ pub enum DiagnosticCode {
     IdDuplicateInArtifact,
     RetrievalObjectNotFound,
     SearchInvalidFilter,
+    EmbedModelLoadFailed,
+    EmbedComputeFailed,
+    EmbedUnexpectedDimension,
     BuildEmbeddingsSkipped,
 }
 
@@ -81,6 +84,9 @@ impl DiagnosticCode {
             DiagnosticCode::IdDuplicateInArtifact,
             DiagnosticCode::RetrievalObjectNotFound,
             DiagnosticCode::SearchInvalidFilter,
+            DiagnosticCode::EmbedModelLoadFailed,
+            DiagnosticCode::EmbedComputeFailed,
+            DiagnosticCode::EmbedUnexpectedDimension,
             DiagnosticCode::BuildEmbeddingsSkipped,
         ]
     }
@@ -113,6 +119,9 @@ impl DiagnosticCode {
             DiagnosticCode::IdDuplicateInArtifact => "id.duplicate_in_artifact",
             DiagnosticCode::RetrievalObjectNotFound => "retrieval.object_not_found",
             DiagnosticCode::SearchInvalidFilter => "search.invalid_filter",
+            DiagnosticCode::EmbedModelLoadFailed => "embed.model_load_failed",
+            DiagnosticCode::EmbedComputeFailed => "embed.compute_failed",
+            DiagnosticCode::EmbedUnexpectedDimension => "embed.unexpected_dim",
             DiagnosticCode::BuildEmbeddingsSkipped => "build.embeddings_skipped",
         }
     }
@@ -193,6 +202,15 @@ impl DiagnosticCode {
             DiagnosticCode::SearchInvalidFilter => {
                 "Change or remove the filter so it matches at least one object field in the artifact."
             }
+            DiagnosticCode::EmbedModelLoadFailed => {
+                "Check network access for the first model download, verify the local model cache is readable, then rerun `adoc build`."
+            }
+            DiagnosticCode::EmbedComputeFailed => {
+                "Retry `adoc build`; if the error repeats, rebuild with `--no-embeddings` while investigating the embedding provider."
+            }
+            DiagnosticCode::EmbedUnexpectedDimension => {
+                "Use an embedding provider that returns exactly one vector per input and the configured vector dimension."
+            }
             DiagnosticCode::BuildEmbeddingsSkipped => {
                 "Run `adoc build` without `--no-embeddings` to emit docs.search.json."
             }
@@ -254,6 +272,9 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "id.duplicate_in_artifact",
     "retrieval.object_not_found",
     "search.invalid_filter",
+    "embed.model_load_failed",
+    "embed.compute_failed",
+    "embed.unexpected_dim",
     "build.embeddings_skipped",
 ];
 

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -49,6 +49,7 @@ pub enum DiagnosticCode {
     IdDuplicateInArtifact,
     RetrievalObjectNotFound,
     SearchInvalidFilter,
+    BuildEmbeddingsSkipped,
 }
 
 impl DiagnosticCode {
@@ -80,6 +81,7 @@ impl DiagnosticCode {
             DiagnosticCode::IdDuplicateInArtifact,
             DiagnosticCode::RetrievalObjectNotFound,
             DiagnosticCode::SearchInvalidFilter,
+            DiagnosticCode::BuildEmbeddingsSkipped,
         ]
     }
 
@@ -111,6 +113,7 @@ impl DiagnosticCode {
             DiagnosticCode::IdDuplicateInArtifact => "id.duplicate_in_artifact",
             DiagnosticCode::RetrievalObjectNotFound => "retrieval.object_not_found",
             DiagnosticCode::SearchInvalidFilter => "search.invalid_filter",
+            DiagnosticCode::BuildEmbeddingsSkipped => "build.embeddings_skipped",
         }
     }
 
@@ -190,6 +193,9 @@ impl DiagnosticCode {
             DiagnosticCode::SearchInvalidFilter => {
                 "Change or remove the filter so it matches at least one object field in the artifact."
             }
+            DiagnosticCode::BuildEmbeddingsSkipped => {
+                "Run `adoc build` without `--no-embeddings` to emit docs.search.json."
+            }
         }
     }
 
@@ -248,6 +254,7 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "id.duplicate_in_artifact",
     "retrieval.object_not_found",
     "search.invalid_filter",
+    "build.embeddings_skipped",
 ];
 
 impl Diagnostic {
@@ -266,6 +273,17 @@ impl Diagnostic {
         Self {
             code,
             severity: Severity::Warning,
+            message: message.into(),
+            span: None,
+            object_id: None,
+            help: Some(code.default_help().to_string()),
+        }
+    }
+
+    pub(crate) fn info(code: DiagnosticCode, message: impl Into<String>) -> Self {
+        Self {
+            code,
+            severity: Severity::Info,
             message: message.into(),
             span: None,
             object_id: None,

--- a/crates/adoc-core/src/domain/inline.rs
+++ b/crates/adoc-core/src/domain/inline.rs
@@ -120,6 +120,12 @@ pub(crate) fn to_source(segments: &[InlineSegment]) -> String {
     buffer
 }
 
+pub(crate) fn embedding_plain_text(segments: &[InlineSegment]) -> String {
+    let mut buffer = String::new();
+    append_embedding_plain_text(segments, &mut buffer);
+    buffer
+}
+
 fn append_source(segments: &[InlineSegment], buffer: &mut String) {
     for segment in segments {
         match segment {
@@ -146,6 +152,28 @@ fn append_source(segments: &[InlineSegment], buffer: &mut String) {
                 buffer.push_str(url);
                 buffer.push(')');
             }
+            InlineSegment::ObjectReferencePending { raw_id, .. } => {
+                buffer.push_str("[[");
+                buffer.push_str(raw_id);
+                buffer.push_str("]]");
+            }
+            InlineSegment::ObjectReference { id, .. } => {
+                buffer.push_str("[[");
+                buffer.push_str(id.as_str());
+                buffer.push_str("]]");
+            }
+        }
+    }
+}
+
+fn append_embedding_plain_text(segments: &[InlineSegment], buffer: &mut String) {
+    for segment in segments {
+        match segment {
+            InlineSegment::Text(text) | InlineSegment::Code(text) => buffer.push_str(text),
+            InlineSegment::Emphasis(inner) | InlineSegment::Strong(inner) => {
+                append_embedding_plain_text(inner, buffer)
+            }
+            InlineSegment::Link { text, .. } => append_embedding_plain_text(text, buffer),
             InlineSegment::ObjectReferencePending { raw_id, .. } => {
                 buffer.push_str("[[");
                 buffer.push_str(raw_id);

--- a/crates/adoc-core/src/domain/knowledge_object/projection.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/projection.rs
@@ -74,7 +74,6 @@ impl MetadataField<'_> {
 }
 
 impl KnowledgeObject {
-    #[allow(dead_code)]
     pub(crate) fn embedding_input(&self) -> String {
         let metadata = self.metadata_projection();
         let status = metadata

--- a/crates/adoc-core/src/domain/knowledge_object/projection.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/projection.rs
@@ -7,6 +7,8 @@ use crate::domain::knowledge_object::{
     warning::WarningSeverity,
 };
 
+const UNKNOWN_METADATA_VALUE: &str = "unknown";
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KnowledgeObjectMetadata<'a> {
     discriminant: Option<MetadataDiscriminant<'a>>,
@@ -72,6 +74,31 @@ impl MetadataField<'_> {
 }
 
 impl KnowledgeObject {
+    #[allow(dead_code)]
+    pub(crate) fn embedding_input(&self) -> String {
+        let metadata = self.metadata_projection();
+        let status = metadata
+            .discriminant()
+            .map(MetadataDiscriminant::value_as_str)
+            .unwrap_or(UNKNOWN_METADATA_VALUE);
+        let owner = metadata
+            .fields()
+            .iter()
+            .find(|field| field.key() == OWNER_FIELD)
+            .map(MetadataField::value_as_str)
+            .unwrap_or(UNKNOWN_METADATA_VALUE);
+        let body = normalized_embedding_body(&self.body().to_embedding_plain_text());
+
+        format!(
+            "{}: {}\n[id: {}] [status: {}] [owner: {}]",
+            self.kind().as_str(),
+            body,
+            self.id().as_str(),
+            status,
+            owner
+        )
+    }
+
     pub(crate) fn metadata_projection(&self) -> KnowledgeObjectMetadata<'_> {
         let mut fields: Vec<MetadataField<'_>> = self
             .fields()
@@ -106,6 +133,13 @@ impl KnowledgeObject {
     }
 }
 
+fn normalized_embedding_body(body: &str) -> String {
+    body.replace("\r\n", "\n")
+        .replace('\r', "\n")
+        .trim()
+        .to_string()
+}
+
 fn append_verification_fields<'a>(
     fields: &mut Vec<MetadataField<'a>>,
     verification: Option<&'a Verification>,
@@ -126,6 +160,8 @@ mod tests {
 
     use super::*;
     use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+    use crate::domain::identity::ObjectId;
+    use crate::domain::inline::InlineSegment;
     use crate::domain::knowledge_object::{
         KnowledgeObject,
         claim::{Claim, Evidence, NonEmpty, Owner, Verification, VerifiedAt},
@@ -349,6 +385,75 @@ mod tests {
         assert_eq!(
             field_entries(&projection),
             vec![entry("owner", "team-billing"), entry("status", "draft")]
+        );
+    }
+
+    #[test]
+    fn canonical_embedding_input_uses_unknown_metadata_defaults() {
+        let object = KnowledgeObject::Glossary(
+            Glossary::try_new(
+                "billing.credits",
+                "Credits balance.",
+                BTreeMap::new(),
+                span(),
+            )
+            .expect("valid glossary"),
+        );
+
+        assert_eq!(
+            object.embedding_input(),
+            "glossary: Credits balance.\n[id: billing.credits] [status: unknown] [owner: unknown]"
+        );
+    }
+
+    #[test]
+    fn canonical_embedding_input_uses_status_owner_and_preserves_object_reference_markers() {
+        let mut claim = Claim::try_new(
+            "billing.refunds",
+            Some("draft"),
+            "Placeholder.",
+            BTreeMap::from([("owner".to_string(), "team-billing".to_string())]),
+            None,
+            span(),
+        )
+        .expect("valid claim");
+        claim.body_mut().inlines_mut().clear();
+        claim
+            .body_mut()
+            .inlines_mut()
+            .push(InlineSegment::Text("See ".to_string()));
+        claim
+            .body_mut()
+            .inlines_mut()
+            .push(InlineSegment::ObjectReference {
+                id: ObjectId::new("billing.ledger").expect("valid id"),
+                span: span(),
+            });
+        let object = KnowledgeObject::Claim(claim);
+
+        assert_eq!(
+            object.embedding_input(),
+            "claim: See [[billing.ledger]]\n[id: billing.refunds] [status: draft] [owner: team-billing]"
+        );
+    }
+
+    #[test]
+    fn canonical_embedding_input_normalizes_line_endings_and_trims_edges() {
+        let object = KnowledgeObject::Claim(
+            Claim::try_new(
+                "billing.newline",
+                Some("plain"),
+                " First line\r\nSecond line\r ",
+                BTreeMap::new(),
+                None,
+                span(),
+            )
+            .expect("valid claim"),
+        );
+
+        assert_eq!(
+            object.embedding_input(),
+            "claim: First line\nSecond line\n[id: billing.newline] [status: plain] [owner: unknown]"
         );
     }
 }

--- a/crates/adoc-core/src/domain/ports/embedding_provider.rs
+++ b/crates/adoc-core/src/domain/ports/embedding_provider.rs
@@ -1,0 +1,30 @@
+#![allow(dead_code)]
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ModelId {
+    pub(crate) id: String,
+    pub(crate) provider: String,
+}
+
+impl ModelId {
+    pub(crate) fn new(id: impl Into<String>, provider: impl Into<String>) -> Self {
+        Self {
+            id: id.into(),
+            provider: provider.into(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EmbeddingError {
+    ModelLoad(String),
+    Compute(String),
+    DimensionMismatch { expected: usize, actual: usize },
+}
+
+pub(crate) trait EmbeddingProvider {
+    fn model_id(&self) -> &ModelId;
+    fn dim(&self) -> usize;
+    fn embed_passages(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError>;
+    fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbeddingError>;
+}

--- a/crates/adoc-core/src/domain/ports/embedding_provider.rs
+++ b/crates/adoc-core/src/domain/ports/embedding_provider.rs
@@ -19,7 +19,7 @@ pub(crate) enum EmbeddingError {
     ModelLoad(String),
     #[cfg_attr(not(any(test, feature = "embeddings")), allow(dead_code))]
     Compute(String),
-    #[allow(dead_code)]
+    #[cfg_attr(not(any(test, feature = "embeddings")), allow(dead_code))]
     DimensionMismatch {
         expected: usize,
         actual: usize,

--- a/crates/adoc-core/src/domain/ports/embedding_provider.rs
+++ b/crates/adoc-core/src/domain/ports/embedding_provider.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ModelId {
     pub(crate) id: String,
@@ -19,12 +17,17 @@ impl ModelId {
 pub(crate) enum EmbeddingError {
     ModelLoad(String),
     Compute(String),
-    DimensionMismatch { expected: usize, actual: usize },
+    #[allow(dead_code)]
+    DimensionMismatch {
+        expected: usize,
+        actual: usize,
+    },
 }
 
 pub(crate) trait EmbeddingProvider {
     fn model_id(&self) -> &ModelId;
     fn dim(&self) -> usize;
     fn embed_passages(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError>;
+    #[allow(dead_code)]
     fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbeddingError>;
 }

--- a/crates/adoc-core/src/domain/ports/embedding_provider.rs
+++ b/crates/adoc-core/src/domain/ports/embedding_provider.rs
@@ -5,6 +5,7 @@ pub(crate) struct ModelId {
 }
 
 impl ModelId {
+    #[cfg_attr(not(any(test, feature = "embeddings")), allow(dead_code))]
     pub(crate) fn new(id: impl Into<String>, provider: impl Into<String>) -> Self {
         Self {
             id: id.into(),
@@ -16,6 +17,7 @@ impl ModelId {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum EmbeddingError {
     ModelLoad(String),
+    #[cfg_attr(not(any(test, feature = "embeddings")), allow(dead_code))]
     Compute(String),
     #[allow(dead_code)]
     DimensionMismatch {

--- a/crates/adoc-core/src/domain/ports/mod.rs
+++ b/crates/adoc-core/src/domain/ports/mod.rs
@@ -1,5 +1,6 @@
 // see ADR-0009
 pub(crate) mod artifact_reader;
 pub(crate) mod artifact_writer;
+pub(crate) mod embedding_provider;
 pub(crate) mod renderer;
 pub(crate) mod source_provider;

--- a/crates/adoc-core/src/domain/values.rs
+++ b/crates/adoc-core/src/domain/values.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use crate::domain::inline::{InlineSegment, plain_text, to_source};
+use crate::domain::inline::{InlineSegment, embedding_plain_text, plain_text, to_source};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct NonEmptyText(String);
@@ -41,6 +41,10 @@ impl Body {
 
     pub(crate) fn to_source(&self) -> String {
         to_source(&self.0)
+    }
+
+    pub(crate) fn to_embedding_plain_text(&self) -> String {
+        embedding_plain_text(&self.0)
     }
 }
 

--- a/crates/adoc-core/src/infrastructure/artifact/mod.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod agent_json;
+pub(crate) mod search_json;
 
 pub(crate) use agent_json::AgentJsonArtifact;
 

--- a/crates/adoc-core/src/infrastructure/artifact/search_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/search_json.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::fs;
 use std::io;
 use std::path::Path;

--- a/crates/adoc-core/src/infrastructure/artifact/search_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/search_json.rs
@@ -1,0 +1,134 @@
+#![allow(dead_code)]
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use crate::domain::artifact::SearchArtifactDocument;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
+
+pub(crate) const SUPPORTED_SEARCH_SCHEMA_VERSION: &str = "adoc.search.v0";
+
+pub(crate) fn read_search_artifact_document(
+    path: &Path,
+) -> Result<SearchArtifactDocument, Vec<Diagnostic>> {
+    let contents = match fs::read_to_string(path) {
+        Ok(contents) => contents,
+        Err(error) => return Err(vec![read_error_diagnostic(path, error)]),
+    };
+    let document = match serde_json::from_str::<SearchArtifactDocument>(&contents) {
+        Ok(document) => document,
+        Err(error) => {
+            return Err(vec![
+                Diagnostic::error(
+                    DiagnosticCode::IoArtifactMalformed,
+                    format!("Artifact '{}' is malformed: {error}", path.display()),
+                )
+                .with_help("Rebuild docs.search.json from the source workspace."),
+            ]);
+        }
+    };
+
+    if document.schema_version != SUPPORTED_SEARCH_SCHEMA_VERSION {
+        return Err(vec![
+            Diagnostic::error(
+                DiagnosticCode::SchemaUnsupportedVersion,
+                format!(
+                    "Artifact '{}' uses unsupported schema_version '{}'.",
+                    path.display(),
+                    document.schema_version
+                ),
+            )
+            .with_help(format!(
+                "Expected schema_version '{}'.",
+                SUPPORTED_SEARCH_SCHEMA_VERSION
+            )),
+        ]);
+    }
+
+    Ok(document)
+}
+
+fn read_error_diagnostic(path: &Path, error: io::Error) -> Diagnostic {
+    let code = if error.kind() == io::ErrorKind::NotFound {
+        DiagnosticCode::IoArtifactMissing
+    } else {
+        DiagnosticCode::IoArtifactUnreadable
+    };
+    Diagnostic::error(
+        code,
+        format!("Unable to read artifact '{}': {error}", path.display()),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use crate::domain::artifact::{SearchArtifactDocument, SearchEmbedding, SearchModelHeader};
+    use crate::domain::diagnostic::DiagnosticCode;
+    use crate::infrastructure::artifact::search_json::{
+        SUPPORTED_SEARCH_SCHEMA_VERSION, read_search_artifact_document,
+    };
+
+    #[test]
+    fn read_search_artifact_rejects_unsupported_schema_version() {
+        let artifact = tempfile::Builder::new()
+            .prefix("adoc-search-")
+            .suffix(".json")
+            .tempfile()
+            .expect("temp artifact can be created");
+        fs::write(
+            artifact.path(),
+            serde_json::json!({
+                "schema_version": "adoc.search.v99",
+                "model": { "id": "model", "provider": "test", "dim": 2 },
+                "agent_artifact_hash": "sha256:agent",
+                "embeddings": []
+            })
+            .to_string(),
+        )
+        .expect("artifact can be written");
+
+        let diagnostics =
+            read_search_artifact_document(artifact.path()).expect_err("version must fail");
+
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaUnsupportedVersion
+        );
+    }
+
+    #[test]
+    fn search_artifact_pretty_json_round_trips() {
+        let artifact = SearchArtifactDocument {
+            schema_version: SUPPORTED_SEARCH_SCHEMA_VERSION.to_string(),
+            model: SearchModelHeader {
+                id: "in-memory".to_string(),
+                provider: "test".to_string(),
+                dim: 2,
+            },
+            agent_artifact_hash: "sha256:agent".to_string(),
+            embeddings: vec![SearchEmbedding {
+                id: "billing.credits".to_string(),
+                content_hash: "sha256:content".to_string(),
+                vector: vec![1.0, 0.0],
+            }],
+        };
+        let artifact_file = tempfile::Builder::new()
+            .prefix("adoc-search-")
+            .suffix(".json")
+            .tempfile()
+            .expect("temp artifact can be created");
+        fs::write(
+            artifact_file.path(),
+            artifact.to_pretty_json().expect("artifact serializes"),
+        )
+        .expect("artifact can be written");
+
+        let read_back =
+            read_search_artifact_document(artifact_file.path()).expect("artifact loads");
+
+        assert_eq!(read_back, artifact);
+    }
+}

--- a/crates/adoc-core/src/infrastructure/embedding/fastembed.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/fastembed.rs
@@ -1,0 +1,116 @@
+use std::sync::Mutex;
+
+use fastembed::{EmbeddingModel, InitOptions, TextEmbedding};
+
+use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider, ModelId};
+
+const MODEL_ID: &str = "bge-small-en-v1.5";
+const PROVIDER_ID: &str = "fastembed";
+const DIM: usize = 384;
+
+pub(crate) struct FastEmbedProvider {
+    model_id: ModelId,
+    model: Option<Mutex<TextEmbedding>>,
+}
+
+impl FastEmbedProvider {
+    pub(crate) fn try_new() -> Result<Self, EmbeddingError> {
+        let model = TextEmbedding::try_new(InitOptions::new(EmbeddingModel::BGESmallENV15))
+            .map_err(|error| EmbeddingError::ModelLoad(error.to_string()))?;
+
+        Ok(Self {
+            model_id: Self::default_model_id(),
+            model: Some(Mutex::new(model)),
+        })
+    }
+
+    fn default_model_id() -> ModelId {
+        ModelId::new(MODEL_ID, PROVIDER_ID)
+    }
+
+    #[cfg(test)]
+    pub(crate) fn metadata_only_for_test() -> Self {
+        Self {
+            model_id: Self::default_model_id(),
+            model: None,
+        }
+    }
+
+    fn embed_texts<S>(&self, texts: S) -> Result<Vec<Vec<f32>>, EmbeddingError>
+    where
+        S: AsRef<[String]>,
+    {
+        let model = self
+            .model
+            .as_ref()
+            .ok_or_else(|| EmbeddingError::Compute("FastEmbed model is not loaded".to_string()))?;
+        let mut model = model.lock().map_err(|error| {
+            EmbeddingError::Compute(format!("FastEmbed model lock failed: {error}"))
+        })?;
+
+        model
+            .embed(texts, None)
+            .map_err(|error| EmbeddingError::Compute(error.to_string()))
+    }
+
+    fn validate_vector_dimensions(
+        &self,
+        vectors: Vec<Vec<f32>>,
+    ) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        for vector in &vectors {
+            if vector.len() != DIM {
+                return Err(EmbeddingError::DimensionMismatch {
+                    expected: DIM,
+                    actual: vector.len(),
+                });
+            }
+        }
+
+        Ok(vectors)
+    }
+}
+
+impl EmbeddingProvider for FastEmbedProvider {
+    fn model_id(&self) -> &ModelId {
+        &self.model_id
+    }
+
+    fn dim(&self) -> usize {
+        DIM
+    }
+
+    fn embed_passages(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        let vectors = self.embed_texts(inputs)?;
+        self.validate_vector_dimensions(vectors)
+    }
+
+    fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbeddingError> {
+        let vectors =
+            self.validate_vector_dimensions(self.embed_texts(vec![query.to_string()])?)?;
+        vectors
+            .into_iter()
+            .next()
+            .ok_or(EmbeddingError::DimensionMismatch {
+                expected: 1,
+                actual: 0,
+            })
+    }
+}
+
+#[cfg(all(test, feature = "fastembed-it"))]
+mod fastembed_it_tests {
+    use crate::domain::ports::embedding_provider::EmbeddingProvider;
+    use crate::infrastructure::embedding::fastembed::FastEmbedProvider;
+
+    #[test]
+    fn fastembed_provider_embeds_passage_end_to_end() {
+        let provider = FastEmbedProvider::try_new().expect("FastEmbed model loads");
+
+        let vectors = provider
+            .embed_passages(&["claim: Credits apply after payment.".to_string()])
+            .expect("FastEmbed computes passage embedding");
+
+        assert_eq!(vectors.len(), 1);
+        assert_eq!(vectors[0].len(), provider.dim());
+    }
+}

--- a/crates/adoc-core/src/infrastructure/embedding/fastembed.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/fastembed.rs
@@ -7,6 +7,7 @@ use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider
 const MODEL_ID: &str = "bge-small-en-v1.5";
 const PROVIDER_ID: &str = "fastembed";
 const DIM: usize = 384;
+const QUERY_INSTRUCTION: &str = "Represent this sentence for searching relevant passages: ";
 
 pub(crate) struct FastEmbedProvider {
     model_id: ModelId,
@@ -85,16 +86,23 @@ impl EmbeddingProvider for FastEmbedProvider {
     }
 
     fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbeddingError> {
-        let vectors =
-            self.validate_vector_dimensions(self.embed_texts(vec![query.to_string()])?)?;
-        vectors
-            .into_iter()
-            .next()
-            .ok_or(EmbeddingError::DimensionMismatch {
-                expected: 1,
-                actual: 0,
-            })
+        let query = format_query_for_passage_search(query);
+        let vectors = self.validate_vector_dimensions(self.embed_texts(vec![query])?)?;
+        query_vector_from_fastembed_response(vectors)
     }
+}
+
+fn format_query_for_passage_search(query: &str) -> String {
+    format!("{QUERY_INSTRUCTION}{query}")
+}
+
+fn query_vector_from_fastembed_response(
+    vectors: Vec<Vec<f32>>,
+) -> Result<Vec<f32>, EmbeddingError> {
+    vectors
+        .into_iter()
+        .next()
+        .ok_or_else(|| EmbeddingError::Compute("fastembed returned no vectors".to_string()))
 }
 
 #[cfg(all(test, feature = "fastembed-it"))]
@@ -112,5 +120,31 @@ mod fastembed_it_tests {
 
         assert_eq!(vectors.len(), 1);
         assert_eq!(vectors[0].len(), provider.dim());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::ports::embedding_provider::EmbeddingError;
+    use crate::infrastructure::embedding::fastembed::{
+        format_query_for_passage_search, query_vector_from_fastembed_response,
+    };
+
+    #[test]
+    fn format_query_for_passage_search_uses_bge_search_instruction() {
+        assert_eq!(
+            format_query_for_passage_search("refund policy"),
+            "Represent this sentence for searching relevant passages: refund policy"
+        );
+    }
+
+    #[test]
+    fn query_vector_from_fastembed_response_maps_empty_response_to_compute_error() {
+        let error = query_vector_from_fastembed_response(Vec::new()).expect_err("empty response");
+
+        assert_eq!(
+            error,
+            EmbeddingError::Compute("fastembed returned no vectors".to_string())
+        );
     }
 }

--- a/crates/adoc-core/src/infrastructure/embedding/in_memory.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/in_memory.rs
@@ -1,0 +1,77 @@
+#![allow(dead_code)]
+
+use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider, ModelId};
+
+#[derive(Debug, Clone)]
+pub(crate) struct InMemoryProvider {
+    model_id: ModelId,
+    dim: usize,
+}
+
+impl InMemoryProvider {
+    pub(crate) fn new(dim: usize) -> Self {
+        Self {
+            model_id: ModelId::new("in-memory", "test"),
+            dim,
+        }
+    }
+
+    fn embed_text(&self, text: &str) -> Vec<f32> {
+        (0..self.dim)
+            .map(|index| stable_component(text.as_bytes(), index as u64))
+            .collect()
+    }
+}
+
+impl EmbeddingProvider for InMemoryProvider {
+    fn model_id(&self) -> &ModelId {
+        &self.model_id
+    }
+
+    fn dim(&self) -> usize {
+        self.dim
+    }
+
+    fn embed_passages(&self, inputs: &[String]) -> Result<Vec<Vec<f32>>, EmbeddingError> {
+        Ok(inputs.iter().map(|input| self.embed_text(input)).collect())
+    }
+
+    fn embed_query(&self, query: &str) -> Result<Vec<f32>, EmbeddingError> {
+        Ok(self.embed_text(query))
+    }
+}
+
+fn stable_component(bytes: &[u8], seed: u64) -> f32 {
+    let mut hash = 0xcbf29ce484222325_u64 ^ seed.wrapping_mul(0x100000001b3);
+    for byte in bytes {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(0x100000001b3);
+    }
+    let bucket = (hash % 2001) as f32;
+    (bucket - 1000.0) / 1000.0
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::ports::embedding_provider::EmbeddingProvider;
+    use crate::infrastructure::embedding::in_memory::InMemoryProvider;
+
+    #[test]
+    fn in_memory_provider_returns_deterministic_vectors_with_configured_dim() {
+        let provider = InMemoryProvider::new(4);
+
+        let first = provider
+            .embed_passages(&["Credits apply after payment.".to_string()])
+            .expect("passage embedding succeeds");
+        let second = provider
+            .embed_passages(&["Credits apply after payment.".to_string()])
+            .expect("passage embedding succeeds");
+
+        assert_eq!(provider.model_id().id, "in-memory");
+        assert_eq!(provider.model_id().provider, "test");
+        assert_eq!(provider.dim(), 4);
+        assert_eq!(first, second);
+        assert_eq!(first[0].len(), 4);
+        assert_ne!(first[0], vec![0.0; 4]);
+    }
+}

--- a/crates/adoc-core/src/infrastructure/embedding/in_memory.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/in_memory.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider, ModelId};
 
 #[derive(Debug, Clone)]

--- a/crates/adoc-core/src/infrastructure/embedding/mod.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod in_memory;

--- a/crates/adoc-core/src/infrastructure/embedding/mod.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/mod.rs
@@ -1,1 +1,18 @@
+pub(crate) mod fastembed;
+#[cfg(test)]
 pub(crate) mod in_memory;
+
+#[cfg(test)]
+mod tests {
+    use crate::domain::ports::embedding_provider::EmbeddingProvider;
+    use crate::infrastructure::embedding::fastembed::FastEmbedProvider;
+
+    #[test]
+    fn fastembed_provider_header_matches_search_contract_without_model_download() {
+        let provider = FastEmbedProvider::metadata_only_for_test();
+
+        assert_eq!(provider.model_id().id, "bge-small-en-v1.5");
+        assert_eq!(provider.model_id().provider, "fastembed");
+        assert_eq!(provider.dim(), 384);
+    }
+}

--- a/crates/adoc-core/src/infrastructure/embedding/mod.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/mod.rs
@@ -1,5 +1,5 @@
 pub(crate) mod fastembed;
-#[cfg(test)]
+#[cfg(any(test, feature = "test-embedding-provider"))]
 pub(crate) mod in_memory;
 
 #[cfg(test)]

--- a/crates/adoc-core/src/infrastructure/embedding/mod.rs
+++ b/crates/adoc-core/src/infrastructure/embedding/mod.rs
@@ -1,8 +1,9 @@
+#[cfg(feature = "embeddings")]
 pub(crate) mod fastembed;
 #[cfg(any(test, feature = "test-embedding-provider"))]
 pub(crate) mod in_memory;
 
-#[cfg(test)]
+#[cfg(all(test, feature = "embeddings"))]
 mod tests {
     use crate::domain::ports::embedding_provider::EmbeddingProvider;
     use crate::infrastructure::embedding::fastembed::FastEmbedProvider;

--- a/crates/adoc-core/src/infrastructure/mod.rs
+++ b/crates/adoc-core/src/infrastructure/mod.rs
@@ -1,5 +1,6 @@
 // see ADR-0009
 pub(crate) mod artifact;
+pub(crate) mod embedding;
 pub(crate) mod parser;
 pub(crate) mod render;
 pub(crate) mod source;

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -26,10 +26,22 @@ pub fn compile_workspace(input: CompileInput) -> CompileResult {
 }
 
 pub fn build_workspace(input: BuildInput) -> CompileResult {
-    build_workspace_with_embedding_provider_factory(input, || {
-        infrastructure::embedding::fastembed::FastEmbedProvider::try_new().map(|provider| {
-            Box::new(provider) as Box<dyn domain::ports::embedding_provider::EmbeddingProvider>
-        })
+    build_workspace_with_embedding_provider_factory(input, default_embedding_provider)
+}
+
+fn default_embedding_provider() -> Result<
+    Box<dyn domain::ports::embedding_provider::EmbeddingProvider>,
+    domain::ports::embedding_provider::EmbeddingError,
+> {
+    #[cfg(feature = "test-embedding-provider")]
+    if std::env::var("ADOC_TEST_EMBEDDING_PROVIDER").as_deref() != Ok("fastembed") {
+        return Ok(Box::new(
+            infrastructure::embedding::in_memory::InMemoryProvider::new(384),
+        ));
+    }
+
+    infrastructure::embedding::fastembed::FastEmbedProvider::try_new().map(|provider| {
+        Box::new(provider) as Box<dyn domain::ports::embedding_provider::EmbeddingProvider>
     })
 }
 

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -26,16 +26,40 @@ pub fn compile_workspace(input: CompileInput) -> CompileResult {
 }
 
 pub fn build_workspace(input: BuildInput) -> CompileResult {
+    build_workspace_with_embedding_provider_factory(input, || {
+        infrastructure::embedding::fastembed::FastEmbedProvider::try_new().map(|provider| {
+            Box::new(provider) as Box<dyn domain::ports::embedding_provider::EmbeddingProvider>
+        })
+    })
+}
+
+fn build_workspace_with_embedding_provider_factory<F>(
+    input: BuildInput,
+    provider_factory: F,
+) -> CompileResult
+where
+    F: FnOnce() -> Result<
+        Box<dyn domain::ports::embedding_provider::EmbeddingProvider>,
+        domain::ports::embedding_provider::EmbeddingError,
+    >,
+{
     let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
     match input.embeddings {
         BuildEmbeddingMode::Enabled => {
-            let embedding_provider =
-                infrastructure::embedding::in_memory::InMemoryProvider::new(384);
+            let embedding_provider = match provider_factory() {
+                Ok(provider) => provider,
+                Err(error) => {
+                    return CompileResult {
+                        diagnostics: vec![application::compile::embedding_error_diagnostic(error)],
+                        artifacts: None,
+                    };
+                }
+            };
             application::compile::build_with_provider(
                 &provider,
                 application::compile::BuildOptions {
                     embeddings: application::compile::BuildEmbeddingBehavior::Enabled {
-                        provider: &embedding_provider,
+                        provider: embedding_provider.as_ref(),
                     },
                     prior_search_artifact_path: input.prior_search_artifact_path,
                 },
@@ -56,4 +80,54 @@ pub fn load_retrieval_session(input: RetrievalInput) -> RetrievalLoadResult {
         input,
         &infrastructure::artifact::AgentJsonArtifact,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::Cell;
+
+    use super::*;
+    use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider};
+
+    #[test]
+    fn build_workspace_enabled_maps_default_embedding_provider_load_failure() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        let result = build_workspace_with_embedding_provider_factory(
+            BuildInput {
+                root: workspace.path().to_path_buf(),
+                embeddings: BuildEmbeddingMode::Enabled,
+                prior_search_artifact_path: None,
+            },
+            || Err(EmbeddingError::ModelLoad("model unavailable".to_string())),
+        );
+
+        assert!(result.has_errors());
+        assert!(result.artifacts.is_none());
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == DiagnosticCode::EmbedModelLoadFailed)
+        );
+    }
+
+    #[test]
+    fn build_workspace_skipped_does_not_construct_default_embedding_provider() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        let constructed = Cell::new(false);
+        let result = build_workspace_with_embedding_provider_factory(
+            BuildInput {
+                root: workspace.path().to_path_buf(),
+                embeddings: BuildEmbeddingMode::Skipped,
+                prior_search_artifact_path: None,
+            },
+            || -> Result<Box<dyn EmbeddingProvider>, EmbeddingError> {
+                constructed.set(true);
+                panic!("skipped build must not construct embedding provider")
+            },
+        );
+
+        assert!(!constructed.get());
+        assert!(!result.has_errors(), "skipped build should pass");
+    }
 }

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -103,7 +103,13 @@ mod tests {
         );
 
         assert!(result.has_errors());
-        assert!(result.artifacts.is_none());
+        let artifacts = result
+            .artifacts
+            .expect("clean source still returns V0 artifacts on embedding failure");
+        assert!(
+            artifacts.search_json.is_none(),
+            "failed embedding build should not return a search artifact"
+        );
         assert!(
             result
                 .diagnostics

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -27,13 +27,28 @@ pub fn compile_workspace(input: CompileInput) -> CompileResult {
 
 pub fn build_workspace(input: BuildInput) -> CompileResult {
     let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
-    application::compile::build_with_provider(
-        &provider,
-        application::compile::BuildOptions {
-            embeddings: input.embeddings,
-            prior_search_artifact_path: input.prior_search_artifact_path,
-        },
-    )
+    match input.embeddings {
+        BuildEmbeddingMode::Enabled => {
+            let embedding_provider =
+                infrastructure::embedding::in_memory::InMemoryProvider::new(384);
+            application::compile::build_with_provider(
+                &provider,
+                application::compile::BuildOptions {
+                    embeddings: application::compile::BuildEmbeddingBehavior::Enabled {
+                        provider: &embedding_provider,
+                    },
+                    prior_search_artifact_path: input.prior_search_artifact_path,
+                },
+            )
+        }
+        BuildEmbeddingMode::Skipped => application::compile::build_with_provider(
+            &provider,
+            application::compile::BuildOptions {
+                embeddings: application::compile::BuildEmbeddingBehavior::Skipped,
+                prior_search_artifact_path: input.prior_search_artifact_path,
+            },
+        ),
+    }
 }
 
 pub fn load_retrieval_session(input: RetrievalInput) -> RetrievalLoadResult {

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -34,7 +34,7 @@ fn default_embedding_provider() -> Result<
     domain::ports::embedding_provider::EmbeddingError,
 > {
     #[cfg(feature = "test-embedding-provider")]
-    if std::env::var("ADOC_TEST_EMBEDDING_PROVIDER").as_deref() != Ok("fastembed") {
+    if use_in_memory_test_embedding_provider() {
         return Ok(Box::new(
             infrastructure::embedding::in_memory::InMemoryProvider::new(384),
         ));
@@ -53,6 +53,11 @@ fn default_embedding_provider() -> Result<
             "embedding support is disabled; rebuild with the `embeddings` feature or run with --no-embeddings".to_string(),
         ))
     }
+}
+
+#[cfg(feature = "test-embedding-provider")]
+fn use_in_memory_test_embedding_provider() -> bool {
+    std::env::var("ADOC_TEST_EMBEDDING_PROVIDER").as_deref() == Ok("in-memory")
 }
 
 fn build_workspace_with_embedding_provider_factory<F>(
@@ -209,5 +214,49 @@ mod tests {
                 .expect("help")
                 .contains("--no-embeddings")
         );
+    }
+
+    #[cfg(feature = "test-embedding-provider")]
+    #[test]
+    fn test_embedding_provider_env_uses_in_memory_only_when_explicitly_requested() {
+        temp_env_remove("ADOC_TEST_EMBEDDING_PROVIDER", || {
+            assert!(!use_in_memory_test_embedding_provider());
+        });
+        temp_env_set("ADOC_TEST_EMBEDDING_PROVIDER", "fastembed", || {
+            assert!(!use_in_memory_test_embedding_provider());
+        });
+        temp_env_set("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory", || {
+            assert!(use_in_memory_test_embedding_provider());
+        });
+    }
+
+    #[cfg(feature = "test-embedding-provider")]
+    fn temp_env_remove(name: &str, test: impl FnOnce()) {
+        let previous = std::env::var_os(name);
+        unsafe {
+            std::env::remove_var(name);
+        }
+        test();
+        restore_env(name, previous);
+    }
+
+    #[cfg(feature = "test-embedding-provider")]
+    fn temp_env_set(name: &str, value: &str, test: impl FnOnce()) {
+        let previous = std::env::var_os(name);
+        unsafe {
+            std::env::set_var(name, value);
+        }
+        test();
+        restore_env(name, previous);
+    }
+
+    #[cfg(feature = "test-embedding-provider")]
+    fn restore_env(name: &str, value: Option<std::ffi::OsString>) {
+        unsafe {
+            match value {
+                Some(value) => std::env::set_var(name, value),
+                None => std::env::remove_var(name),
+            }
+        }
     }
 }

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -47,36 +47,25 @@ fn default_embedding_provider() -> Result<
 
 fn build_workspace_with_embedding_provider_factory<F>(
     input: BuildInput,
-    provider_factory: F,
+    mut provider_factory: F,
 ) -> CompileResult
 where
-    F: FnOnce() -> Result<
+    F: FnMut() -> Result<
         Box<dyn domain::ports::embedding_provider::EmbeddingProvider>,
         domain::ports::embedding_provider::EmbeddingError,
     >,
 {
     let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
     match input.embeddings {
-        BuildEmbeddingMode::Enabled => {
-            let embedding_provider = match provider_factory() {
-                Ok(provider) => provider,
-                Err(error) => {
-                    return CompileResult {
-                        diagnostics: vec![application::compile::embedding_error_diagnostic(error)],
-                        artifacts: None,
-                    };
-                }
-            };
-            application::compile::build_with_provider(
-                &provider,
-                application::compile::BuildOptions {
-                    embeddings: application::compile::BuildEmbeddingBehavior::Enabled {
-                        provider: embedding_provider.as_ref(),
-                    },
-                    prior_search_artifact_path: input.prior_search_artifact_path,
+        BuildEmbeddingMode::Enabled => application::compile::build_with_provider(
+            &provider,
+            application::compile::BuildOptions {
+                embeddings: application::compile::BuildEmbeddingBehavior::EnabledFactory {
+                    provider_factory: &mut provider_factory,
                 },
-            )
-        }
+                prior_search_artifact_path: input.prior_search_artifact_path,
+            },
+        ),
         BuildEmbeddingMode::Skipped => application::compile::build_with_provider(
             &provider,
             application::compile::BuildOptions {
@@ -141,5 +130,38 @@ mod tests {
 
         assert!(!constructed.get());
         assert!(!result.has_errors(), "skipped build should pass");
+    }
+
+    #[test]
+    fn build_workspace_enabled_does_not_construct_embedding_provider_when_source_has_errors() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+        std::fs::write(
+            workspace.path().join("guide.adoc"),
+            "# Guide @doc(team.guide)\n\n<div>raw</div>\n",
+        )
+        .expect("source can be written");
+        let constructed = Cell::new(false);
+
+        let result = build_workspace_with_embedding_provider_factory(
+            BuildInput {
+                root: workspace.path().to_path_buf(),
+                embeddings: BuildEmbeddingMode::Enabled,
+                prior_search_artifact_path: None,
+            },
+            || -> Result<Box<dyn EmbeddingProvider>, EmbeddingError> {
+                constructed.set(true);
+                panic!("source errors must not construct embedding provider")
+            },
+        );
+
+        assert!(!constructed.get());
+        assert!(result.has_errors(), "raw HTML should produce an error");
+        assert!(result.artifacts.is_none());
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == DiagnosticCode::ParseRawHtml)
+        );
     }
 }

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -40,9 +40,19 @@ fn default_embedding_provider() -> Result<
         ));
     }
 
-    infrastructure::embedding::fastembed::FastEmbedProvider::try_new().map(|provider| {
-        Box::new(provider) as Box<dyn domain::ports::embedding_provider::EmbeddingProvider>
-    })
+    #[cfg(feature = "embeddings")]
+    {
+        infrastructure::embedding::fastembed::FastEmbedProvider::try_new().map(|provider| {
+            Box::new(provider) as Box<dyn domain::ports::embedding_provider::EmbeddingProvider>
+        })
+    }
+
+    #[cfg(not(feature = "embeddings"))]
+    {
+        Err(domain::ports::embedding_provider::EmbeddingError::ModelLoad(
+            "embedding support is disabled; rebuild with the `embeddings` feature or run with --no-embeddings".to_string(),
+        ))
+    }
 }
 
 fn build_workspace_with_embedding_provider_factory<F>(
@@ -168,6 +178,36 @@ mod tests {
                 .diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.code == DiagnosticCode::ParseRawHtml)
+        );
+    }
+
+    #[cfg(not(feature = "embeddings"))]
+    #[test]
+    fn build_workspace_enabled_without_embeddings_feature_reports_model_load_failure() {
+        let workspace = tempfile::tempdir().expect("temp workspace");
+
+        let result = build_workspace(BuildInput {
+            root: workspace.path().to_path_buf(),
+            embeddings: BuildEmbeddingMode::Enabled,
+            prior_search_artifact_path: None,
+        });
+
+        assert!(result.has_errors());
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::EmbedModelLoadFailed)
+            .expect("model load diagnostic");
+        assert!(
+            diagnostic.message.contains("`embeddings` feature"),
+            "diagnostic should explain the missing feature: {diagnostic:?}"
+        );
+        assert!(
+            diagnostic
+                .help
+                .as_deref()
+                .expect("help")
+                .contains("--no-embeddings")
         );
     }
 }

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -2,7 +2,9 @@ mod application;
 mod domain;
 mod infrastructure;
 
-pub use application::compile::{BuildArtifacts, CompileInput, CompileResult};
+pub use application::compile::{
+    BuildArtifacts, BuildEmbeddingMode, BuildInput, CompileInput, CompileResult,
+};
 pub use application::retrieval::{
     ExplainResult, RETRIEVAL_SCHEMA_VERSION, RetrievalEnvelope, RetrievalInput,
     RetrievalLoadResult, RetrievalSession, SearchFilters, SearchQuery, SearchResult,
@@ -13,6 +15,7 @@ pub use application::retrieval_format::{
 };
 pub use domain::artifact::{
     AgentJsonDocument, AgentJsonObject, AgentJsonRelations, AgentJsonSourceSpan,
+    SearchArtifactDocument,
 };
 pub use domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 pub use domain::retrieval::{RetrievalMatch, RetrievalRecord, RetrievalSource, SearchMode};
@@ -20,6 +23,17 @@ pub use domain::retrieval::{RetrievalMatch, RetrievalRecord, RetrievalSource, Se
 pub fn compile_workspace(input: CompileInput) -> CompileResult {
     let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
     application::compile::compile_with_provider(&provider)
+}
+
+pub fn build_workspace(input: BuildInput) -> CompileResult {
+    let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
+    application::compile::build_with_provider(
+        &provider,
+        application::compile::BuildOptions {
+            embeddings: input.embeddings,
+            prior_search_artifact_path: input.prior_search_artifact_path,
+        },
+    )
 }
 
 pub fn load_retrieval_session(input: RetrievalInput) -> RetrievalLoadResult {

--- a/crates/adoc-core/tests/compile_workspace.rs
+++ b/crates/adoc-core/tests/compile_workspace.rs
@@ -1,7 +1,67 @@
 mod support;
 
-use adoc_core::{AgentJsonObject, CompileInput, DiagnosticCode, Severity, compile_workspace};
+use adoc_core::{
+    AgentJsonObject, BuildEmbeddingMode, BuildInput, CompileInput, DiagnosticCode, Severity,
+    build_workspace, compile_workspace,
+};
 use support::TestWorkspace;
+
+#[test]
+fn build_workspace_skips_embeddings_without_affecting_check_path() {
+    let workspace = TestWorkspace::new("build-workspace-skip-embeddings");
+    let source = workspace.write(
+        "billing.adoc",
+        concat!(
+            "# Billing Guide @doc(team.billing)\n",
+            "\n",
+            "::claim billing.credits\n",
+            "status: draft\n",
+            "--\n",
+            "Credits apply after successful payment.\n",
+            "::\n",
+        ),
+    );
+
+    let check_result = compile_workspace(CompileInput {
+        root: source.clone(),
+    });
+    assert!(
+        !check_result
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == DiagnosticCode::BuildEmbeddingsSkipped),
+        "check must not emit build-only embedding diagnostics"
+    );
+
+    let build_result = build_workspace(BuildInput {
+        root: source,
+        embeddings: BuildEmbeddingMode::Skipped,
+        prior_search_artifact_path: None,
+    });
+
+    assert!(
+        !build_result.has_errors(),
+        "skipping embeddings should not fail build: {:?}",
+        build_result.diagnostics
+    );
+    assert!(
+        build_result
+            .diagnostics
+            .iter()
+            .any(
+                |diagnostic| diagnostic.code == DiagnosticCode::BuildEmbeddingsSkipped
+                    && diagnostic.severity == Severity::Info
+            ),
+        "skipped embeddings should be reported as info"
+    );
+    let artifacts = build_result
+        .artifacts
+        .expect("build artifacts are produced");
+    assert!(
+        artifacts.search_json.is_none(),
+        "skipping embeddings must omit the search artifact"
+    );
+}
 
 #[test]
 fn compile_workspace_returns_mixed_validation_diagnostics_in_source_order() {

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -89,6 +89,7 @@ fn public_surface_compiles_with_only_documented_imports() {
     let _ = DiagnosticCode::IdDuplicateInArtifact;
     let _ = DiagnosticCode::RetrievalObjectNotFound;
     let _ = DiagnosticCode::SearchInvalidFilter;
+    let _ = DiagnosticCode::BuildEmbeddingsCacheIgnored;
     // The wire string remains available for hosts that serialize manually.
     let _: &'static str = DiagnosticCode::ParseRawHtml.as_str();
     let _: &'static str = DiagnosticCode::ParseRawHtml.default_help();
@@ -169,6 +170,10 @@ fn public_surface_compiles_with_only_documented_imports() {
     assert_eq!(
         DiagnosticCode::SearchInvalidFilter.as_str(),
         "search.invalid_filter"
+    );
+    assert_eq!(
+        DiagnosticCode::BuildEmbeddingsCacheIgnored.as_str(),
+        "build.embeddings_cache_ignored"
     );
 
     let _: fn(RetrievalInput) -> RetrievalLoadResult = load_retrieval_session;

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -315,13 +315,14 @@ Goal: make `adoc build` produce a deterministic, content-hashed search artifact.
 Scope:
 
 - Add the `EmbeddingProvider` internal port (governed by ADR-0006).
-- Add `FastEmbedProvider` (`fastembed-rs` + `bge-small-en-v1.5`) as the default adapter; first-run weights cached locally; subsequent runs are offline.
-- Add `InMemoryProvider` as a deterministic test adapter mirroring the role of `InMemorySourceProvider`.
+- Add `FastEmbedProvider` (`fastembed-rs` + `bge-small-en-v1.5`) as the default adapter behind the default-on `embeddings` feature; first-run weights cached locally; subsequent runs are offline.
+- Add `InMemoryProvider` as a deterministic test adapter mirroring the role of `InMemorySourceProvider`; tests select it explicitly with `ADOC_TEST_EMBEDDING_PROVIDER=in-memory`.
 - Extend the application pipeline so `compile_with_provider` accepts an `EmbeddingProvider`; `compile_workspace()` defaults to `FastEmbedProvider`.
 - Emit `dist/docs.search.json` with the schema documented in V1-DESIGN: `{ schema_version: "adoc.search.v0", model: { id, provider, dim }, agent_artifact_hash, embeddings: [{ id, content_hash, vector }] }`.
-- Add per-Object-ID embedding cache: when prior content hash matches, the prior vector is reused.
+- Add per-Object-ID embedding cache: when prior content hash matches, the prior vector is reused and reported with `build.embeddings_cached` (`embeddings: cached N, computed M`).
 - Add `--no-embeddings` to `adoc build`. Add diagnostics: `embed.model_load_failed`, `embed.compute_failed`, `embed.unexpected_dim`, `build.embeddings_skipped`.
-- Hermetic `cargo test` uses `InMemoryProvider` by default. The fastembed path runs under a gated feature flag (`cargo test --features fastembed-it`).
+- Embedding failures after clean source compilation preserve `docs.html` and `docs.agent.json`, omit a new `docs.search.json`, leave any prior search sidecar untouched, and exit `1`.
+- FastEmbed is the default test-provider path when `test-embedding-provider` is enabled but `ADOC_TEST_EMBEDDING_PROVIDER` is unset. The FastEmbed integration path runs under a gated feature flag (`cargo test --features fastembed-it`).
 
 Acceptance:
 

--- a/docs/V1-DESIGN.md
+++ b/docs/V1-DESIGN.md
@@ -144,7 +144,9 @@ adoc search "<query>"
 
 Behavior:
 
-- `adoc build` writes `dist/docs.html`, `dist/docs.agent.json`, and `dist/docs.search.json`. With `--no-embeddings`, the search artifact is skipped and a `build.embeddings_skipped` info diagnostic is emitted.
+- `adoc build` writes `dist/docs.html` and `dist/docs.agent.json` after clean source compilation. It writes `dist/docs.search.json` only when embedding-enabled search artifact construction succeeds.
+- Embedding failures after clean source compilation emit `embed.model_load_failed`, `embed.compute_failed`, or `embed.unexpected_dim`, return/emit V0 artifacts, set `search_json` to `None`, leave any prior `dist/docs.search.json` untouched, and exit `1`.
+- Successful embedding-enabled search builds emit `build.embeddings_cached` with `embeddings: cached N, computed M`. With `--no-embeddings`, the search artifact is skipped and a `build.embeddings_skipped` info diagnostic is emitted.
 - `adoc explain` reads only the agent artifact. It exits `0` on success, `1` on argument errors, `2` on artifact errors, and `3` on object not found.
 - `adoc search` reads both artifacts. Empty result sets exit `0` with an explicit `(no matches)` line; argument errors exit `1`; artifact errors exit `2`. There is no separate "no results" exit code.
 - `--format json` emits a stable JSON envelope: `{ "schema_version": "adoc.retrieval.v0", "records": [...], "diagnostics": [...] }`. This is the wire format a future MCP wrapper consumes; it must not change shape inside V1.
@@ -225,8 +227,8 @@ Rules:
 
 - The port stays `pub(crate)` per ADR-0006. Promoted to `pub` only when an external consumer (LSP, MCP server, alternate CLI) exists.
 - `embed_passages` and `embed_query` are split because most modern embedding models distinguish passage and query encoding (asymmetric retrieval). For models that do not, a single implementation can dispatch both.
-- The default adapter is `FastEmbedProvider` wrapping `fastembed-rs` with `bge-small-en-v1.5`. First run downloads weights via the crate's built-in HF fetcher; subsequent runs read the cached file.
-- `InMemoryProvider` produces deterministic pseudo-embeddings via a small hashing scheme. It is the only provider used in unit and integration tests so the test suite remains hermetic and the bge weights are not pulled in CI.
+- The default adapter is `FastEmbedProvider` wrapping `fastembed-rs` with `bge-small-en-v1.5`. First run downloads weights via the crate's built-in HF fetcher; subsequent runs read the cached file. The dependency is behind the default-on `embeddings` feature; no-default builds that request embeddings return `embed.model_load_failed` with help to enable the feature or use `--no-embeddings`.
+- `InMemoryProvider` produces deterministic pseudo-embeddings via a small hashing scheme. It is selected only in tests that enable `test-embedding-provider` and set `ADOC_TEST_EMBEDDING_PROVIDER=in-memory`; unset or `fastembed` uses FastEmbed when the `embeddings` feature is available.
 - Adding a hosted provider later means adding one file in `infrastructure/embedding/` and one CLI flag (`--embedding-provider hosted`); the port does not change.
 
 ## Retrieval Pipeline
@@ -490,7 +492,7 @@ fixtures/
 
 Test guidance:
 
-- Hermetic by default: every unit and integration test uses `InMemoryProvider`. The fastembed path runs only under `cargo test --features fastembed-it`.
+- Hermetic tests opt into `InMemoryProvider` explicitly with `ADOC_TEST_EMBEDDING_PROVIDER=in-memory`. The fastembed path is the default when the test feature is enabled but the env var is unset, and end-to-end FastEmbed coverage runs under `cargo test --features fastembed-it`.
 - CLI tests that need the production `build_workspace()` boundary without model downloads enable the test-only `test-embedding-provider` feature and set `ADOC_TEST_EMBEDDING_PROVIDER=in-memory`. Production builds do not use this seam.
 - Golden-test the JSON envelope produced by `--format json` for both `explain` and `search`. Schema regressions must update the golden file plus the schema version explicitly.
 - Property suite generated from any agent artifact: every body verbatim → top 1 lexical, every Object ID → top 1 lexical, every owner query covers every claim with that owner.

--- a/docs/V1-DESIGN.md
+++ b/docs/V1-DESIGN.md
@@ -491,6 +491,7 @@ fixtures/
 Test guidance:
 
 - Hermetic by default: every unit and integration test uses `InMemoryProvider`. The fastembed path runs only under `cargo test --features fastembed-it`.
+- CLI tests that need the production `build_workspace()` boundary without model downloads enable the test-only `test-embedding-provider` feature and set `ADOC_TEST_EMBEDDING_PROVIDER=in-memory`. Production builds do not use this seam.
 - Golden-test the JSON envelope produced by `--format json` for both `explain` and `search`. Schema regressions must update the golden file plus the schema version explicitly.
 - Property suite generated from any agent artifact: every body verbatim → top 1 lexical, every Object ID → top 1 lexical, every owner query covers every claim with that owner.
 

--- a/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
+++ b/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
@@ -1,0 +1,31 @@
+{
+  "schema_version": "adoc.search.v0",
+  "model": {
+    "id": "in-memory",
+    "provider": "test",
+    "dim": 4
+  },
+  "agent_artifact_hash": "sha256:7ddfcacbfdc7a3e92d2d436c8f904579ff327de51938ffae2e429b6273c74bd0",
+  "embeddings": [
+    {
+      "id": "billing.credits",
+      "content_hash": "sha256:b92ead57472b302fc075ecf7ef404c8e9f0cc1f7a94176b19748ee9fa3f061b1",
+      "vector": [
+        0.419,
+        -0.552,
+        0.355,
+        -0.029
+      ]
+    },
+    {
+      "id": "billing.ledger",
+      "content_hash": "sha256:a0cc177269a2bb29028b7cc37db4c8bf88dcd0baf97d29ba3c4c1e165f38e9c6",
+      "vector": [
+        -0.229,
+        0.666,
+        -0.55,
+        0.428
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/v1_3_embed/input.adoc
+++ b/tests/fixtures/v1_3_embed/input.adoc
@@ -1,0 +1,13 @@
+# Embed Fixture @doc(fixtures.embed)
+
+::claim billing.credits
+status: draft
+owner: team-billing
+--
+Credits apply after successful payment.
+::
+
+::glossary billing.ledger
+--
+Ledger records billing balance movements.
+::


### PR DESCRIPTION
## Summary

Implements V1.3 of the retrieval roadmap: `adoc build` now produces a deterministic, content-hashed `dist/docs.search.json` search artifact alongside the existing `docs.html` and `docs.agent.json`. No retrieval changes yet — V1.4 will wire `--semantic` to read this artifact.

- Adds `domain/ports/embedding_provider.rs` (pub(crate) per ADR-0006) with `embed_passages` / `embed_query` and the `adoc.search.v0` artifact schema.
- Ships two adapters: `FastEmbedProvider` (default, `bge-small-en-v1.5`, weights cached under the platform user data dir, offline after first run) and `InMemoryProvider` (deterministic hashing — used by every hermetic test).
- Composes the canonical embedding input per Knowledge Object (`{kind}: {body_plain_text}` + ID/status/owner footer, relations excluded) and computes a per-Object-ID `content_hash` (sha256). Reuses the prior vector when content hash + model header match — `embeddings: cached N, computed M` shows in the build log.
- Adds `--no-embeddings` to `adoc build` to skip artifact write and emit `build.embeddings_skipped` (info).
- New diagnostics: `embed.model_load_failed`, `embed.compute_failed`, `embed.unexpected_dim`, `build.embeddings_skipped`.
- Hermetic `cargo test` runs entirely on `InMemoryProvider`. The fastembed path lives behind `--features fastembed-it` so default CI stays network-free per ADR-0008.
- Golden fixture under `tests/fixtures/v1_3_embed/in_memory_baseline.search.json` pins artifact shape and serialization.

Closes #63.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` (hermetic, all suites green)
- [x] `cargo test -p adoc-core --features fastembed-it` (FastEmbedProvider end-to-end, all green)
- [ ] Manual: `adoc build examples/billing-pilot --out examples/billing-pilot/dist` produces all three artifacts; second run reports `cached N, computed 0`; editing one object recomputes only that vector
- [ ] Manual: `adoc build --no-embeddings` skips the search artifact and emits `build.embeddings_skipped`