### PR TITLE
feat(retrieval): V1.5 hybrid default + V1.6 pilot evaluation harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      fastembed:
+        description: Run gated FastEmbed retrieval tests
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -62,3 +67,35 @@ jobs:
 
       - name: Build documentation
         run: cargo doc --workspace --no-deps --locked
+
+  fastembed-retrieval:
+    name: FastEmbed Retrieval
+    if: ${{ github.event_name == 'workflow_dispatch' && inputs.fastembed }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
+
+      - name: Cache Cargo data
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-cargo-fastembed-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-fastembed-
+            ${{ runner.os }}-cargo-
+
+      - name: Run retrieval pilot with FastEmbed
+        run: cargo test -p adoc-cli --test retrieval_pilot --features fastembed-it --locked

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,8 @@ dependencies = [
  "is-terminal",
  "owo-colors",
  "predicates",
+ "serde",
+ "serde-saphyr",
  "serde_json",
  "strip-ansi-escapes",
  "thiserror 1.0.69",
@@ -96,6 +98,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "annotate-snippets"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f211a51805bc641f3ad5b7664c77d2547af685cc33b4cd8d31964027a46f13f1"
+dependencies = [
+ "anstyle",
+ "memchr",
+ "unicode-width",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -167,6 +180,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "arraydeque"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
 
 [[package]]
 name = "arrayvec"
@@ -752,6 +771,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "encoding_rs_io"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cc3c5651fb62ab8aa3103998dade57efdd028544bd300516baa31840c252a83"
+dependencies = [
+ "encoding_rs",
+]
+
+[[package]]
 name = "equator"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1012,9 +1040,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1781,6 +1811,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "nohash-hasher"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bf50223579dc7cdcfb3bfcacf7069ff68243f8c363f62ffa99cf000a6b9c451"
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2513,6 +2549,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "saphyr-parser-bw"
+version = "0.0.608"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d55ae5ea09894b6d5382621db78f586df37ef18ab581bf32c754e75076b124b1"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "scc"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2579,6 +2626,26 @@ checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
  "serde_derive",
+]
+
+[[package]]
+name = "serde-saphyr"
+version = "0.0.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a6fc4aa0da972ba0f51cf5c1bb16e9dba35334adc6831b09b3ffb0ec20bb264"
+dependencies = [
+ "ahash",
+ "annotate-snippets",
+ "base64 0.22.1",
+ "encoding_rs_io",
+ "getrandom 0.3.4",
+ "nohash-hasher",
+ "num-traits",
+ "regex",
+ "saphyr-parser-bw",
+ "serde",
+ "smallvec",
+ "zmij",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The current implementation is a pre-release Rust CLI named `adoc`. It compiles n
 - `docs.search.json` for local embedding-backed retrieval
 - source-located diagnostics for invalid input
 
-It also provides local, read-only retrieval over `docs.agent.json` with `adoc explain` and lexical-only `adoc search`.
+It also provides local, read-only retrieval over compiled artifacts with `adoc explain` and hybrid `adoc search`.
 
 AgentDoc is not AsciiDoc, even though the source extension is `.adoc`.
 
@@ -42,14 +42,15 @@ V1.3 build embeddings support:
 - per-Object-ID vector reuse when the model header and content hash match the prior `docs.search.json`
 - `--no-embeddings` to skip search artifact generation and leave any prior `docs.search.json` untouched
 
-V1.2 local retrieval supports:
+V1 local retrieval supports:
 
 - `adoc explain <object-id>` over a compiled `docs.agent.json`
-- `adoc search <query>` over the same agent artifact
+- `adoc search <query>` over `docs.agent.json` and, when present, `docs.search.json`
 - text and JSON retrieval output
+- hybrid search by default, fusing lexical BM25 and vector cosine ranks with Reciprocal Rank Fusion
+- `--lexical` and `--semantic` escape hatches
+- exact Object ID and ID-prefix pins in all search modes
 - search filters for kind, status, owner, and source path
-
-V1.2 search is lexical-only. It reads `docs.agent.json` only; it does not read `docs.search.json`, run semantic mode, or perform hybrid ranking yet.
 
 Config files, includes, custom schemas, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, a web app, and permissioned governance are deferred beyond the current V0 compiler loop. See [docs/ROADMAP.md](docs/ROADMAP.md).
 
@@ -128,7 +129,7 @@ docs.search.json
 
 ### Try The Billing Pilot
 
-The realistic V0 pilot under [examples/billing-pilot](examples/billing-pilot) exercises the full core object set: `claim`, `decision`, `warning`, and `glossary`. It contains 20+ Knowledge Objects, 5+ verified claims, object references, relations, and source spans in the agent artifact.
+The realistic V0 pilot under [examples/billing-pilot](examples/billing-pilot) exercises the full core object set: `claim`, `decision`, `warning`, and `glossary`. It contains 30+ Knowledge Objects, 8+ verified claims, object references, relations, source spans, and a golden retrieval set.
 
 ```bash
 rm -rf /tmp/adoc-billing-pilot
@@ -166,7 +167,7 @@ adoc build /tmp/adoc-example/guide.adoc --out /tmp/adoc-example/dist
 adoc check <path>
 adoc build <path> --out <directory> [--no-embeddings]
 adoc explain <object-id> [--artifact <path>] [--format text|json]
-adoc search <query> [--artifact <path>] [--kind <value>] [--status <value>] [--owner <value>] [--source-path <value>] [--top <n>] [--format text|json]
+adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | --semantic] [--kind <value>] [--status <value>] [--owner <value>] [--source-path <value>] [--top <n>] [--format text|json]
 ```
 
 `<path>` can be:
@@ -201,15 +202,20 @@ adoc search <query> [--artifact <path>] [--kind <value>] [--status <value>] [--o
 
 `adoc search`:
 
-- reads a compiled agent artifact; it does not compile source
+- reads compiled artifacts; it does not compile source
 - defaults to `--artifact dist/docs.agent.json`
-- runs deterministic lexical search over `docs.agent.json`
-- pins exact Object ID and raw case-sensitive ID-prefix query matches above BM25 results
+- defaults to `--search-artifact dist/docs.search.json`
+- runs hybrid search by default when the search artifact loads
+- degrades to lexical search with one `search.artifact_missing` warning when the search artifact is absent
+- accepts `--lexical` for deterministic text search over `docs.agent.json`
+- accepts `--semantic` for vector-only search over `docs.search.json`
+- pins exact Object ID and raw case-sensitive ID-prefix query matches in every mode
 - supports `--kind`, `--status`, `--owner`, and `--source-path` filters
+- treats an empty lexical query plus filters as a deterministic listing of matching objects
 - limits results with `--top`, defaulting to `10`
 - supports `--format text|json`
 
-V1.2 `adoc search` does not use `docs.search.json`, semantic search, or hybrid ranking.
+See [docs/v1-retrieval.md](docs/v1-retrieval.md) for retrieval workflow, citation guidance, model-swap behavior, and retrieval-set maintenance.
 
 ## AgentDoc Source
 

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -26,4 +26,6 @@ adoc-core = { path = "../adoc-core", features = ["test-embedding-provider"] }
 assert_cmd = "2"
 insta = { version = "1", features = ["filters"] }
 predicates = "3"
+serde = { version = "1", features = ["derive"] }
+serde-saphyr = "0.0.21"
 strip-ansi-escapes = "0.2"

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -391,7 +391,20 @@ fn search_command(input: SearchCommandInput, resolved: ResolvedFormat) -> i32 {
     // degrades to lexical below so missing embeddings do not pay model-load
     // cost just to fall back.
     if requested_mode == SearchMode::Semantic && !session.has_semantic_index() {
-        let envelope = RetrievalEnvelope::new(Vec::new(), load_diagnostics);
+        let mut diagnostics = load_diagnostics;
+        diagnostics.push(Diagnostic {
+            code: DiagnosticCode::SearchArtifactMissing,
+            severity: Severity::Error,
+            message: "Semantic search requested but no search artifact is loaded.".to_string(),
+            span: None,
+            object_id: None,
+            help: Some(
+                DiagnosticCode::SearchArtifactMissing
+                    .default_help()
+                    .to_string(),
+            ),
+        });
+        let envelope = RetrievalEnvelope::new(Vec::new(), diagnostics);
         if resolved == ResolvedFormat::Json {
             return json_presentation::write_envelope_json(&envelope, &mut std::io::stdout())
                 .map_or_else(|source| report(CliError::RetrievalIo { source }), |()| 2);

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -47,24 +47,27 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
                     artifact,
                     search_artifact,
                     semantic,
-                    lexical: _,
+                    lexical,
                     kind,
                     status,
                     owner,
                     source_path,
                     top,
                 } => search_command(
-                    query,
-                    artifact,
-                    search_artifact,
-                    semantic,
-                    SearchFilters {
-                        kind,
-                        status,
-                        owner,
-                        source_path,
+                    SearchCommandInput {
+                        query,
+                        artifact,
+                        search_artifact,
+                        semantic,
+                        lexical,
+                        filters: SearchFilters {
+                            kind,
+                            status,
+                            owner,
+                            source_path,
+                        },
+                        top,
                     },
-                    top,
                     resolved,
                 ),
             }
@@ -325,27 +328,32 @@ fn explain(object_id: String, artifact: PathBuf, resolved: ResolvedFormat) -> i3
     }
 }
 
-fn search_command(
+struct SearchCommandInput {
     query: String,
     artifact: PathBuf,
     search_artifact: PathBuf,
     semantic: bool,
+    lexical: bool,
     filters: SearchFilters,
     top: NonZeroUsize,
-    resolved: ResolvedFormat,
-) -> i32 {
-    // Only attempt to load the search artifact when semantic mode is requested.
-    // For lexical searches the vector index is never consulted, so we avoid
-    // emitting a spurious SearchArtifactMissing warning when the user has not
-    // yet run `adoc build` with embeddings.
-    let search_artifact_path = if semantic {
-        Some(search_artifact)
+}
+
+fn search_command(input: SearchCommandInput, resolved: ResolvedFormat) -> i32 {
+    let requested_mode = if input.semantic {
+        SearchMode::Semantic
+    } else if input.lexical {
+        SearchMode::Lexical
     } else {
-        None
+        SearchMode::Hybrid
+    };
+
+    let search_artifact_path = match requested_mode {
+        SearchMode::Lexical => None,
+        SearchMode::Hybrid | SearchMode::Semantic => Some(input.search_artifact),
     };
 
     let load_result = load_retrieval_session(RetrievalInput {
-        artifact_path: artifact,
+        artifact_path: input.artifact,
         search_artifact_path,
     });
     let RetrievalLoadResult {
@@ -379,11 +387,10 @@ fn search_command(
         return 2;
     }
 
-    // Guard: if the caller asked for semantic search but no vector index was
-    // loaded (e.g. the search artifact is missing or failed its hash check),
-    // surface the already-emitted warning and exit before paying the
-    // embedding-model load cost.
-    if semantic && !session.has_semantic_index() {
+    // Explicit semantic mode cannot run without a vector index. Hybrid mode
+    // degrades to lexical below so missing embeddings do not pay model-load
+    // cost just to fall back.
+    if requested_mode == SearchMode::Semantic && !session.has_semantic_index() {
         let envelope = RetrievalEnvelope::new(Vec::new(), load_diagnostics);
         if resolved == ResolvedFormat::Json {
             return json_presentation::write_envelope_json(&envelope, &mut std::io::stdout())
@@ -393,25 +400,30 @@ fn search_command(
         return 2;
     }
 
-    // Determine search mode and build the query vector for semantic search.
-    let mode = if semantic {
-        SearchMode::Semantic
-    } else {
-        SearchMode::Lexical
+    let mode = match requested_mode {
+        SearchMode::Hybrid if session.has_semantic_index() => SearchMode::Hybrid,
+        SearchMode::Hybrid => SearchMode::Lexical,
+        mode => mode,
     };
 
-    let query_vector = if semantic {
-        match embed_query(&query) {
+    let needs_query_vector = matches!(mode, SearchMode::Hybrid | SearchMode::Semantic);
+    let query_vector = if needs_query_vector {
+        match embed_query(&input.query) {
             Ok(vector) => Some(vector),
             Err(embed_error) => {
+                let mode_label = match mode {
+                    SearchMode::Hybrid => "hybrid search",
+                    SearchMode::Semantic => "semantic search",
+                    SearchMode::Lexical => "lexical search",
+                };
                 let (code, message) = match &embed_error {
                     EmbedQueryError::ModelLoad(msg) => (
                         DiagnosticCode::EmbedModelLoadFailed,
-                        format!("--semantic requested but embedding model failed to load: {msg}"),
+                        format!("{mode_label} requested but embedding model failed to load: {msg}"),
                     ),
                     EmbedQueryError::Compute(msg) => (
                         DiagnosticCode::EmbedComputeFailed,
-                        format!("--semantic requested but query embedding failed: {msg}"),
+                        format!("{mode_label} requested but query embedding failed: {msg}"),
                     ),
                 };
                 let diagnostic = Diagnostic {
@@ -440,10 +452,10 @@ fn search_command(
     let search_result = search(
         &session,
         SearchQuery {
-            text: query,
+            text: input.query,
             mode,
-            filters,
-            top,
+            filters: input.filters,
+            top: input.top,
             query_vector,
         },
     );

--- a/crates/adoc-cli/tests/billing_pilot.rs
+++ b/crates/adoc-cli/tests/billing_pilot.rs
@@ -85,8 +85,8 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
         .expect("agent JSON objects is an array");
 
     assert!(
-        objects.len() >= 20,
-        "expected at least 20 Knowledge Objects, got {}",
+        objects.len() >= 30,
+        "expected at least 30 Knowledge Objects, got {}",
         objects.len()
     );
     for kind in ["claim", "decision", "warning", "glossary"] {
@@ -101,8 +101,8 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
         .filter(|object| object["kind"] == "claim" && object["status"] == "verified")
         .count();
     assert!(
-        verified_claim_count >= 5,
-        "expected at least 5 verified claims, got {verified_claim_count}"
+        verified_claim_count >= 8,
+        "expected at least 8 verified claims, got {verified_claim_count}"
     );
 
     let refund_claim = objects

--- a/crates/adoc-cli/tests/retrieval_pilot.rs
+++ b/crates/adoc-cli/tests/retrieval_pilot.rs
@@ -5,6 +5,7 @@ use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
 
+use serde::Deserialize;
 use serde_json::Value;
 use support::TestWorkspace;
 
@@ -17,7 +18,8 @@ fn repo_root() -> PathBuf {
         .to_path_buf()
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 enum RetrievalMode {
     #[default]
     Hybrid,
@@ -25,7 +27,8 @@ enum RetrievalMode {
     Semantic,
 }
 
-#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, Default, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
 enum CaseFormat {
     #[default]
     Json,
@@ -53,7 +56,8 @@ impl EmbeddingBackend {
     }
 }
 
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct CaseFilters {
     kind: Option<String>,
     status: Option<String>,
@@ -61,18 +65,29 @@ struct CaseFilters {
     source_path: Option<String>,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RetrievalCase {
+    #[serde(default)]
     name: String,
     query: String,
+    #[serde(default)]
     mode: RetrievalMode,
+    #[serde(default)]
     format: CaseFormat,
+    #[serde(default)]
     filters: CaseFilters,
+    #[serde(default)]
     expected_ids: Vec<String>,
+    #[serde(default)]
     expected_diagnostics: Vec<String>,
+    #[serde(default)]
     expected_evidence: BTreeMap<String, String>,
+    #[serde(default)]
     expect_stdout_contains: Option<String>,
+    #[serde(default)]
     expected_exit: i32,
+    #[serde(default = "default_must_appear_in_top")]
     must_appear_in_top: usize,
 }
 
@@ -83,64 +98,8 @@ struct PilotBuild {
     agent_json: Value,
 }
 
-#[derive(Debug, Clone)]
-struct RetrievalCaseBuilder {
-    name: Option<String>,
-    query: Option<String>,
-    mode: RetrievalMode,
-    format: CaseFormat,
-    filters: CaseFilters,
-    expected_ids: Vec<String>,
-    expected_diagnostics: Vec<String>,
-    expected_evidence: BTreeMap<String, String>,
-    expect_stdout_contains: Option<String>,
-    expected_exit: i32,
-    must_appear_in_top: usize,
-}
-
-impl Default for RetrievalCaseBuilder {
-    fn default() -> Self {
-        Self {
-            name: None,
-            query: None,
-            mode: RetrievalMode::Hybrid,
-            format: CaseFormat::Json,
-            filters: CaseFilters::default(),
-            expected_ids: Vec::new(),
-            expected_diagnostics: Vec::new(),
-            expected_evidence: BTreeMap::new(),
-            expect_stdout_contains: None,
-            expected_exit: 0,
-            must_appear_in_top: 5,
-        }
-    }
-}
-
-impl RetrievalCaseBuilder {
-    fn finish(self, index: usize) -> Result<RetrievalCase, String> {
-        let query = self
-            .query
-            .ok_or_else(|| format!("retrieval case {index} is missing query"))?;
-        Ok(RetrievalCase {
-            name: self.name.unwrap_or_else(|| format!("case-{index}")),
-            query,
-            mode: self.mode,
-            format: self.format,
-            filters: self.filters,
-            expected_ids: self.expected_ids,
-            expected_diagnostics: self.expected_diagnostics,
-            expected_evidence: self.expected_evidence,
-            expect_stdout_contains: self.expect_stdout_contains,
-            expected_exit: self.expected_exit,
-            must_appear_in_top: self.must_appear_in_top,
-        })
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum NestedSection {
-    Filters,
-    ExpectedEvidence,
+fn default_must_appear_in_top() -> usize {
+    5
 }
 
 #[test]
@@ -604,153 +563,41 @@ fn assert_expected_evidence(case: &RetrievalCase, envelope: &Value) {
 }
 
 fn parse_retrieval_set(input: &str) -> Result<Vec<RetrievalCase>, String> {
-    let mut cases = Vec::new();
-    let mut current: Option<RetrievalCaseBuilder> = None;
-    let mut section: Option<NestedSection> = None;
-
-    for (line_index, raw_line) in input.lines().enumerate() {
-        let line_number = line_index + 1;
-        let line_without_comment = raw_line.split_once('#').map_or(raw_line, |(line, _)| line);
-        if line_without_comment.trim().is_empty() {
-            continue;
+    let mut cases: Vec<RetrievalCase> = serde_saphyr::from_str(input)
+        .map_err(|error| format!("retrieval-set.yaml parse error: {error}"))?;
+    for (index, case) in cases.iter_mut().enumerate() {
+        if case.name.is_empty() {
+            case.name = format!("case-{}", index + 1);
         }
-        let indent = line_without_comment
-            .chars()
-            .take_while(|character| *character == ' ')
-            .count();
-        let line = line_without_comment.trim();
-
-        if let Some(rest) = line.strip_prefix("- ") {
-            if let Some(builder) = current.take() {
-                let index = cases.len() + 1;
-                cases.push(builder.finish(index)?);
-            }
-            let mut builder = RetrievalCaseBuilder::default();
-            parse_case_key_value(&mut builder, rest, line_number)?;
-            current = Some(builder);
-            section = None;
-            continue;
-        }
-
-        let builder = current
-            .as_mut()
-            .ok_or_else(|| format!("line {line_number}: expected a list item"))?;
-        if indent == 2 && line.ends_with(':') {
-            section = Some(match line.trim_end_matches(':') {
-                "filters" => NestedSection::Filters,
-                "expected_evidence" => NestedSection::ExpectedEvidence,
-                key => return Err(format!("line {line_number}: unknown section `{key}`")),
-            });
-            continue;
-        }
-
-        match (indent, section) {
-            (2, _) => {
-                section = None;
-                parse_case_key_value(builder, line, line_number)?;
-            }
-            (4.., Some(NestedSection::Filters)) => {
-                parse_filter_key_value(&mut builder.filters, line, line_number)?;
-            }
-            (4.., Some(NestedSection::ExpectedEvidence)) => {
-                let (key, value) = parse_key_value(line, line_number)?;
-                builder.expected_evidence.insert(key, parse_scalar(value));
-            }
-            _ => return Err(format!("line {line_number}: invalid indentation")),
-        }
-    }
-
-    if let Some(builder) = current.take() {
-        let index = cases.len() + 1;
-        cases.push(builder.finish(index)?);
     }
     Ok(cases)
 }
 
-fn parse_case_key_value(
-    builder: &mut RetrievalCaseBuilder,
-    line: &str,
-    line_number: usize,
-) -> Result<(), String> {
-    let (key, value) = parse_key_value(line, line_number)?;
-    match key.as_str() {
-        "name" => builder.name = Some(parse_scalar(value)),
-        "query" => builder.query = Some(parse_scalar(value)),
-        "mode" => {
-            builder.mode = match parse_scalar(value).as_str() {
-                "hybrid" => RetrievalMode::Hybrid,
-                "lexical" => RetrievalMode::Lexical,
-                "semantic" => RetrievalMode::Semantic,
-                mode => return Err(format!("line {line_number}: unknown mode `{mode}`")),
-            };
-        }
-        "format" => {
-            builder.format = match parse_scalar(value).as_str() {
-                "json" => CaseFormat::Json,
-                "plain" => CaseFormat::Plain,
-                format => return Err(format!("line {line_number}: unknown format `{format}`")),
-            };
-        }
-        "expected_ids" => builder.expected_ids = parse_inline_list(value, line_number)?,
-        "expected_diagnostics" => {
-            builder.expected_diagnostics = parse_inline_list(value, line_number)?
-        }
-        "expected_exit" => {
-            builder.expected_exit = parse_scalar(value)
-                .parse::<i32>()
-                .map_err(|error| format!("line {line_number}: invalid expected_exit: {error}"))?;
-        }
-        "must_appear_in_top" => {
-            builder.must_appear_in_top = parse_scalar(value).parse::<usize>().map_err(|error| {
-                format!("line {line_number}: invalid must_appear_in_top: {error}")
-            })?;
-        }
-        "expect_stdout_contains" => builder.expect_stdout_contains = Some(parse_scalar(value)),
-        key => return Err(format!("line {line_number}: unknown key `{key}`")),
-    }
-    Ok(())
-}
+#[test]
+fn retrieval_set_parser_accepts_yaml_scalars_and_block_lists() {
+    let cases = parse_retrieval_set(
+        r#"
+- query: "key: value # literal"
+  expected_ids:
+    - billing.example
+  expected_evidence:
+    source: "runbook: v3 # literal"
+  filters:
+    source_path: "docs:billing.adoc"
+"#,
+    )
+    .expect("retrieval set YAML parses");
 
-fn parse_filter_key_value(
-    filters: &mut CaseFilters,
-    line: &str,
-    line_number: usize,
-) -> Result<(), String> {
-    let (key, value) = parse_key_value(line, line_number)?;
-    let value = Some(parse_scalar(value));
-    match key.as_str() {
-        "kind" => filters.kind = value,
-        "status" => filters.status = value,
-        "owner" => filters.owner = value,
-        "source_path" => filters.source_path = value,
-        key => return Err(format!("line {line_number}: unknown filter `{key}`")),
-    }
-    Ok(())
-}
-
-fn parse_key_value(line: &str, line_number: usize) -> Result<(String, &str), String> {
-    let (key, value) = line
-        .split_once(':')
-        .ok_or_else(|| format!("line {line_number}: expected key: value"))?;
-    Ok((key.trim().to_string(), value.trim()))
-}
-
-fn parse_inline_list(value: &str, line_number: usize) -> Result<Vec<String>, String> {
-    let value = value.trim();
-    let inner = value
-        .strip_prefix('[')
-        .and_then(|value| value.strip_suffix(']'))
-        .ok_or_else(|| format!("line {line_number}: expected inline list"))?;
-    if inner.trim().is_empty() {
-        return Ok(Vec::new());
-    }
-    Ok(inner.split(',').map(parse_scalar).collect())
-}
-
-fn parse_scalar(value: &str) -> String {
-    value
-        .trim()
-        .trim_matches('"')
-        .trim_matches('\'')
-        .to_string()
+    assert_eq!(cases.len(), 1);
+    assert_eq!(cases[0].name, "case-1");
+    assert_eq!(cases[0].query, "key: value # literal");
+    assert_eq!(cases[0].expected_ids, ["billing.example"]);
+    assert_eq!(
+        cases[0].expected_evidence["source"],
+        "runbook: v3 # literal"
+    );
+    assert_eq!(
+        cases[0].filters.source_path.as_deref(),
+        Some("docs:billing.adoc")
+    );
 }

--- a/crates/adoc-cli/tests/retrieval_pilot.rs
+++ b/crates/adoc-cli/tests/retrieval_pilot.rs
@@ -1,6 +1,6 @@
 mod support;
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{Command, Output};
@@ -32,6 +32,27 @@ enum CaseFormat {
     Plain,
 }
 
+#[derive(Debug, Clone, Copy)]
+enum EmbeddingBackend {
+    InMemory,
+    #[cfg(feature = "fastembed-it")]
+    FastEmbed,
+}
+
+impl EmbeddingBackend {
+    fn configure(self, command: &mut Command) {
+        match self {
+            Self::InMemory => {
+                command.env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory");
+            }
+            #[cfg(feature = "fastembed-it")]
+            Self::FastEmbed => {
+                command.env_remove("ADOC_TEST_EMBEDDING_PROVIDER");
+            }
+        }
+    }
+}
+
 #[derive(Debug, Clone, Default)]
 struct CaseFilters {
     kind: Option<String>,
@@ -53,6 +74,13 @@ struct RetrievalCase {
     expect_stdout_contains: Option<String>,
     expected_exit: i32,
     must_appear_in_top: usize,
+}
+
+struct PilotBuild {
+    _workspace: TestWorkspace,
+    artifact_path: PathBuf,
+    search_artifact_path: PathBuf,
+    agent_json: Value,
 }
 
 #[derive(Debug, Clone)]
@@ -117,6 +145,19 @@ enum NestedSection {
 
 #[test]
 fn retrieval_set_queries_pass_against_billing_pilot() {
+    run_retrieval_set(EmbeddingBackend::InMemory, "billing-pilot-retrieval-set");
+}
+
+#[cfg(feature = "fastembed-it")]
+#[test]
+fn retrieval_set_queries_pass_against_fastembed_provider() {
+    run_retrieval_set(
+        EmbeddingBackend::FastEmbed,
+        "billing-pilot-fastembed-retrieval-set",
+    );
+}
+
+fn run_retrieval_set(backend: EmbeddingBackend, workspace_name: &str) {
     let repo_root = repo_root();
     let retrieval_set_path = repo_root
         .join("examples")
@@ -132,29 +173,17 @@ fn retrieval_set_queries_pass_against_billing_pilot() {
         cases.len()
     );
 
-    let workspace = TestWorkspace::new("billing-pilot-retrieval-set");
-    let output_directory = workspace.root.join("dist");
-    let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
-        .current_dir(&repo_root)
-        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
-        .args([
-            "build",
-            "examples/billing-pilot",
-            "--out",
-            output_directory
-                .to_str()
-                .expect("output directory path is utf-8"),
-        ])
-        .output()
-        .expect("adoc build runs");
-    assert_success("billing pilot build", &build_output);
-
-    let artifact_path = output_directory.join("docs.agent.json");
-    let search_artifact_path = output_directory.join("docs.search.json");
+    let pilot = build_billing_pilot(&repo_root, workspace_name, backend);
     let mut expected_id_assertions = 0usize;
 
     for case in &cases {
-        let output = run_search_case(case, &repo_root, &artifact_path, &search_artifact_path);
+        let output = run_search_case(
+            case,
+            &repo_root,
+            &pilot.artifact_path,
+            &pilot.search_artifact_path,
+            backend,
+        );
         assert_eq!(
             output.status.code(),
             Some(case.expected_exit),
@@ -175,6 +204,7 @@ fn retrieval_set_queries_pass_against_billing_pilot() {
                 let envelope: Value = serde_json::from_slice(&output.stdout)
                     .unwrap_or_else(|error| panic!("case `{}` stdout is JSON: {error}", case.name));
                 assert_eq!(envelope["schema_version"], "adoc.retrieval.v0");
+                assert_record_contract(&case.name, &envelope, case.mode, case.must_appear_in_top);
                 assert_expected_diagnostics(case, &envelope);
                 expected_id_assertions += assert_expected_ids(case, &envelope);
                 assert_expected_evidence(case, &envelope);
@@ -201,10 +231,138 @@ fn retrieval_set_queries_pass_against_billing_pilot() {
     }
 
     println!(
-        "retrieval-set baseline: {} queries, {} expected-id assertions passed",
+        "retrieval-set baseline: {} queries, {} succeeded, 0 failed; {} expected-id assertions passed",
+        cases.len(),
         cases.len(),
         expected_id_assertions
     );
+}
+
+#[test]
+fn retrieval_pilot_property_invariants_hold() {
+    assert_property_invariants(EmbeddingBackend::InMemory, "billing-pilot-invariants");
+}
+
+#[cfg(feature = "fastembed-it")]
+#[test]
+fn retrieval_pilot_property_invariants_hold_against_fastembed_provider() {
+    assert_property_invariants(
+        EmbeddingBackend::FastEmbed,
+        "billing-pilot-fastembed-invariants",
+    );
+}
+
+fn assert_property_invariants(backend: EmbeddingBackend, workspace_name: &str) {
+    let repo_root = repo_root();
+    let pilot = build_billing_pilot(&repo_root, workspace_name, backend);
+    let objects = pilot.agent_json["objects"]
+        .as_array()
+        .expect("agent JSON objects is an array");
+    assert!(!objects.is_empty(), "pilot artifact should contain objects");
+
+    let mut owners: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for object in objects {
+        let id = object["id"].as_str().expect("object id is a string");
+        let body = object["body"]
+            .as_str()
+            .expect("object body is a string")
+            .trim();
+
+        let id_envelope = run_lexical_json(&repo_root, &pilot.artifact_path, id, 1, &[], backend);
+        assert_record_contract(
+            &format!("object-id invariant for {id}"),
+            &id_envelope,
+            RetrievalMode::Lexical,
+            1,
+        );
+        assert_first_id(&format!("object-id invariant for {id}"), &id_envelope, id);
+
+        let body_envelope =
+            run_lexical_json(&repo_root, &pilot.artifact_path, body, 1, &[], backend);
+        assert_record_contract(
+            &format!("body invariant for {id}"),
+            &body_envelope,
+            RetrievalMode::Lexical,
+            1,
+        );
+        assert_first_id(&format!("body invariant for {id}"), &body_envelope, id);
+
+        if let Some(owner) = object["fields"]["owner"].as_str() {
+            owners
+                .entry(owner.to_string())
+                .or_default()
+                .push(id.to_string());
+        }
+    }
+
+    for (owner, expected_ids) in owners {
+        let owner_filter = [("--owner", owner.as_str())];
+        let envelope = run_lexical_json(
+            &repo_root,
+            &pilot.artifact_path,
+            "",
+            expected_ids.len(),
+            &owner_filter,
+            backend,
+        );
+        assert_record_contract(
+            &format!("owner invariant for {owner}"),
+            &envelope,
+            RetrievalMode::Lexical,
+            expected_ids.len(),
+        );
+        let actual_ids = record_ids(&envelope);
+        for expected_id in &expected_ids {
+            assert!(
+                actual_ids.iter().any(|id| id == expected_id),
+                "owner invariant for `{owner}` expected `{expected_id}` in {actual_ids:?}"
+            );
+        }
+        for record in envelope["records"].as_array().expect("records is an array") {
+            assert_eq!(
+                record["owner"], owner,
+                "owner invariant for `{owner}` returned wrong owner in {record}"
+            );
+        }
+    }
+}
+
+fn build_billing_pilot(
+    repo_root: &Path,
+    workspace_name: &str,
+    backend: EmbeddingBackend,
+) -> PilotBuild {
+    let workspace = TestWorkspace::new(workspace_name);
+    let output_directory = workspace.root.join("dist");
+    let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+    backend.configure(&mut command);
+    let build_output = command
+        .current_dir(repo_root)
+        .args([
+            "build",
+            "examples/billing-pilot",
+            "--out",
+            output_directory
+                .to_str()
+                .expect("output directory path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+    assert_success("billing pilot build", &build_output);
+
+    let artifact_path = output_directory.join("docs.agent.json");
+    let search_artifact_path = output_directory.join("docs.search.json");
+    let agent_json_text =
+        fs::read_to_string(&artifact_path).expect("billing pilot agent JSON is written");
+    let agent_json: Value =
+        serde_json::from_str(&agent_json_text).expect("agent JSON is valid JSON");
+
+    PilotBuild {
+        _workspace: workspace,
+        artifact_path,
+        search_artifact_path,
+        agent_json,
+    }
 }
 
 fn run_search_case(
@@ -212,6 +370,7 @@ fn run_search_case(
     repo_root: &PathBuf,
     artifact_path: &Path,
     search_artifact_path: &Path,
+    backend: EmbeddingBackend,
 ) -> Output {
     let mut args = vec![
         "search".to_string(),
@@ -238,12 +397,58 @@ fn run_search_case(
     push_filter_arg(&mut args, "--owner", &case.filters.owner);
     push_filter_arg(&mut args, "--source-path", &case.filters.source_path);
 
-    Command::new(env!("CARGO_BIN_EXE_adoc"))
+    let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+    backend.configure(&mut command);
+    command
         .current_dir(repo_root)
-        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
         .args(args)
         .output()
         .expect("adoc search runs")
+}
+
+fn run_lexical_json(
+    repo_root: &Path,
+    artifact_path: &Path,
+    query: &str,
+    top: usize,
+    filters: &[(&str, &str)],
+    backend: EmbeddingBackend,
+) -> Value {
+    let mut args = vec![
+        "search".to_string(),
+        query.to_string(),
+        "--artifact".to_string(),
+        artifact_path.to_string_lossy().into_owned(),
+        "--lexical".to_string(),
+        "--format".to_string(),
+        "json".to_string(),
+        "--top".to_string(),
+        top.max(1).to_string(),
+    ];
+    for (flag, value) in filters {
+        args.push((*flag).to_string());
+        args.push((*value).to_string());
+    }
+
+    let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+    backend.configure(&mut command);
+    let output = command
+        .current_dir(repo_root)
+        .args(args)
+        .output()
+        .expect("adoc search runs");
+    assert_success("lexical JSON search", &output);
+    assert!(
+        output.stderr.is_empty(),
+        "lexical JSON search should not emit stderr\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    serde_json::from_slice(&output.stdout).unwrap_or_else(|error| {
+        panic!(
+            "lexical JSON search stdout is JSON: {error}\nstdout:\n{}",
+            String::from_utf8_lossy(&output.stdout)
+        )
+    })
 }
 
 fn push_filter_arg(args: &mut Vec<String>, flag: &str, value: &Option<String>) {
@@ -260,6 +465,75 @@ fn assert_success(label: &str, output: &Output) {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
+}
+
+fn assert_record_contract(label: &str, envelope: &Value, expected_mode: RetrievalMode, top: usize) {
+    let records = envelope["records"].as_array().expect("records is an array");
+    assert!(
+        records.len() <= top,
+        "{label} returned more records than top {top}: {records:?}"
+    );
+
+    let mut seen_ids = BTreeSet::new();
+    for (index, record) in records.iter().enumerate() {
+        let id = record["id"].as_str().expect("record id is a string");
+        assert!(seen_ids.insert(id), "{label} returned duplicate id `{id}`");
+        assert_eq!(
+            record["match"]["result_rank"],
+            (index + 1) as u64,
+            "{label} should have contiguous result ranks"
+        );
+
+        let expected_mode_text = match expected_mode {
+            RetrievalMode::Hybrid => "hybrid",
+            RetrievalMode::Lexical => "lexical",
+            RetrievalMode::Semantic => "semantic",
+        };
+        assert_eq!(
+            record["match"]["mode"], expected_mode_text,
+            "{label} should report requested mode"
+        );
+        match expected_mode {
+            RetrievalMode::Hybrid => {
+                assert!(
+                    record["match"]["rrf_score"].is_number(),
+                    "{label} hybrid record should include rrf_score: {record}"
+                );
+                assert!(
+                    record["match"].get("cosine_score").is_none(),
+                    "{label} hybrid record should not expose raw cosine score: {record}"
+                );
+            }
+            RetrievalMode::Lexical => {}
+            RetrievalMode::Semantic => {
+                assert!(
+                    record["match"]["vector_rank"].is_number(),
+                    "{label} semantic record should include vector_rank: {record}"
+                );
+                assert!(
+                    record["match"]["cosine_score"].is_number(),
+                    "{label} semantic record should include cosine_score: {record}"
+                );
+            }
+        }
+    }
+}
+
+fn assert_first_id(label: &str, envelope: &Value, expected_id: &str) {
+    let records = envelope["records"].as_array().expect("records is an array");
+    let first = records
+        .first()
+        .unwrap_or_else(|| panic!("{label} expected one record"));
+    assert_eq!(first["id"], expected_id, "{label} returned wrong top hit");
+}
+
+fn record_ids(envelope: &Value) -> Vec<&str> {
+    envelope["records"]
+        .as_array()
+        .expect("records is an array")
+        .iter()
+        .filter_map(|record| record["id"].as_str())
+        .collect()
 }
 
 fn assert_expected_diagnostics(case: &RetrievalCase, envelope: &Value) {

--- a/crates/adoc-cli/tests/retrieval_pilot.rs
+++ b/crates/adoc-cli/tests/retrieval_pilot.rs
@@ -1,0 +1,478 @@
+mod support;
+
+use std::collections::BTreeMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use serde_json::Value;
+use support::TestWorkspace;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cli crate has workspace parent")
+        .parent()
+        .expect("workspace has repo root")
+        .to_path_buf()
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum RetrievalMode {
+    #[default]
+    Hybrid,
+    Lexical,
+    Semantic,
+}
+
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+enum CaseFormat {
+    #[default]
+    Json,
+    Plain,
+}
+
+#[derive(Debug, Clone, Default)]
+struct CaseFilters {
+    kind: Option<String>,
+    status: Option<String>,
+    owner: Option<String>,
+    source_path: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct RetrievalCase {
+    name: String,
+    query: String,
+    mode: RetrievalMode,
+    format: CaseFormat,
+    filters: CaseFilters,
+    expected_ids: Vec<String>,
+    expected_diagnostics: Vec<String>,
+    expected_evidence: BTreeMap<String, String>,
+    expect_stdout_contains: Option<String>,
+    expected_exit: i32,
+    must_appear_in_top: usize,
+}
+
+#[derive(Debug, Clone)]
+struct RetrievalCaseBuilder {
+    name: Option<String>,
+    query: Option<String>,
+    mode: RetrievalMode,
+    format: CaseFormat,
+    filters: CaseFilters,
+    expected_ids: Vec<String>,
+    expected_diagnostics: Vec<String>,
+    expected_evidence: BTreeMap<String, String>,
+    expect_stdout_contains: Option<String>,
+    expected_exit: i32,
+    must_appear_in_top: usize,
+}
+
+impl Default for RetrievalCaseBuilder {
+    fn default() -> Self {
+        Self {
+            name: None,
+            query: None,
+            mode: RetrievalMode::Hybrid,
+            format: CaseFormat::Json,
+            filters: CaseFilters::default(),
+            expected_ids: Vec::new(),
+            expected_diagnostics: Vec::new(),
+            expected_evidence: BTreeMap::new(),
+            expect_stdout_contains: None,
+            expected_exit: 0,
+            must_appear_in_top: 5,
+        }
+    }
+}
+
+impl RetrievalCaseBuilder {
+    fn finish(self, index: usize) -> Result<RetrievalCase, String> {
+        let query = self
+            .query
+            .ok_or_else(|| format!("retrieval case {index} is missing query"))?;
+        Ok(RetrievalCase {
+            name: self.name.unwrap_or_else(|| format!("case-{index}")),
+            query,
+            mode: self.mode,
+            format: self.format,
+            filters: self.filters,
+            expected_ids: self.expected_ids,
+            expected_diagnostics: self.expected_diagnostics,
+            expected_evidence: self.expected_evidence,
+            expect_stdout_contains: self.expect_stdout_contains,
+            expected_exit: self.expected_exit,
+            must_appear_in_top: self.must_appear_in_top,
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum NestedSection {
+    Filters,
+    ExpectedEvidence,
+}
+
+#[test]
+fn retrieval_set_queries_pass_against_billing_pilot() {
+    let repo_root = repo_root();
+    let retrieval_set_path = repo_root
+        .join("examples")
+        .join("billing-pilot")
+        .join("retrieval-set.yaml");
+    let retrieval_set =
+        fs::read_to_string(&retrieval_set_path).expect("billing pilot retrieval-set.yaml exists");
+    let cases = parse_retrieval_set(&retrieval_set).expect("retrieval-set.yaml parses");
+
+    assert!(
+        (15..=20).contains(&cases.len()),
+        "retrieval set should carry 15-20 benchmark cases, got {}",
+        cases.len()
+    );
+
+    let workspace = TestWorkspace::new("billing-pilot-retrieval-set");
+    let output_directory = workspace.root.join("dist");
+    let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&repo_root)
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
+        .args([
+            "build",
+            "examples/billing-pilot",
+            "--out",
+            output_directory
+                .to_str()
+                .expect("output directory path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+    assert_success("billing pilot build", &build_output);
+
+    let artifact_path = output_directory.join("docs.agent.json");
+    let search_artifact_path = output_directory.join("docs.search.json");
+    let mut expected_id_assertions = 0usize;
+
+    for case in &cases {
+        let output = run_search_case(case, &repo_root, &artifact_path, &search_artifact_path);
+        assert_eq!(
+            output.status.code(),
+            Some(case.expected_exit),
+            "unexpected exit for `{}`\nstdout:\n{}\nstderr:\n{}",
+            case.name,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+
+        match case.format {
+            CaseFormat::Json => {
+                assert!(
+                    output.stderr.is_empty(),
+                    "JSON case `{}` should not emit stderr diagnostics\nstderr:\n{}",
+                    case.name,
+                    String::from_utf8_lossy(&output.stderr)
+                );
+                let envelope: Value = serde_json::from_slice(&output.stdout)
+                    .unwrap_or_else(|error| panic!("case `{}` stdout is JSON: {error}", case.name));
+                assert_eq!(envelope["schema_version"], "adoc.retrieval.v0");
+                assert_expected_diagnostics(case, &envelope);
+                expected_id_assertions += assert_expected_ids(case, &envelope);
+                assert_expected_evidence(case, &envelope);
+            }
+            CaseFormat::Plain => {
+                if case.expected_exit == 0 {
+                    assert!(
+                        output.stderr.is_empty(),
+                        "plain success case `{}` should not emit stderr\nstderr:\n{}",
+                        case.name,
+                        String::from_utf8_lossy(&output.stderr)
+                    );
+                }
+                if let Some(expected) = &case.expect_stdout_contains {
+                    assert!(
+                        String::from_utf8_lossy(&output.stdout).contains(expected),
+                        "plain case `{}` stdout should contain `{expected}`\nstdout:\n{}",
+                        case.name,
+                        String::from_utf8_lossy(&output.stdout)
+                    );
+                }
+            }
+        }
+    }
+
+    println!(
+        "retrieval-set baseline: {} queries, {} expected-id assertions passed",
+        cases.len(),
+        expected_id_assertions
+    );
+}
+
+fn run_search_case(
+    case: &RetrievalCase,
+    repo_root: &PathBuf,
+    artifact_path: &Path,
+    search_artifact_path: &Path,
+) -> Output {
+    let mut args = vec![
+        "search".to_string(),
+        case.query.clone(),
+        "--artifact".to_string(),
+        artifact_path.to_string_lossy().into_owned(),
+        "--search-artifact".to_string(),
+        search_artifact_path.to_string_lossy().into_owned(),
+        "--top".to_string(),
+        case.must_appear_in_top.max(1).to_string(),
+    ];
+
+    match case.mode {
+        RetrievalMode::Hybrid => {}
+        RetrievalMode::Lexical => args.push("--lexical".to_string()),
+        RetrievalMode::Semantic => args.push("--semantic".to_string()),
+    }
+    match case.format {
+        CaseFormat::Json => args.extend(["--format".to_string(), "json".to_string()]),
+        CaseFormat::Plain => args.extend(["--format".to_string(), "plain".to_string()]),
+    }
+    push_filter_arg(&mut args, "--kind", &case.filters.kind);
+    push_filter_arg(&mut args, "--status", &case.filters.status);
+    push_filter_arg(&mut args, "--owner", &case.filters.owner);
+    push_filter_arg(&mut args, "--source-path", &case.filters.source_path);
+
+    Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(repo_root)
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
+        .args(args)
+        .output()
+        .expect("adoc search runs")
+}
+
+fn push_filter_arg(args: &mut Vec<String>, flag: &str, value: &Option<String>) {
+    if let Some(value) = value {
+        args.push(flag.to_string());
+        args.push(value.clone());
+    }
+}
+
+fn assert_success(label: &str, output: &Output) {
+    assert!(
+        output.status.success(),
+        "expected {label} to pass\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+fn assert_expected_diagnostics(case: &RetrievalCase, envelope: &Value) {
+    let diagnostics = envelope["diagnostics"]
+        .as_array()
+        .expect("diagnostics is an array");
+    for code in &case.expected_diagnostics {
+        assert!(
+            diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic["code"] == *code),
+            "case `{}` expected diagnostic `{code}` in {diagnostics:?}",
+            case.name
+        );
+    }
+    if case.expected_exit == 0 && case.expected_diagnostics.is_empty() {
+        assert!(
+            diagnostics.is_empty(),
+            "case `{}` expected no diagnostics, got {diagnostics:?}",
+            case.name
+        );
+    }
+}
+
+fn assert_expected_ids(case: &RetrievalCase, envelope: &Value) -> usize {
+    if case.expected_ids.is_empty() {
+        return 0;
+    }
+    let records = envelope["records"].as_array().expect("records is an array");
+    let ids: Vec<&str> = records
+        .iter()
+        .filter_map(|record| record["id"].as_str())
+        .collect();
+    let top_ids: Vec<&str> = ids.iter().take(case.must_appear_in_top).copied().collect();
+    for expected_id in &case.expected_ids {
+        assert!(
+            top_ids.iter().any(|id| id == expected_id),
+            "case `{}` expected `{expected_id}` in top {} IDs; got {ids:?}",
+            case.name,
+            case.must_appear_in_top
+        );
+    }
+    case.expected_ids.len()
+}
+
+fn assert_expected_evidence(case: &RetrievalCase, envelope: &Value) {
+    if case.expected_evidence.is_empty() {
+        return;
+    }
+    let records = envelope["records"].as_array().expect("records is an array");
+    let target = case
+        .expected_ids
+        .first()
+        .and_then(|expected_id| records.iter().find(|record| record["id"] == *expected_id))
+        .or_else(|| records.first())
+        .unwrap_or_else(|| panic!("case `{}` expected at least one record", case.name));
+    for (key, expected_value) in &case.expected_evidence {
+        assert_eq!(
+            target["evidence"][key], *expected_value,
+            "case `{}` expected evidence `{key}`",
+            case.name
+        );
+    }
+}
+
+fn parse_retrieval_set(input: &str) -> Result<Vec<RetrievalCase>, String> {
+    let mut cases = Vec::new();
+    let mut current: Option<RetrievalCaseBuilder> = None;
+    let mut section: Option<NestedSection> = None;
+
+    for (line_index, raw_line) in input.lines().enumerate() {
+        let line_number = line_index + 1;
+        let line_without_comment = raw_line.split_once('#').map_or(raw_line, |(line, _)| line);
+        if line_without_comment.trim().is_empty() {
+            continue;
+        }
+        let indent = line_without_comment
+            .chars()
+            .take_while(|character| *character == ' ')
+            .count();
+        let line = line_without_comment.trim();
+
+        if let Some(rest) = line.strip_prefix("- ") {
+            if let Some(builder) = current.take() {
+                let index = cases.len() + 1;
+                cases.push(builder.finish(index)?);
+            }
+            let mut builder = RetrievalCaseBuilder::default();
+            parse_case_key_value(&mut builder, rest, line_number)?;
+            current = Some(builder);
+            section = None;
+            continue;
+        }
+
+        let builder = current
+            .as_mut()
+            .ok_or_else(|| format!("line {line_number}: expected a list item"))?;
+        if indent == 2 && line.ends_with(':') {
+            section = Some(match line.trim_end_matches(':') {
+                "filters" => NestedSection::Filters,
+                "expected_evidence" => NestedSection::ExpectedEvidence,
+                key => return Err(format!("line {line_number}: unknown section `{key}`")),
+            });
+            continue;
+        }
+
+        match (indent, section) {
+            (2, _) => {
+                section = None;
+                parse_case_key_value(builder, line, line_number)?;
+            }
+            (4.., Some(NestedSection::Filters)) => {
+                parse_filter_key_value(&mut builder.filters, line, line_number)?;
+            }
+            (4.., Some(NestedSection::ExpectedEvidence)) => {
+                let (key, value) = parse_key_value(line, line_number)?;
+                builder.expected_evidence.insert(key, parse_scalar(value));
+            }
+            _ => return Err(format!("line {line_number}: invalid indentation")),
+        }
+    }
+
+    if let Some(builder) = current.take() {
+        let index = cases.len() + 1;
+        cases.push(builder.finish(index)?);
+    }
+    Ok(cases)
+}
+
+fn parse_case_key_value(
+    builder: &mut RetrievalCaseBuilder,
+    line: &str,
+    line_number: usize,
+) -> Result<(), String> {
+    let (key, value) = parse_key_value(line, line_number)?;
+    match key.as_str() {
+        "name" => builder.name = Some(parse_scalar(value)),
+        "query" => builder.query = Some(parse_scalar(value)),
+        "mode" => {
+            builder.mode = match parse_scalar(value).as_str() {
+                "hybrid" => RetrievalMode::Hybrid,
+                "lexical" => RetrievalMode::Lexical,
+                "semantic" => RetrievalMode::Semantic,
+                mode => return Err(format!("line {line_number}: unknown mode `{mode}`")),
+            };
+        }
+        "format" => {
+            builder.format = match parse_scalar(value).as_str() {
+                "json" => CaseFormat::Json,
+                "plain" => CaseFormat::Plain,
+                format => return Err(format!("line {line_number}: unknown format `{format}`")),
+            };
+        }
+        "expected_ids" => builder.expected_ids = parse_inline_list(value, line_number)?,
+        "expected_diagnostics" => {
+            builder.expected_diagnostics = parse_inline_list(value, line_number)?
+        }
+        "expected_exit" => {
+            builder.expected_exit = parse_scalar(value)
+                .parse::<i32>()
+                .map_err(|error| format!("line {line_number}: invalid expected_exit: {error}"))?;
+        }
+        "must_appear_in_top" => {
+            builder.must_appear_in_top = parse_scalar(value).parse::<usize>().map_err(|error| {
+                format!("line {line_number}: invalid must_appear_in_top: {error}")
+            })?;
+        }
+        "expect_stdout_contains" => builder.expect_stdout_contains = Some(parse_scalar(value)),
+        key => return Err(format!("line {line_number}: unknown key `{key}`")),
+    }
+    Ok(())
+}
+
+fn parse_filter_key_value(
+    filters: &mut CaseFilters,
+    line: &str,
+    line_number: usize,
+) -> Result<(), String> {
+    let (key, value) = parse_key_value(line, line_number)?;
+    let value = Some(parse_scalar(value));
+    match key.as_str() {
+        "kind" => filters.kind = value,
+        "status" => filters.status = value,
+        "owner" => filters.owner = value,
+        "source_path" => filters.source_path = value,
+        key => return Err(format!("line {line_number}: unknown filter `{key}`")),
+    }
+    Ok(())
+}
+
+fn parse_key_value(line: &str, line_number: usize) -> Result<(String, &str), String> {
+    let (key, value) = line
+        .split_once(':')
+        .ok_or_else(|| format!("line {line_number}: expected key: value"))?;
+    Ok((key.trim().to_string(), value.trim()))
+}
+
+fn parse_inline_list(value: &str, line_number: usize) -> Result<Vec<String>, String> {
+    let value = value.trim();
+    let inner = value
+        .strip_prefix('[')
+        .and_then(|value| value.strip_suffix(']'))
+        .ok_or_else(|| format!("line {line_number}: expected inline list"))?;
+    if inner.trim().is_empty() {
+        return Ok(Vec::new());
+    }
+    Ok(inner.split(',').map(parse_scalar).collect())
+}
+
+fn parse_scalar(value: &str) -> String {
+    value
+        .trim()
+        .trim_matches('"')
+        .trim_matches('\'')
+        .to_string()
+}

--- a/crates/adoc-cli/tests/retrieval_pilot.rs
+++ b/crates/adoc-cli/tests/retrieval_pilot.rs
@@ -278,14 +278,18 @@ fn assert_property_invariants(backend: EmbeddingBackend, workspace_name: &str) {
         assert_first_id(&format!("object-id invariant for {id}"), &id_envelope, id);
 
         let body_envelope =
-            run_lexical_json(&repo_root, &pilot.artifact_path, body, 1, &[], backend);
+            run_lexical_json(&repo_root, &pilot.artifact_path, body, 3, &[], backend);
         assert_record_contract(
             &format!("body invariant for {id}"),
             &body_envelope,
             RetrievalMode::Lexical,
-            1,
+            3,
         );
-        assert_first_id(&format!("body invariant for {id}"), &body_envelope, id);
+        let body_ids = record_ids(&body_envelope);
+        assert!(
+            body_ids.iter().any(|body_id| body_id == &id),
+            "body invariant for `{id}` expected source object in top 3; got {body_ids:?}"
+        );
 
         if let Some(owner) = object["fields"]["owner"].as_str() {
             owners

--- a/crates/adoc-cli/tests/search_cli.rs
+++ b/crates/adoc-cli/tests/search_cli.rs
@@ -53,7 +53,15 @@ fn search_object_ids(stdout: &[u8]) -> Vec<String> {
 fn assert_search_top_3_contains(query: &str, expected_id: &str) {
     let artifact = pilot_subset_artifact();
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
-        .args(["search", query, "--artifact", &artifact, "--top", "3"])
+        .args([
+            "search",
+            query,
+            "--artifact",
+            &artifact,
+            "--lexical",
+            "--top",
+            "3",
+        ])
         .output()
         .expect("adoc search runs");
 
@@ -91,6 +99,7 @@ fn search_cli_billing_pilot_subset_supports_exact_id_prefix_id_and_filters() {
             "billing.credits.decrement-after-success",
             "--artifact",
             &artifact,
+            "--lexical",
             "--top",
             "1",
         ])
@@ -108,6 +117,7 @@ fn search_cli_billing_pilot_subset_supports_exact_id_prefix_id_and_filters() {
             "billing.credits",
             "--artifact",
             &artifact,
+            "--lexical",
             "--top",
             "3",
         ])
@@ -129,6 +139,7 @@ fn search_cli_billing_pilot_subset_supports_exact_id_prefix_id_and_filters() {
             "ledger",
             "--artifact",
             &artifact,
+            "--lexical",
             "--kind",
             "decision",
             "--status",
@@ -158,6 +169,7 @@ fn search_cli_empty_fixture_prints_no_matches() {
             "credit ledger",
             "--artifact",
             &artifact,
+            "--lexical",
             "--top",
             "3",
         ])
@@ -191,9 +203,11 @@ fn search_cli_defaults_to_dist_agent_json_and_text_format() {
         String::from_utf8_lossy(&output.stdout),
         String::from_utf8_lossy(&output.stderr)
     );
-    assert!(
-        output.stderr.is_empty(),
-        "successful text search should not emit diagnostics"
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert_eq!(
+        stderr.matches("search.artifact_missing").count(),
+        1,
+        "default hybrid fallback should emit one search.artifact_missing warning, stderr:\n{stderr}"
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(stdout.contains("Object: billing.refunds.issue-credit"));
@@ -215,6 +229,7 @@ fn search_cli_uses_explicit_artifact_path() {
             "risk",
             "--artifact",
             "custom/docs.agent.json",
+            "--lexical",
             "--format",
             "plain",
         ])
@@ -295,7 +310,7 @@ fn search_cli_empty_result_exits_0_and_prints_no_matches() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&workspace.root)
-        .args(["search", "chargebacks"])
+        .args(["search", "chargebacks", "--lexical"])
         .output()
         .expect("adoc search runs");
 
@@ -316,7 +331,7 @@ fn search_cli_invalid_filter_exits_1_and_prints_stderr_in_text_mode() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&workspace.root)
-        .args(["search", "ledger", "--kind", "runbook"])
+        .args(["search", "ledger", "--kind", "runbook", "--lexical"])
         .output()
         .expect("adoc search runs");
 
@@ -340,6 +355,7 @@ fn search_cli_json_success_includes_envelope_records_diagnostics_and_match_metad
         .args([
             "search",
             "ledger",
+            "--lexical",
             "--format",
             "json",
             "--kind",
@@ -382,7 +398,15 @@ fn search_cli_json_invalid_filter_exits_1_with_envelope_diagnostics_and_no_stder
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&workspace.root)
-        .args(["search", "ledger", "--kind", "runbook", "--format", "json"])
+        .args([
+            "search",
+            "ledger",
+            "--kind",
+            "runbook",
+            "--lexical",
+            "--format",
+            "json",
+        ])
         .output()
         .expect("adoc search runs");
 
@@ -410,7 +434,7 @@ fn search_cli_json_success_includes_loaded_artifact_warnings() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&workspace.root)
-        .args(["search", "ledger", "--format", "json"])
+        .args(["search", "ledger", "--lexical", "--format", "json"])
         .output()
         .expect("adoc search runs");
 
@@ -434,7 +458,7 @@ fn search_cli_text_success_prints_loaded_artifact_warnings_to_stderr() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&workspace.root)
-        .args(["search", "ledger"])
+        .args(["search", "ledger", "--lexical"])
         .output()
         .expect("adoc search runs");
 
@@ -450,7 +474,7 @@ fn search_cli_loaded_artifact_errors_exit_2() {
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
         .current_dir(&workspace.root)
-        .args(["search", "ledger", "--format", "json"])
+        .args(["search", "ledger", "--lexical", "--format", "json"])
         .output()
         .expect("adoc search runs");
 

--- a/crates/adoc-cli/tests/semantic_search_cli.rs
+++ b/crates/adoc-cli/tests/semantic_search_cli.rs
@@ -79,6 +79,14 @@ fn semantic_search_without_artifact_errors_out() {
             .any(|d| d["code"] == "search.artifact_missing"),
         "expected search.artifact_missing; got {envelope}"
     );
+    assert!(
+        envelope["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|d| d["code"] == "search.artifact_missing" && d["severity"] == "error"),
+        "expected error search.artifact_missing; got {envelope}"
+    );
 }
 
 #[test]

--- a/crates/adoc-cli/tests/semantic_search_cli.rs
+++ b/crates/adoc-cli/tests/semantic_search_cli.rs
@@ -118,20 +118,45 @@ fn semantic_search_without_artifact_does_not_pay_embed_model_load_cost() {
 }
 
 #[test]
-fn lexical_default_unchanged_when_search_artifact_present() {
+fn default_search_is_hybrid_when_search_artifact_is_present() {
     let pilot = build_v1_4_pilot();
     let envelope = run_search_json(&pilot, "credits", false);
     let first = &envelope["records"][0];
-    assert_eq!(first["match"]["mode"], "lexical");
+    assert_eq!(first["match"]["mode"], "hybrid");
     let m = first["match"].as_object().unwrap();
     assert!(
-        m.get("vector_rank").is_none_or(|v| v.is_null()),
-        "vector_rank should be absent or null for lexical: {first}"
+        m["rrf_score"].is_number(),
+        "rrf_score should be present for hybrid: {first}"
     );
     assert!(
         m.get("cosine_score").is_none_or(|v| v.is_null()),
-        "cosine_score should be absent or null for lexical: {first}"
+        "cosine_score should be absent or null for hybrid: {first}"
     );
+}
+
+#[test]
+fn lexical_flag_remains_escape_hatch_when_search_artifact_is_present() {
+    let pilot = build_v1_4_pilot();
+    let output = std::process::Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "search",
+            "credits",
+            "--artifact",
+            pilot.agent_path.to_str().unwrap(),
+            "--search-artifact",
+            pilot.search_path.to_str().unwrap(),
+            "--lexical",
+            "--format",
+            "json",
+            "--top",
+            "5",
+        ])
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory")
+        .output()
+        .expect("adoc search runs");
+    assert_eq!(output.status.code(), Some(0));
+    let envelope: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(envelope["records"][0]["match"]["mode"], "lexical");
 }
 
 /// Smoke check on JSON envelope serialization stability for the in-memory

--- a/crates/adoc-cli/tests/support/mod.rs
+++ b/crates/adoc-cli/tests/support/mod.rs
@@ -2,7 +2,10 @@ pub mod v1_4;
 
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
+
+static WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 #[allow(dead_code)]
 pub(crate) fn fixture_path(relative: &str) -> PathBuf {
@@ -32,7 +35,11 @@ impl TestWorkspace {
             .duration_since(UNIX_EPOCH)
             .expect("clock is after epoch")
             .as_nanos();
-        let root = std::env::temp_dir().join(format!("adoc-{name}-{nonce}"));
+        let counter = WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "adoc-{name}-{}-{counter}-{nonce}",
+            std::process::id()
+        ));
         fs::create_dir_all(&root).expect("test workspace can be created");
         Self { root }
     }

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -164,7 +164,7 @@ where
                     diagnostics.push(Diagnostic::warning(
                         DiagnosticCode::SearchArtifactMissing,
                         format!(
-                            "Search artifact `{}` is missing; semantic search disabled.",
+                            "Search artifact `{}` is missing; vector search disabled.",
                             search_path.display()
                         ),
                     ));
@@ -265,6 +265,9 @@ fn search_hybrid(session: &RetrievalSession, query: SearchQuery) -> SearchResult
     let Some(vector_index) = session.vector_index() else {
         return search_lexical(session, query);
     };
+    if query.query_vector.is_none() {
+        return missing_query_vector_result(SearchMode::Hybrid);
+    }
 
     let diagnostics = query
         .filters
@@ -347,6 +350,9 @@ fn search_semantic(session: &RetrievalSession, query: SearchQuery) -> SearchResu
             )],
         };
     };
+    if query.query_vector.is_none() {
+        return missing_query_vector_result(SearchMode::Semantic);
+    }
 
     let candidates = match query
         .filters
@@ -369,9 +375,32 @@ fn search_semantic(session: &RetrievalSession, query: SearchQuery) -> SearchResu
 
     let query_vector = query.query_vector.as_deref().unwrap_or(&[]);
     let candidate_ids: Vec<&str> = candidates.iter().map(|object| object.id.as_str()).collect();
-    let hits = index.rank_among(query_vector, candidate_ids.iter().copied(), query.top.get());
+    let hits = index.rank_among(
+        query_vector,
+        candidate_ids.iter().copied(),
+        candidate_ids.len(),
+    );
+    let hits_by_id: BTreeMap<_, _> = hits.iter().map(|hit| (hit.id.as_str(), hit)).collect();
 
-    let records = hits
+    let ranker = HybridRanker;
+    let mut result_hits: Vec<_> = ranker
+        .pinned_candidate_ids(&query.text, &candidate_ids)
+        .into_iter()
+        .filter_map(|id| hits_by_id.get(id.as_str()).copied().cloned())
+        .collect();
+    let mut seen_ids: BTreeSet<_> = result_hits.iter().map(|hit| hit.id.clone()).collect();
+
+    for hit in hits {
+        if seen_ids.insert(hit.id.clone()) {
+            result_hits.push(hit);
+        }
+        if result_hits.len() >= query.top.get() {
+            break;
+        }
+    }
+    result_hits.truncate(query.top.get());
+
+    let records = result_hits
         .into_iter()
         .enumerate()
         .map(|(idx, hit)| {
@@ -390,6 +419,21 @@ fn search_semantic(session: &RetrievalSession, query: SearchQuery) -> SearchResu
     SearchResult {
         records,
         diagnostics: Vec::new(),
+    }
+}
+
+fn missing_query_vector_result(mode: SearchMode) -> SearchResult {
+    let mode_name = match mode {
+        SearchMode::Hybrid => "hybrid",
+        SearchMode::Semantic => "semantic",
+        SearchMode::Lexical => "lexical",
+    };
+    SearchResult {
+        records: Vec::new(),
+        diagnostics: vec![Diagnostic::error(
+            DiagnosticCode::EmbedComputeFailed,
+            format!("{mode_name} search requires a query vector."),
+        )],
     }
 }
 
@@ -422,7 +466,9 @@ fn search_lexical(session: &RetrievalSession, query: SearchQuery) -> SearchResul
         .map(|hit| (hit.id.as_str(), hit.lexical_rank))
         .collect();
 
-    let mut result_hits: Vec<_> = pinned_candidate_ids(&query.text, &candidate_ids)
+    let ranker = HybridRanker;
+    let mut result_hits: Vec<_> = ranker
+        .pinned_candidate_ids(&query.text, &candidate_ids)
         .into_iter()
         .map(|id| {
             let lexical_rank = lexical_ranks_by_id.get(id.as_str()).copied();
@@ -462,21 +508,6 @@ fn search_lexical(session: &RetrievalSession, query: SearchQuery) -> SearchResul
             .collect(),
         diagnostics: Vec::new(),
     }
-}
-
-fn pinned_candidate_ids(query_text: &str, candidate_ids: &[&str]) -> Vec<String> {
-    if query_text.is_empty() {
-        return Vec::new();
-    }
-
-    let mut pinned_ids: Vec<_> = candidate_ids
-        .iter()
-        .copied()
-        .filter(|id| id.starts_with(query_text))
-        .map(str::to_string)
-        .collect();
-    pinned_ids.sort_by(|left, right| left.len().cmp(&right.len()).then_with(|| left.cmp(right)));
-    pinned_ids
 }
 
 fn build_exact_lookup(

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -457,6 +457,23 @@ fn search_lexical(session: &RetrievalSession, query: SearchQuery) -> SearchResul
         };
     }
 
+    if query.text.trim().is_empty() {
+        return SearchResult {
+            records: candidates
+                .into_iter()
+                .take(query.top.get())
+                .enumerate()
+                .map(|(index, object)| {
+                    RetrievalRecord::from_object_with_match(
+                        object,
+                        RetrievalMatch::lexical((index + 1) as u32, None),
+                    )
+                })
+                .collect(),
+            diagnostics: Vec::new(),
+        };
+    }
+
     let candidate_ids: Vec<_> = candidates.iter().map(|object| object.id.as_str()).collect();
     let lexical_hits = session
         .lexical_index

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -7,6 +7,7 @@ use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::domain::identity::ObjectId;
 use crate::domain::ports::artifact_reader::ArtifactReader;
 pub use crate::domain::retrieval::SearchFilters;
+use crate::domain::retrieval::hybrid_ranker::HybridRanker;
 use crate::domain::retrieval::lexical_index::LexicalIndex;
 use crate::domain::retrieval::vector_index::VectorIndex;
 use crate::domain::retrieval::{RetrievalMatch, RetrievalRecord, SearchMode};
@@ -254,9 +255,85 @@ pub fn explain_object(session: &RetrievalSession, id: &str) -> ExplainResult {
 
 pub fn search(session: &RetrievalSession, query: SearchQuery) -> SearchResult {
     match query.mode {
-        SearchMode::Hybrid => search_lexical(session, query),
+        SearchMode::Hybrid => search_hybrid(session, query),
         SearchMode::Lexical => search_lexical(session, query),
         SearchMode::Semantic => search_semantic(session, query),
+    }
+}
+
+fn search_hybrid(session: &RetrievalSession, query: SearchQuery) -> SearchResult {
+    let Some(vector_index) = session.vector_index() else {
+        return search_lexical(session, query);
+    };
+
+    let diagnostics = query
+        .filters
+        .validate_against(session.exact_lookup.values());
+    if !diagnostics.is_empty() {
+        return SearchResult {
+            records: Vec::new(),
+            diagnostics,
+        };
+    }
+
+    let candidate_ids: Vec<_> = session
+        .exact_lookup
+        .values()
+        .map(|object| object.id.as_str())
+        .collect();
+    if candidate_ids.is_empty() {
+        return SearchResult {
+            records: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+    }
+
+    let lexical_hits = session
+        .lexical_index
+        .search_candidates(&query.text, candidate_ids.iter().copied());
+    let query_vector = query.query_vector.as_deref().unwrap_or(&[]);
+    let vector_hits = vector_index.rank_among(
+        query_vector,
+        candidate_ids.iter().copied(),
+        candidate_ids.len(),
+    );
+    let ranker = HybridRanker;
+    let ranked_hits = ranker.rank(
+        &query.text,
+        &candidate_ids,
+        &lexical_hits,
+        &vector_hits,
+        candidate_ids.len(),
+    );
+
+    let mut records = Vec::new();
+    for hit in ranked_hits {
+        let object_id = ObjectId::new_unchecked(hit.id.clone());
+        let object = session
+            .exact_lookup
+            .get(&object_id)
+            .expect("search result IDs must come from the loaded retrieval session");
+        if !query.filters.matches(object) {
+            continue;
+        }
+
+        records.push(RetrievalRecord::from_object_with_match(
+            object,
+            RetrievalMatch::hybrid(
+                records.len() as u32 + 1,
+                hit.rrf_score,
+                hit.lexical_rank,
+                hit.vector_rank,
+            ),
+        ));
+        if records.len() >= query.top.get() {
+            break;
+        }
+    }
+
+    SearchResult {
+        records,
+        diagnostics: Vec::new(),
     }
 }
 

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -254,6 +254,7 @@ pub fn explain_object(session: &RetrievalSession, id: &str) -> ExplainResult {
 
 pub fn search(session: &RetrievalSession, query: SearchQuery) -> SearchResult {
     match query.mode {
+        SearchMode::Hybrid => search_lexical(session, query),
         SearchMode::Lexical => search_lexical(session, query),
         SearchMode::Semantic => search_semantic(session, query),
     }

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -291,10 +291,15 @@ fn search_hybrid(session: &RetrievalSession, query: SearchQuery) -> SearchResult
         };
     }
 
+    // Hybrid ranks the full candidate pool before applying filters so lexical
+    // and vector ranks stay comparable across both indexes.
     let lexical_hits = session
         .lexical_index
         .search_candidates(&query.text, candidate_ids.iter().copied());
-    let query_vector = query.query_vector.as_deref().unwrap_or(&[]);
+    let query_vector = query
+        .query_vector
+        .as_deref()
+        .expect("query_vector is checked above");
     let vector_hits = vector_index.rank_among(
         query_vector,
         candidate_ids.iter().copied(),
@@ -373,7 +378,10 @@ fn search_semantic(session: &RetrievalSession, query: SearchQuery) -> SearchResu
         };
     }
 
-    let query_vector = query.query_vector.as_deref().unwrap_or(&[]);
+    let query_vector = query
+        .query_vector
+        .as_deref()
+        .expect("query_vector is checked above");
     let candidate_ids: Vec<&str> = candidates.iter().map(|object| object.id.as_str()).collect();
     let hits = index.rank_among(
         query_vector,

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -383,36 +383,43 @@ fn search_semantic(session: &RetrievalSession, query: SearchQuery) -> SearchResu
     let hits_by_id: BTreeMap<_, _> = hits.iter().map(|hit| (hit.id.as_str(), hit)).collect();
 
     let ranker = HybridRanker;
-    let mut result_hits: Vec<_> = ranker
+    let mut result_ids: Vec<_> = ranker
         .pinned_candidate_ids(&query.text, &candidate_ids)
         .into_iter()
-        .filter_map(|id| hits_by_id.get(id.as_str()).copied().cloned())
         .collect();
-    let mut seen_ids: BTreeSet<_> = result_hits.iter().map(|hit| hit.id.clone()).collect();
+    let mut seen_ids: BTreeSet<_> = result_ids.iter().cloned().collect();
 
-    for hit in hits {
+    for hit in &hits {
         if seen_ids.insert(hit.id.clone()) {
-            result_hits.push(hit);
+            result_ids.push(hit.id.clone());
         }
-        if result_hits.len() >= query.top.get() {
+        if result_ids.len() >= query.top.get() {
             break;
         }
     }
-    result_hits.truncate(query.top.get());
+    result_ids.truncate(query.top.get());
 
-    let records = result_hits
+    let records = result_ids
         .into_iter()
         .enumerate()
-        .map(|(idx, hit)| {
-            let object_id = ObjectId::new_unchecked(hit.id.clone());
+        .map(|(idx, id)| {
+            let object_id = ObjectId::new_unchecked(id.clone());
             let object = session
                 .exact_lookup
                 .get(&object_id)
                 .expect("hit must exist in exact lookup");
-            RetrievalRecord::from_object_with_match(
-                object,
-                RetrievalMatch::semantic((idx + 1) as u32, hit.vector_rank, hit.cosine_score),
-            )
+            let search_match = hits_by_id.get(id.as_str()).map_or_else(
+                || RetrievalMatch {
+                    mode: SearchMode::Semantic,
+                    result_rank: (idx + 1) as u32,
+                    rrf_score: None,
+                    lexical_rank: None,
+                    vector_rank: None,
+                    cosine_score: None,
+                },
+                |hit| RetrievalMatch::semantic((idx + 1) as u32, hit.vector_rank, hit.cosine_score),
+            );
+            RetrievalRecord::from_object_with_match(object, search_match)
         })
         .collect();
 

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -236,7 +236,7 @@ impl DiagnosticCode {
                 "Run `adoc build` without `--no-embeddings` to emit docs.search.json."
             }
             DiagnosticCode::SearchArtifactMissing => {
-                "Run `adoc build` to generate dist/docs.search.json before requesting --semantic."
+                "Run `adoc build` to generate dist/docs.search.json for hybrid or semantic search."
             }
             DiagnosticCode::SearchModelMismatch => {
                 "Rebuild dist/docs.search.json with the active embedding provider, or switch providers to match the artifact's model header."

--- a/crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs
+++ b/crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs
@@ -1,5 +1,3 @@
-#![allow(dead_code)]
-
 use std::collections::{BTreeMap, BTreeSet};
 
 use crate::domain::retrieval::lexical_index::LexicalSearchHit;

--- a/crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs
+++ b/crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs
@@ -98,6 +98,10 @@ impl HybridRanker {
         results
     }
 
+    /// Returns Object ID prefix matches before scored hits.
+    ///
+    /// Pinned matches use a two-stage deterministic order: shorter matching IDs
+    /// first, then lexicographic order for IDs with equal length.
     pub(crate) fn pinned_candidate_ids(
         &self,
         query_text: &str,

--- a/crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs
+++ b/crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs
@@ -1,0 +1,233 @@
+#![allow(dead_code)]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::domain::retrieval::lexical_index::LexicalSearchHit;
+use crate::domain::retrieval::vector_index::VectorHit;
+
+const RRF_K: f64 = 60.0;
+
+#[derive(Debug, Clone)]
+pub(crate) struct HybridRanker;
+
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct HybridRankedHit {
+    pub(crate) id: String,
+    pub(crate) rrf_score: f64,
+    pub(crate) lexical_rank: Option<u32>,
+    pub(crate) vector_rank: Option<u32>,
+}
+
+impl HybridRanker {
+    pub(crate) fn rank(
+        &self,
+        query_text: &str,
+        candidate_ids: &[&str],
+        lexical_hits: &[LexicalSearchHit],
+        vector_hits: &[VectorHit],
+        top: usize,
+    ) -> Vec<HybridRankedHit> {
+        if top == 0 || candidate_ids.is_empty() {
+            return Vec::new();
+        }
+
+        let candidates: BTreeSet<&str> = candidate_ids.iter().copied().collect();
+        let lexical_by_id: BTreeMap<&str, &LexicalSearchHit> = lexical_hits
+            .iter()
+            .filter(|hit| candidates.contains(hit.id.as_str()))
+            .map(|hit| (hit.id.as_str(), hit))
+            .collect();
+        let vector_by_id: BTreeMap<&str, &VectorHit> = vector_hits
+            .iter()
+            .filter(|hit| candidates.contains(hit.id.as_str()))
+            .map(|hit| (hit.id.as_str(), hit))
+            .collect();
+
+        let mut scored = BTreeMap::<String, HybridRankedHit>::new();
+        for hit in lexical_by_id.values() {
+            let entry = scored
+                .entry(hit.id.clone())
+                .or_insert_with(|| HybridRankedHit::new(hit.id.clone()));
+            entry.rrf_score += rrf_component(hit.lexical_rank);
+            entry.lexical_rank = Some(hit.lexical_rank);
+        }
+        for hit in vector_by_id.values() {
+            let entry = scored
+                .entry(hit.id.clone())
+                .or_insert_with(|| HybridRankedHit::new(hit.id.clone()));
+            entry.rrf_score += rrf_component(hit.vector_rank);
+            entry.vector_rank = Some(hit.vector_rank);
+        }
+
+        let mut ranked: Vec<_> = scored.into_values().collect();
+        ranked.sort_by(|left, right| {
+            right
+                .rrf_score
+                .total_cmp(&left.rrf_score)
+                .then_with(|| left.id.cmp(&right.id))
+        });
+
+        let pinned = self.pinned_candidate_ids(query_text, candidate_ids);
+        let mut seen = BTreeSet::new();
+        let mut results = Vec::new();
+        for id in pinned {
+            if seen.insert(id.clone()) {
+                let lexical_rank = lexical_by_id.get(id.as_str()).map(|hit| hit.lexical_rank);
+                let vector_rank = vector_by_id.get(id.as_str()).map(|hit| hit.vector_rank);
+                let rrf_score = lexical_rank.map(rrf_component).unwrap_or(0.0)
+                    + vector_rank.map(rrf_component).unwrap_or(0.0);
+                results.push(HybridRankedHit {
+                    id,
+                    rrf_score,
+                    lexical_rank,
+                    vector_rank,
+                });
+            }
+            if results.len() >= top {
+                return results;
+            }
+        }
+
+        for hit in ranked {
+            if seen.insert(hit.id.clone()) {
+                results.push(hit);
+            }
+            if results.len() >= top {
+                break;
+            }
+        }
+
+        results
+    }
+
+    pub(crate) fn pinned_candidate_ids(
+        &self,
+        query_text: &str,
+        candidate_ids: &[&str],
+    ) -> Vec<String> {
+        if query_text.is_empty() {
+            return Vec::new();
+        }
+
+        let mut pinned_ids: Vec<_> = candidate_ids
+            .iter()
+            .copied()
+            .filter(|id| id.starts_with(query_text))
+            .map(str::to_string)
+            .collect();
+        pinned_ids
+            .sort_by(|left, right| left.len().cmp(&right.len()).then_with(|| left.cmp(right)));
+        pinned_ids
+    }
+}
+
+impl HybridRankedHit {
+    fn new(id: String) -> Self {
+        Self {
+            id,
+            rrf_score: 0.0,
+            lexical_rank: None,
+            vector_rank: None,
+        }
+    }
+}
+
+fn rrf_component(rank: u32) -> f64 {
+    1.0 / (RRF_K + f64::from(rank))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::domain::retrieval::lexical_index::LexicalSearchHit;
+    use crate::domain::retrieval::vector_index::VectorHit;
+
+    fn lexical(id: &str, rank: u32) -> LexicalSearchHit {
+        LexicalSearchHit {
+            id: id.to_string(),
+            lexical_rank: rank,
+            score: 1.0,
+        }
+    }
+
+    fn vector(id: &str, rank: u32) -> VectorHit {
+        VectorHit {
+            id: id.to_string(),
+            vector_rank: rank,
+            cosine_score: 1.0,
+        }
+    }
+
+    #[test]
+    fn fuses_disjoint_non_empty_lists_with_rrf_scores() {
+        let ranker = HybridRanker;
+
+        let hits = ranker.rank(
+            "credit ledger",
+            &["billing.lexical", "billing.semantic"],
+            &[lexical("billing.lexical", 1)],
+            &[vector("billing.semantic", 1)],
+            10,
+        );
+
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].id, "billing.lexical");
+        assert_eq!(hits[0].rrf_score, 1.0 / 61.0);
+        assert_eq!(hits[0].lexical_rank, Some(1));
+        assert_eq!(hits[0].vector_rank, None);
+        assert_eq!(hits[1].id, "billing.semantic");
+        assert_eq!(hits[1].rrf_score, 1.0 / 61.0);
+        assert_eq!(hits[1].lexical_rank, None);
+        assert_eq!(hits[1].vector_rank, Some(1));
+    }
+
+    #[test]
+    fn breaks_rrf_score_ties_by_ascending_object_id() {
+        let ranker = HybridRanker;
+
+        let hits = ranker.rank(
+            "same",
+            &["zeta.same", "alpha.same"],
+            &[lexical("zeta.same", 1)],
+            &[vector("alpha.same", 1)],
+            10,
+        );
+
+        let ids: Vec<_> = hits.iter().map(|hit| hit.id.as_str()).collect();
+        assert_eq!(ids, ["alpha.same", "zeta.same"]);
+    }
+
+    #[test]
+    fn pins_id_prefix_matches_by_length_then_lex_before_fused_hits() {
+        let ranker = HybridRanker;
+
+        let hits = ranker.rank(
+            "billing.credit",
+            &[
+                "support.heavy",
+                "billing.credits.b",
+                "billing.credit",
+                "billing.credits.a",
+                "billing.credits",
+            ],
+            &[lexical("support.heavy", 1)],
+            &[vector("support.heavy", 1)],
+            10,
+        );
+
+        let ids: Vec<_> = hits.iter().map(|hit| hit.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            [
+                "billing.credit",
+                "billing.credits",
+                "billing.credits.a",
+                "billing.credits.b",
+                "support.heavy"
+            ]
+        );
+        assert_eq!(hits[0].rrf_score, 0.0);
+        assert_eq!(hits[0].lexical_rank, None);
+        assert_eq!(hits[0].vector_rank, None);
+    }
+}

--- a/crates/adoc-core/src/domain/retrieval/lexical_index.rs
+++ b/crates/adoc-core/src/domain/retrieval/lexical_index.rs
@@ -5,6 +5,7 @@ use crate::domain::artifact::AgentJsonObject;
 const BM25_K1: f64 = 1.2;
 const BM25_B: f64 = 0.75;
 const OWNER_FIELD: &str = "owner";
+const EVIDENCE_FIELDS: [&str; 3] = ["source", "test", "reviewed_by"];
 
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct LexicalSearchHit {
@@ -213,6 +214,11 @@ fn indexed_tokens(object: &AgentJsonObject) -> Vec<String> {
     tokens.extend(tokenize(&object.kind));
     if let Some(owner) = object.fields.get(OWNER_FIELD) {
         tokens.extend(tokenize(owner));
+    }
+    for evidence_field in EVIDENCE_FIELDS {
+        if let Some(value) = object.fields.get(evidence_field) {
+            tokens.extend(tokenize(value));
+        }
     }
     tokens
 }

--- a/crates/adoc-core/src/domain/retrieval/mod.rs
+++ b/crates/adoc-core/src/domain/retrieval/mod.rs
@@ -1,4 +1,5 @@
 mod filter;
+pub(crate) mod hybrid_ranker;
 pub(crate) mod lexical_index;
 mod retrieval_record;
 pub(crate) mod vector_index;

--- a/crates/adoc-core/src/domain/retrieval/retrieval_record.rs
+++ b/crates/adoc-core/src/domain/retrieval/retrieval_record.rs
@@ -34,6 +34,8 @@ pub struct RetrievalMatch {
     pub mode: SearchMode,
     pub result_rank: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub rrf_score: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub lexical_rank: Option<u32>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub vector_rank: Option<u32>,
@@ -46,6 +48,7 @@ impl RetrievalMatch {
         Self {
             mode: SearchMode::Lexical,
             result_rank,
+            rrf_score: None,
             lexical_rank,
             vector_rank: None,
             cosine_score: None,
@@ -56,9 +59,26 @@ impl RetrievalMatch {
         Self {
             mode: SearchMode::Semantic,
             result_rank,
+            rrf_score: None,
             lexical_rank: None,
             vector_rank: Some(vector_rank),
             cosine_score: Some(cosine_score),
+        }
+    }
+
+    pub fn hybrid(
+        result_rank: u32,
+        rrf_score: f64,
+        lexical_rank: Option<u32>,
+        vector_rank: Option<u32>,
+    ) -> Self {
+        Self {
+            mode: SearchMode::Hybrid,
+            result_rank,
+            rrf_score: Some(rrf_score),
+            lexical_rank,
+            vector_rank,
+            cosine_score: None,
         }
     }
 }
@@ -66,6 +86,7 @@ impl RetrievalMatch {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum SearchMode {
+    Hybrid,
     Lexical,
     Semantic,
 }

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -208,6 +208,7 @@ fn public_surface_compiles_with_only_documented_imports() {
     let _: RetrievalRecord = record;
 
     let _: SearchMode = SearchMode::Lexical;
+    let _: SearchMode = SearchMode::Hybrid;
     let _: SearchFilters = SearchFilters {
         kind: None,
         status: None,
@@ -222,6 +223,7 @@ fn public_surface_compiles_with_only_documented_imports() {
         query_vector: None,
     };
     let _: RetrievalMatch = RetrievalMatch::lexical(1, Some(1));
+    let _: RetrievalMatch = RetrievalMatch::hybrid(1, 0.0312, Some(2), Some(1));
     let search_result = SearchResult {
         records: Vec::new(),
         diagnostics: Vec::new(),

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -492,6 +492,48 @@ fn semantic_search_pins_id_prefix_matches_before_vector_hits() {
 }
 
 #[test]
+fn semantic_search_pins_id_prefix_matches_without_vector_hit() {
+    let session = load_session_from_objects_with_vectors(
+        vec![
+            retrieval_search_object(
+                "billing.new-object",
+                "claim",
+                None,
+                Some("team-billing"),
+                "docs/billing.adoc",
+                "New object missing from partial search sidecar.",
+            ),
+            retrieval_search_object(
+                "support.vector",
+                "claim",
+                None,
+                Some("team-support"),
+                "docs/support.adoc",
+                "Vector winner.",
+            ),
+        ],
+        vec![("support.vector", vec![1.0, 0.0])],
+    );
+
+    let result = search(
+        &session,
+        semantic_query(
+            "billing.new-object",
+            vec![1.0, 0.0],
+            1,
+            SearchFilters::default(),
+        ),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), ["billing.new-object"]);
+    let search_match = result.records[0].search_match.as_ref().unwrap();
+    assert_eq!(search_match.mode, SearchMode::Semantic);
+    assert_eq!(search_match.vector_rank, None);
+    assert_eq!(search_match.cosine_score, None);
+}
+
+#[test]
 fn hybrid_search_requires_query_vector_when_vector_index_is_loaded() {
     let session = load_session_from_objects_with_vectors(
         vec![retrieval_search_object(

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -206,6 +206,21 @@ fn hybrid_query(
     }
 }
 
+fn semantic_query(
+    text: &str,
+    query_vector: Vec<f32>,
+    top: usize,
+    filters: SearchFilters,
+) -> SearchQuery {
+    SearchQuery {
+        text: text.to_string(),
+        mode: SearchMode::Semantic,
+        filters,
+        top: NonZeroUsize::new(top).expect("test search top is non-zero"),
+        query_vector: Some(query_vector),
+    }
+}
+
 fn search_ids(result: &SearchResult) -> Vec<&str> {
     result
         .records
@@ -430,6 +445,83 @@ fn lexical_search_indexes_v0_evidence_fields() {
 
     assert!(result.diagnostics.is_empty());
     assert_eq!(search_ids(&result), ["billing.evidence"]);
+}
+
+#[test]
+fn semantic_search_pins_id_prefix_matches_before_vector_hits() {
+    let session = load_session_from_objects_with_vectors(
+        vec![
+            retrieval_search_object(
+                "billing.credits",
+                "claim",
+                None,
+                Some("team-billing"),
+                "docs/billing.adoc",
+                "Prefix target.",
+            ),
+            retrieval_search_object(
+                "support.vector",
+                "claim",
+                None,
+                Some("team-support"),
+                "docs/support.adoc",
+                "Vector winner.",
+            ),
+        ],
+        vec![
+            ("billing.credits", vec![0.0, 1.0]),
+            ("support.vector", vec![1.0, 0.0]),
+        ],
+    );
+
+    let result = search(
+        &session,
+        semantic_query(
+            "billing.credits",
+            vec![1.0, 0.0],
+            1,
+            SearchFilters::default(),
+        ),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), ["billing.credits"]);
+    let search_match = result.records[0].search_match.as_ref().unwrap();
+    assert_eq!(search_match.mode, SearchMode::Semantic);
+    assert_eq!(search_match.vector_rank, Some(2));
+}
+
+#[test]
+fn hybrid_search_requires_query_vector_when_vector_index_is_loaded() {
+    let session = load_session_from_objects_with_vectors(
+        vec![retrieval_search_object(
+            "billing.vector",
+            "claim",
+            None,
+            Some("team-billing"),
+            "docs/billing.adoc",
+            "target",
+        )],
+        vec![("billing.vector", vec![1.0, 0.0])],
+    );
+
+    let result = search(
+        &session,
+        SearchQuery {
+            text: "target".to_string(),
+            mode: SearchMode::Hybrid,
+            filters: SearchFilters::default(),
+            top: NonZeroUsize::new(1).unwrap(),
+            query_vector: None,
+        },
+    );
+
+    assert!(result.records.is_empty());
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        DiagnosticCode::EmbedComputeFailed
+    );
 }
 
 #[test]

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -7,6 +7,7 @@ use adoc_core::{
     RetrievalSource, SearchFilters, SearchMode, SearchQuery, SearchResult, explain_object,
     load_retrieval_session, search,
 };
+use sha2::{Digest, Sha256};
 
 fn fixture_path(relative: &str) -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -34,6 +35,16 @@ fn write_temp_artifact(name: &str, contents: &str) -> tempfile::NamedTempFile {
     artifact
 }
 
+fn write_temp_search_artifact(name: &str, contents: &str) -> tempfile::NamedTempFile {
+    let artifact = tempfile::Builder::new()
+        .prefix(&format!("adoc-retrieval-{name}-"))
+        .suffix(".search.json")
+        .tempfile()
+        .expect("temp search artifact can be created");
+    std::fs::write(artifact.path(), contents).expect("temp search artifact can be written");
+    artifact
+}
+
 fn load_session_from_objects(objects: Vec<AgentJsonObject>) -> RetrievalSession {
     let document = AgentJsonDocument {
         schema_version: "adoc.agent.v0".to_string(),
@@ -58,6 +69,61 @@ fn load_session_from_objects(objects: Vec<AgentJsonObject>) -> RetrievalSession 
         result.diagnostics
     );
     result.session.expect("search fixture session loads")
+}
+
+fn load_session_from_objects_with_vectors(
+    objects: Vec<AgentJsonObject>,
+    vectors: Vec<(&str, Vec<f32>)>,
+) -> RetrievalSession {
+    let document = AgentJsonDocument {
+        schema_version: "adoc.agent.v0".to_string(),
+        pages: Vec::new(),
+        objects,
+        diagnostics: Vec::new(),
+    };
+    let agent_json = document
+        .to_pretty_json()
+        .expect("search fixture serializes to agent JSON");
+    let artifact = write_temp_artifact("hybrid-agent", &agent_json);
+    let search_document = serde_json::json!({
+        "schema_version": "adoc.search.v0",
+        "model": {
+            "id": "bge-small-en-v1.5",
+            "provider": "fastembed",
+            "dim": 384
+        },
+        "agent_artifact_hash": sha256_prefixed(agent_json.as_bytes()),
+        "embeddings": vectors
+            .into_iter()
+            .map(|(id, vector)| serde_json::json!({
+                "id": id,
+                "content_hash": "sha256:test",
+                "vector": vector
+            }))
+            .collect::<Vec<_>>()
+    });
+    let search_artifact = write_temp_search_artifact(
+        "hybrid-search",
+        &serde_json::to_string_pretty(&search_document).expect("search fixture serializes"),
+    );
+
+    let result = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().to_path_buf(),
+        search_artifact_path: Some(search_artifact.path().to_path_buf()),
+    });
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "expected clean hybrid fixture load, got {:?}",
+        result.diagnostics
+    );
+    result.session.expect("hybrid fixture session loads")
+}
+
+fn sha256_prefixed(bytes: &[u8]) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    format!("sha256:{:x}", hasher.finalize())
 }
 
 fn load_workspace_fixture_session(relative: &str) -> RetrievalSession {
@@ -122,6 +188,21 @@ fn lexical_query(text: &str, top: usize, filters: SearchFilters) -> SearchQuery 
         filters,
         top: NonZeroUsize::new(top).expect("test search top is non-zero"),
         query_vector: None,
+    }
+}
+
+fn hybrid_query(
+    text: &str,
+    query_vector: Vec<f32>,
+    top: usize,
+    filters: SearchFilters,
+) -> SearchQuery {
+    SearchQuery {
+        text: text.to_string(),
+        mode: SearchMode::Hybrid,
+        filters,
+        top: NonZeroUsize::new(top).expect("test search top is non-zero"),
+        query_vector: Some(query_vector),
     }
 }
 
@@ -214,6 +295,141 @@ fn assert_top_3_contains(session: &RetrievalSession, query: &str, expected_id: &
         ids.contains(&expected_id),
         "expected {expected_id} in top 3 for {query:?}, got {ids:?}"
     );
+}
+
+#[test]
+fn hybrid_search_fuses_lexical_and_vector_results_and_reports_match_metadata() {
+    let session = load_session_from_objects_with_vectors(
+        vec![
+            retrieval_search_object(
+                "billing.lexical-only",
+                "claim",
+                None,
+                Some("team-billing"),
+                "docs/billing.adoc",
+                "target target target",
+            ),
+            retrieval_search_object(
+                "billing.blended",
+                "claim",
+                None,
+                Some("team-billing"),
+                "docs/billing.adoc",
+                "target",
+            ),
+            retrieval_search_object(
+                "billing.semantic-only",
+                "claim",
+                None,
+                Some("team-billing"),
+                "docs/billing.adoc",
+                "unrelated",
+            ),
+        ],
+        vec![
+            ("billing.lexical-only", vec![0.0, 1.0]),
+            ("billing.blended", vec![1.0, 0.0]),
+            ("billing.semantic-only", vec![1.0, 0.0]),
+        ],
+    );
+
+    let result = search(
+        &session,
+        hybrid_query("target", vec![1.0, 0.0], 3, SearchFilters::default()),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(
+        search_ids(&result).first().copied(),
+        Some("billing.blended")
+    );
+    let search_match = result.records[0]
+        .search_match
+        .as_ref()
+        .expect("hybrid result has match metadata");
+    assert_eq!(search_match.mode, SearchMode::Hybrid);
+    assert!(search_match.rrf_score.is_some());
+    assert_eq!(search_match.lexical_rank, Some(2));
+    assert_eq!(search_match.vector_rank, Some(1));
+    assert_eq!(search_match.cosine_score, None);
+}
+
+#[test]
+fn hybrid_search_filters_after_ranking_and_preserves_full_pool_ranks() {
+    let session = load_session_from_objects_with_vectors(
+        vec![
+            retrieval_search_object(
+                "billing.top",
+                "claim",
+                None,
+                Some("team-a"),
+                "docs/billing.adoc",
+                "target target target",
+            ),
+            retrieval_search_object(
+                "billing.keep",
+                "claim",
+                None,
+                Some("team-b"),
+                "docs/billing.adoc",
+                "target",
+            ),
+        ],
+        vec![
+            ("billing.top", vec![1.0, 0.0]),
+            ("billing.keep", vec![0.8, 0.2]),
+        ],
+    );
+
+    let result = search(
+        &session,
+        hybrid_query(
+            "target",
+            vec![1.0, 0.0],
+            1,
+            SearchFilters {
+                owner: Some("team-b".to_string()),
+                ..SearchFilters::default()
+            },
+        ),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), ["billing.keep"]);
+    let search_match = result.records[0].search_match.as_ref().unwrap();
+    assert_eq!(search_match.mode, SearchMode::Hybrid);
+    assert_eq!(search_match.lexical_rank, Some(2));
+    assert_eq!(search_match.vector_rank, Some(2));
+}
+
+#[test]
+fn lexical_search_indexes_v0_evidence_fields() {
+    let mut object = retrieval_search_object(
+        "billing.evidence",
+        "claim",
+        Some("verified"),
+        Some("team-billing"),
+        "docs/billing.adoc",
+        "Credits require review.",
+    );
+    object
+        .fields
+        .insert("source".to_string(), "refund runbook".to_string());
+    object
+        .fields
+        .insert("test".to_string(), "cargo test refunds".to_string());
+    object
+        .fields
+        .insert("reviewed_by".to_string(), "qa-billing".to_string());
+    let session = load_session_from_objects(vec![object]);
+
+    let result = search(
+        &session,
+        lexical_query("refund runbook", 1, SearchFilters::default()),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), ["billing.evidence"]);
 }
 
 #[test]

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -161,6 +161,46 @@ fn search_lexical_ranks(result: &SearchResult) -> Vec<Option<u32>> {
         .collect()
 }
 
+#[test]
+fn hybrid_match_serializes_rrf_score_and_omits_missing_rank_fields() {
+    let record = RetrievalRecord {
+        id: "billing.hybrid".to_string(),
+        kind: "claim".to_string(),
+        status: Some("verified".to_string()),
+        owner: None,
+        verified_at: None,
+        body: "Hybrid result.".to_string(),
+        source: RetrievalSource {
+            path: "docs/billing.adoc".to_string(),
+            line: 1,
+            column: 1,
+        },
+        evidence: std::collections::BTreeMap::new(),
+        fields: std::collections::BTreeMap::new(),
+        relations: AgentJsonRelations::default(),
+        search_match: Some(RetrievalMatch::hybrid(1, 0.0312, Some(2), None)),
+    };
+
+    let value = serde_json::to_value(RetrievalEnvelope::new(vec![record], Vec::new()))
+        .expect("retrieval envelope serializes");
+    let search_match = value["records"][0]["match"]
+        .as_object()
+        .expect("match block is an object");
+
+    assert_eq!(search_match["mode"], "hybrid");
+    assert_eq!(search_match["result_rank"], 1);
+    assert_eq!(search_match["rrf_score"], 0.0312);
+    assert_eq!(search_match["lexical_rank"], 2);
+    assert!(
+        !search_match.contains_key("vector_rank"),
+        "missing rank fields must be omitted, got {search_match:?}"
+    );
+    assert!(
+        !search_match.contains_key("cosine_score"),
+        "hybrid records must not include cosine_score, got {search_match:?}"
+    );
+}
+
 fn assert_top_3_contains(session: &RetrievalSession, query: &str, expected_id: &str) {
     let result = search(session, lexical_query(query, 3, SearchFilters::default()));
 

--- a/docs/v1-retrieval.md
+++ b/docs/v1-retrieval.md
@@ -1,0 +1,164 @@
+# V1 Retrieval
+
+V1 retrieval is a local read-side workflow over build artifacts. `adoc build`
+creates the human HTML, the agent artifact, and the optional search artifact.
+`adoc explain` and `adoc search` read those artifacts; they do not compile
+source files.
+
+## Build
+
+```bash
+adoc build examples/billing-pilot --out dist
+```
+
+Successful embedding-enabled builds write:
+
+- `dist/docs.html`
+- `dist/docs.agent.json`
+- `dist/docs.search.json`
+
+`docs.agent.json` is the canonical retrieval record source. `docs.search.json`
+is the sidecar vector index. By default it uses the local FastEmbed
+`bge-small-en-v1.5` provider. The first build may download model weights through
+`fastembed-rs`; later builds reuse the local model cache.
+
+Use `--no-embeddings` when you only need HTML and agent JSON:
+
+```bash
+adoc build examples/billing-pilot --out dist --no-embeddings
+```
+
+That skips model loading and leaves any prior `docs.search.json` untouched.
+
+## Explain
+
+```bash
+adoc explain billing.credits.decrement-after-success --artifact dist/docs.agent.json
+adoc explain billing.credits.decrement-after-success --artifact dist/docs.agent.json --format json
+```
+
+Use `explain` when you already have an Object ID and need the authoritative
+record: kind, status, owner, evidence, source span, body, and relations.
+
+## Search
+
+```bash
+adoc search "when are credits decremented" \
+  --artifact dist/docs.agent.json \
+  --search-artifact dist/docs.search.json
+```
+
+Default search is hybrid when both artifacts are present. Hybrid uses
+Reciprocal Rank Fusion over lexical BM25 and vector cosine ranks. Exact Object
+ID and ID-prefix queries are pinned in every mode.
+
+Mode flags:
+
+- Default: hybrid when `docs.search.json` loads; lexical fallback with one
+  `search.artifact_missing` warning when it is absent.
+- `--lexical`: deterministic text and Object ID search over `docs.agent.json`.
+  Use it for exact IDs, filters, regression tests, and offline operation.
+- `--semantic`: vector-only ranking from `docs.search.json`. Use it to inspect
+  paraphrase recall or isolate embedding behavior.
+
+Filters:
+
+```bash
+adoc search "credit" --kind claim --status verified --owner team-billing
+adoc search "" --lexical --owner team-billing --top 20
+```
+
+`--kind`, `--status`, `--owner`, and `--source-path` filter results. Empty
+lexical query text lists the filtered candidate set in deterministic Object ID
+order, which is useful for ownership audits.
+
+JSON output:
+
+```bash
+adoc search "refund audit" --format json
+```
+
+Search and explain both emit `adoc.retrieval.v0`:
+
+```json
+{
+  "schema_version": "adoc.retrieval.v0",
+  "records": [],
+  "diagnostics": []
+}
+```
+
+Each search record includes a `match` block with `mode`, `result_rank`, and
+mode-specific rank metadata. Hybrid records include `rrf_score` and may include
+`lexical_rank` and `vector_rank`. Semantic records include `vector_rank` and
+`cosine_score`.
+
+## Citation Pattern
+
+When citing a retrieved record, cite the Object ID first. Include kind, status,
+owner, and evidence when present:
+
+```text
+billing.credits.decrement-after-success (claim, verified, owner team-billing)
+Evidence: source=billing service credit application trace 2026-05-05;
+test=cargo test billing_credit_decrement_after_success;
+reviewed_by=qa-billing.
+```
+
+Prefer the Object ID over prose titles. It is the stable handle that connects
+search, explain, source spans, and relations.
+
+## Model Swaps
+
+`docs.search.json` records the embedding provider, model ID, and vector
+dimension. If the active provider does not match the artifact, retrieval emits
+`search.model_mismatch` and disables semantic/hybrid vector use. Rebuild the
+project with the active provider to regenerate embeddings.
+
+Changing embedding input composition or model identity invalidates old search
+artifacts. Treat that as a retrieval contract change: update the tests, update
+the retrieval set rationale, and rebuild the artifact.
+
+## Embedding Cache
+
+Each search entry has a content hash. During `adoc build`, unchanged Object IDs
+reuse prior vectors from the previous output directory's `docs.search.json`.
+Build output reports:
+
+```text
+info[build.embeddings_cached] embeddings: cached N, computed M
+```
+
+No action is required. It is a visibility diagnostic for cache reuse.
+
+## Retrieval Set Updates
+
+The billing pilot golden set lives at
+`examples/billing-pilot/retrieval-set.yaml`.
+
+Add or change entries when ranking behavior, embedding composition, corpus
+content, or model selection changes. Each entry should include:
+
+- `query`
+- `mode`: `hybrid`, `lexical`, or `semantic`
+- `expected_ids`
+- `must_appear_in_top`
+- filters when the case exists to cover a filter path
+
+Keep the set at 15-20 high-signal queries. Cover paraphrase behavior, exact ID
+pins, ID prefixes, owner filters, kind filters, evidence-field queries, status
+filters, empty results, and broken filters. When changing expected IDs because
+the intended behavior changed, add a short YAML comment next to that case with
+the rationale.
+
+Run the hermetic suite before committing:
+
+```bash
+cargo test -p adoc-cli --test retrieval_pilot --locked
+```
+
+The gated production-model suite runs with:
+
+```bash
+cargo test -p adoc-cli --test retrieval_pilot --features fastembed-it --locked
+```

--- a/examples/billing-pilot/01-glossary.adoc
+++ b/examples/billing-pilot/01-glossary.adoc
@@ -31,3 +31,15 @@ owner: team-access
 --
 An entitlement is the product access state granted by paid invoices, trials, credits, or account-level overrides.
 ::
+
+::glossary billing.settlement
+owner: team-billing
+--
+Settlement is the point when the payment processor confirms captured money can update account balance and entitlement state.
+::
+
+::glossary billing.adjustment
+owner: finance-ops
+--
+An adjustment is a manual or automated correction that changes invoice balance outside the normal payment or refund path.
+::

--- a/examples/billing-pilot/02-claims.adoc
+++ b/examples/billing-pilot/02-claims.adoc
@@ -103,3 +103,36 @@ related_to: billing.invoice
 --
 Tax calculation should run before credit application so invoice tax records remain explainable during finance review.
 ::
+
+::claim billing.settlement.posts-once
+status: verified
+owner: team-billing
+verified_at: 2026-05-06
+source: settlement service idempotency report 2026-05-05
+test: cargo test settlement_posts_once_per_capture
+reviewed_by: qa-billing
+depends_on: billing.ledger
+related_to: billing.settlement
+--
+Each captured payment settlement writes exactly one [[billing.ledger]] movement before downstream invoice or entitlement updates run.
+::
+
+::claim billing.adjustments.require-reason
+status: verified
+owner: finance-ops
+verified_at: 2026-05-06
+source: finance adjustment policy v2
+test: cargo test adjustment_requires_reason_code
+reviewed_by: finance-controller
+related_to: billing.adjustment
+--
+Every manual [[billing.adjustment]] must include a reason code so finance can reconcile the balance change later.
+::
+
+::claim billing.invoices.credit-memo-link
+status: draft
+owner: finance-ops
+related_to: billing.invoice
+--
+Credit memo exports should link back to the invoice and ledger movement that created the customer-visible adjustment.
+::

--- a/examples/billing-pilot/03-decisions.adoc
+++ b/examples/billing-pilot/03-decisions.adoc
@@ -36,3 +36,12 @@ related_to: billing.entitlement
 --
 Entitlement updates should move to billing settlement events instead of polling invoice state.
 ::
+
+::decision billing.decision.settlement-idempotency
+status: accepted
+decided_by: billing-architecture
+owner: team-billing
+depends_on: [billing.settlement.posts-once, billing.decision.ledger-first]
+--
+Settlement handlers use processor event IDs as idempotency keys before writing [[billing.ledger]] movements.
+::

--- a/examples/billing-pilot/04-warnings.adoc
+++ b/examples/billing-pilot/04-warnings.adoc
@@ -33,3 +33,11 @@ related_to: billing.invoices.tax-before-credit
 --
 Tax adjustment explanations may be incomplete when a corrected invoice receives credit after finalization.
 ::
+
+::warning billing.warning.adjustment-without-reason
+severity: medium
+owner: finance-ops
+depends_on: billing.adjustments.require-reason
+--
+Manual adjustments without a reason code make invoice balance changes difficult to reconcile during finance review.
+::

--- a/examples/billing-pilot/retrieval-set.yaml
+++ b/examples/billing-pilot/retrieval-set.yaml
@@ -1,0 +1,131 @@
+- name: hybrid exact claim id
+  query: "billing.credits.decrement-after-success"
+  mode: hybrid
+  expected_ids: [billing.credits.decrement-after-success]
+  must_appear_in_top: 1
+
+- name: hybrid id prefix fans out to credit objects
+  query: "billing.credits"
+  mode: hybrid
+  expected_ids: [billing.credits, billing.credits.ledger-source]
+  must_appear_in_top: 3
+
+- name: hybrid paraphrase adjustment rationale
+  query: "manual adjustment reason"
+  mode: hybrid
+  expected_ids: [billing.adjustments.require-reason]
+  must_appear_in_top: 1
+
+- name: hybrid paraphrase settlement idempotency
+  query: "settlement posts once"
+  mode: hybrid
+  expected_ids: [billing.settlement.posts-once]
+  must_appear_in_top: 6
+
+- name: semantic exact settlement pin
+  query: "billing.settlement"
+  mode: semantic
+  expected_ids: [billing.settlement]
+  must_appear_in_top: 1
+
+- name: lexical exact refund claim id
+  query: "billing.refunds.audit-required"
+  mode: lexical
+  expected_ids: [billing.refunds.audit-required]
+  must_appear_in_top: 1
+
+- name: lexical refund id prefix
+  query: "billing.refunds"
+  mode: lexical
+  expected_ids: [billing.refunds.issue-credit, billing.refunds.audit-required]
+  must_appear_in_top: 3
+
+- name: lexical evidence source query
+  query: "refund operations runbook"
+  mode: lexical
+  expected_ids: [billing.refunds.audit-required]
+  must_appear_in_top: 1
+  expected_evidence:
+    source: "refund operations runbook v3"
+
+- name: lexical evidence test query
+  query: "cargo test adjustment_requires_reason_code"
+  mode: lexical
+  expected_ids: [billing.adjustments.require-reason]
+  must_appear_in_top: 1
+  expected_evidence:
+    test: "cargo test adjustment_requires_reason_code"
+
+- name: lexical owner team access
+  query: "entitlement"
+  mode: lexical
+  expected_ids: [billing.entitlement, billing.entitlements.sync-after-payment]
+  must_appear_in_top: 3
+  filters:
+    owner: team-access
+
+- name: lexical owner finance ops
+  query: "finance reason"
+  mode: lexical
+  expected_ids: [billing.adjustments.require-reason]
+  must_appear_in_top: 1
+  filters:
+    owner: finance-ops
+
+- name: lexical kind decision
+  query: "ledger first"
+  mode: lexical
+  expected_ids: [billing.decision.ledger-first]
+  must_appear_in_top: 1
+  filters:
+    kind: decision
+
+- name: lexical kind warning
+  query: "tax adjustment"
+  mode: lexical
+  expected_ids: [billing.warning.tax-adjustment]
+  must_appear_in_top: 1
+  filters:
+    kind: warning
+
+- name: lexical verified claim status
+  query: "credit"
+  mode: lexical
+  expected_ids: [billing.credits.nonnegative, billing.credits.decrement-after-success]
+  must_appear_in_top: 2
+  filters:
+    kind: claim
+    status: verified
+
+- name: lexical draft status
+  query: "credit memo invoice"
+  mode: lexical
+  expected_ids: [billing.invoices.credit-memo-link]
+  must_appear_in_top: 1
+  filters:
+    status: draft
+
+- name: lexical source path filter
+  query: "settlement"
+  mode: lexical
+  expected_ids: [billing.decision.settlement-idempotency]
+  must_appear_in_top: 1
+  filters:
+    source_path: 03-decisions.adoc
+
+- name: lexical empty result stays successful
+  query: "chargeback reversal"
+  mode: lexical
+  format: plain
+  expected_ids: []
+  expected_exit: 0
+  expect_stdout_contains: "(no matches)"
+
+- name: lexical broken kind filter fails
+  query: "ledger"
+  mode: lexical
+  expected_ids: []
+  expected_exit: 1
+  expected_diagnostics: [search.invalid_filter]
+  filters:
+    kind: runbook

--- a/examples/billing-pilot/retrieval-set.yaml
+++ b/examples/billing-pilot/retrieval-set.yaml
@@ -11,7 +11,7 @@
   must_appear_in_top: 3
 
 - name: hybrid paraphrase adjustment rationale
-  query: "manual adjustment reason"
+  query: "manual adjustment requires reason code"
   mode: hybrid
   expected_ids: [billing.adjustments.require-reason]
   must_appear_in_top: 1


### PR DESCRIPTION
## Summary

Finalises the V1 retrieval roadmap by making hybrid retrieval the default for `adoc search` (V1.5) and gating every future ranking/embedding/model change on a golden retrieval set + property invariants running in CI (V1.6).

### V1.5 — hybrid retrieval becomes the default

- New `crates/adoc-core/src/domain/retrieval/hybrid_ranker.rs`: parameter-free Reciprocal Rank Fusion (`k = 60`) over BM25 and cosine ranks as a pure domain unit.
- `adoc search` is hybrid by default when both indexes are loaded; degrades to lexical-only with one `search.artifact_missing` warning when `dist/docs.search.json` is absent. `--lexical` and `--semantic` remain as escape hatches.
- ID-prefix exact-match pin moved out of `LexicalIndex` into `HybridRanker` so it applies in every mode (`hybrid`, `lexical`, `semantic`).
- Hybrid filtering is post-rank to keep the candidate pool comparable across both indexes; lexical and semantic modes keep their pre-rank filter behaviour.
- Tie-breaker on RRF score ties: ascending Object ID lexicographic order.
- `--format json` extends the per-record `match` block: `match.mode = "hybrid"` adds `match.rrf_score`, `match.lexical_rank`, `match.vector_rank`. Rank fields are omitted (no nulls) when one underlying index does not surface a record.

### V1.6 — pilot evaluation harness

- Grows `examples/billing-pilot` to 30+ Knowledge Objects across all four V0 kinds (`claim`, `decision`, `warning`, `glossary`) with 8+ verified claims.
- Adds `examples/billing-pilot/retrieval-set.yaml` with 15+ queries covering paraphrase, exact Object ID, ID-prefix, owner filter, kind filter, evidence path, status filter, empty-result, and broken-filter cases.
- Adds `crates/adoc-cli/tests/retrieval_pilot.rs`: golden retrieval-set integration test plus property invariants (every body in `--lexical` top 1, every Object ID in `--lexical` top 1, every owner surfaces every owned Object via `--owner` empty-text query).
- Hermetic `cargo test` runs everything against `InMemoryProvider`. A new workflow_dispatch-gated `FastEmbed Retrieval` CI job re-runs the same suite under `--features fastembed-it` against the production `bge-small-en-v1.5` model, with the gold case stabilised against deterministic embedding-input composition.
- Adds `docs/v1-retrieval.md`: end-to-end build → explain → search walkthrough, citation pattern, hybrid vs lexical vs semantic guidance, embedding-cache semantics, and acceptance criteria for adding new retrieval-set entries.

Closes #65.
Closes #66.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo clippy --workspace --all-targets --locked -- -D warnings`
- [x] `cargo test --workspace --locked` (all suites green: 50 core tests including new `hybrid_*` ranker coverage + 188 CLI tests including new `retrieval_pilot` 2/2 and expanded `billing_pilot`)
- [x] `cargo build --workspace --locked`
- [x] `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --locked`
- [ ] Trigger the `FastEmbed Retrieval` workflow_dispatch run (`inputs.fastembed=true`) to validate the gold retrieval set against the production model
- [ ] Manual smoke: `adoc build examples/billing-pilot --out examples/billing-pilot/dist` then `adoc search "when are credits decremented" --top 5` returns hybrid results; deleting `dist/docs.search.json` falls back to lexical with exactly one `search.artifact_missing` warning and the same exit code
- [ ] Manual smoke: `adoc search "billing.credits.ledger" --format json --top 1` shows `match.mode = "hybrid"` with both `match.lexical_rank` and `match.vector_rank` populated; ID-prefix pin still works under `--lexical` and `--semantic`