### PR TITLE
feat: add V1.5 local project workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,11 @@ AgentDoc is not AsciiDoc, even though the source extension is `.adoc`.
 
 AgentDoc is pre-release compiler and retrieval infrastructure. The source-to-artifact loop supports:
 
-- `adoc check <path>`
-- `adoc build <path> --out <directory>`
+- `adoc init`
+- `adoc check [path]`
+- `adoc build [path] [--out <directory>]`
 - one file or a directory of `.adoc` files as input
+- config-backed defaults from `agentdoc.config.yaml` for `docs_path`, outputs, and embedding mode
 - page headings with optional `@doc(id)` page identity
 - path-derived page identity when no annotation exists
 - headings, paragraphs, unordered lists, ordered lists, and fenced code blocks
@@ -33,14 +35,19 @@ AgentDoc is pre-release compiler and retrieval infrastructure. The source-to-art
 - strict diagnostics for raw HTML, unsafe links, unclosed fenced code blocks, malformed typed blocks, malformed page annotations, invalid or duplicate Object IDs, invalid verified claims, broken references, and unsupported single-file source extensions
 - diagnostic metadata with source location, severity, code, message, and `object_id`/`help` when available
 - HTML, agent JSON, and search artifact emission when no error diagnostics exist
+- warning-only `lifecycle.expired` diagnostics for Knowledge Objects with parseable past `expires_at` dates; source files are not mutated
 
-V1.3 build embeddings support:
+V1.5 local workflow supports:
 
-- `adoc build <path> --out <directory>` emits `docs.search.json` by default
-- local FastEmbed embeddings using `bge-small-en-v1.5` (`provider: "fastembed"`, `dim: 384`)
+- `adoc init` creates `agentdoc.config.yaml` and `docs/index.adoc`
+- omitted `check` and `build` paths use config `docs_path`
+- omitted `build --out` uses config outputs
+- `embeddings.provider: local|none`; missing `embeddings` defaults to `local`
+- `local` uses FastEmbed `bge-small-en-v1.5` (`provider: "fastembed"`, `dim: 384`)
 - first-run model download through `fastembed-rs`, then local cache reuse on later builds
 - per-Object-ID vector reuse when the model header and content hash match the prior `docs.search.json`
 - `--no-embeddings` to skip search artifact generation and leave any prior `docs.search.json` untouched
+- hosted embedding adapters remain deferred; the shipped default provider is local
 
 V1 local retrieval supports:
 
@@ -52,7 +59,7 @@ V1 local retrieval supports:
 - exact Object ID and ID-prefix pins in all search modes
 - search filters for kind, status, owner, and source path
 
-Config files, includes, custom schemas, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, a web app, and permissioned governance are deferred beyond the current V0 compiler loop. See [docs/ROADMAP.md](docs/ROADMAP.md).
+Includes, custom schemas, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, a web app, hosted embedding adapters, and permissioned governance are deferred beyond the current local CLI workflow. See [docs/ROADMAP.md](docs/ROADMAP.md).
 
 ## Quick Start
 
@@ -70,32 +77,29 @@ rustup toolchain install --no-self-update
 
 ### Run From Source
 
-Create a small AgentDoc Source file:
+Build the CLI, then initialize a local AgentDoc project:
 
 ````bash
+cargo build -p adoc-cli
+ADOC_BIN="$(pwd)/target/debug/adoc"
+
 mkdir -p /tmp/adoc-example
+cd /tmp/adoc-example
 
-cat > /tmp/adoc-example/guide.adoc <<'EOF'
-# Getting Started @doc(docs.getting-started)
-
-AgentDoc keeps knowledge readable.
-
-- Write source
-- Run check
-- Build artifacts
-
-```rust
-fn main() {
-    println!("hello from AgentDoc");
-}
-```
-EOF
+"$ADOC_BIN" init
 ````
 
-Check the source:
+`adoc init` writes:
+
+```text
+agentdoc.config.yaml
+docs/index.adoc
+```
+
+Check the source using the config default `docs_path`:
 
 ```bash
-cargo run -p adoc-cli --bin adoc -- check /tmp/adoc-example/guide.adoc
+"$ADOC_BIN" check
 ```
 
 Expected output:
@@ -104,19 +108,19 @@ Expected output:
 0 errors, 0 warnings
 ```
 
-Build artifacts:
+Build artifacts using the config output defaults:
 
 ```bash
-cargo run -p adoc-cli --bin adoc -- build /tmp/adoc-example/guide.adoc --out /tmp/adoc-example/dist
+"$ADOC_BIN" build
 ```
 
 Inspect the generated files:
 
 ```bash
-ls -la /tmp/adoc-example/dist
-cat /tmp/adoc-example/dist/docs.html
-cat /tmp/adoc-example/dist/docs.agent.json
-cat /tmp/adoc-example/dist/docs.search.json
+ls -la dist
+cat dist/docs.html
+cat dist/docs.agent.json
+cat dist/docs.search.json
 ```
 
 Expected files:
@@ -125,6 +129,13 @@ Expected files:
 docs.html
 docs.agent.json
 docs.search.json
+```
+
+Explicit paths still work and override config defaults where provided:
+
+```bash
+"$ADOC_BIN" check docs/index.adoc
+"$ADOC_BIN" build docs/index.adoc --out /tmp/adoc-example/explicit-dist
 ```
 
 ### Try The Billing Pilot
@@ -146,6 +157,14 @@ docs.agent.json
 docs.search.json
 ```
 
+The pilot also has [agentdoc.config.yaml](examples/billing-pilot/agentdoc.config.yaml), so config-backed local commands work from the example directory:
+
+```bash
+cd examples/billing-pilot
+cargo run -p adoc-cli --manifest-path ../../Cargo.toml --bin adoc -- check
+cargo run -p adoc-cli --manifest-path ../../Cargo.toml --bin adoc -- build
+```
+
 ### Install Locally
 
 To install the `adoc` binary from this checkout:
@@ -157,17 +176,21 @@ cargo install --path crates/adoc-cli --locked
 Then run:
 
 ```bash
-adoc check /tmp/adoc-example/guide.adoc
-adoc build /tmp/adoc-example/guide.adoc --out /tmp/adoc-example/dist
+mkdir -p /tmp/adoc-example
+cd /tmp/adoc-example
+adoc init
+adoc check
+adoc build
 ```
 
 ## CLI Usage
 
 ```bash
-adoc check <path>
-adoc build <path> --out <directory> [--no-embeddings]
-adoc explain <object-id> [--artifact <path>] [--format text|json]
-adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | --semantic] [--kind <value>] [--status <value>] [--owner <value>] [--source-path <value>] [--top <n>] [--format text|json]
+adoc init
+adoc check [path]
+adoc build [path] [--out <directory>] [--no-embeddings]
+adoc explain <object-id> [--artifact <path>] [--format auto|plain|styled|json]
+adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | --semantic] [--kind <value>] [--status <value>] [--owner <value>] [--source-path <value>] [--top <n>] [--format auto|plain|styled|json]
 ```
 
 `<path>` can be:
@@ -175,8 +198,16 @@ adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | 
 - a single `.adoc` file
 - a directory, scanned recursively for `.adoc` files
 
+`adoc init`:
+
+- creates `agentdoc.config.yaml` and `docs/index.adoc` in the current directory
+- refuses to overwrite either target if it already exists
+- configures strict mode, `docs_path: docs`, `outputs.dir: dist`, exact default artifact paths, and `embeddings.provider: local`
+
 `adoc check`:
 
+- uses explicit `[path]` when passed
+- otherwise discovers the nearest `agentdoc.config.yaml` from the current directory upward and uses `docs_path`
 - compiles the input in strict mode
 - prints diagnostics and a summary
 - exits `0` when there are no errors
@@ -184,6 +215,10 @@ adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | 
 
 `adoc build`:
 
+- uses explicit `[path]` and `--out` when passed
+- otherwise discovers config defaults; without `--out`, config must provide `outputs.dir` or exact `outputs.html`, `outputs.agent_json`, and `outputs.search`
+- with `--out <directory>`, writes `<directory>/docs.html`, `<directory>/docs.agent.json`, and, when embeddings are enabled, `<directory>/docs.search.json`
+- with config outputs, paths are resolved relative to the config file; `outputs.dir` fills omitted artifact paths as `docs.html`, `docs.agent.json`, and `docs.search.json`; exact artifact paths override the `outputs.dir` defaults
 - runs the same compile path as `check`
 - creates the output directory when it does not exist
 - fails if the output path exists as a file
@@ -192,19 +227,20 @@ adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | 
 - reads the prior output directory's `docs.search.json` when present and reuses vectors whose model header and content hash still match, reported as `info[build.embeddings_cached] embeddings: cached N, computed M`
 - if embedding model load, compute, or dimension validation fails after clean source compilation, exits `1`, still writes `docs.html` and `docs.agent.json`, omits a new `docs.search.json`, and leaves any prior `docs.search.json` untouched
 - accepts `--no-embeddings` to skip model loading and search artifact writes; any existing `docs.search.json` is left untouched and an info diagnostic `build.embeddings_skipped` is emitted
+- also skips embeddings when config sets `embeddings.provider: none`; config `local` and missing `embeddings` both enable the shipped local provider
 
 `adoc explain`:
 
 - reads a compiled agent artifact; it does not compile source
-- defaults to `--artifact dist/docs.agent.json`
+- defaults to config `outputs.agent_json`, then `dist/docs.agent.json`
 - prints the matching Knowledge Object with source and relation metadata
-- supports `--format text|json`
+- supports `--format auto|plain|styled|json`
 
 `adoc search`:
 
 - reads compiled artifacts; it does not compile source
-- defaults to `--artifact dist/docs.agent.json`
-- defaults to `--search-artifact dist/docs.search.json`
+- defaults to config `outputs.agent_json`, then `dist/docs.agent.json`
+- defaults to config `outputs.search`, then `dist/docs.search.json`
 - runs hybrid search by default when the search artifact loads
 - degrades to lexical search with one `search.artifact_missing` warning when the search artifact is absent
 - accepts `--lexical` for deterministic text search over `docs.agent.json`
@@ -213,7 +249,7 @@ adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | 
 - supports `--kind`, `--status`, `--owner`, and `--source-path` filters
 - treats an empty lexical query plus filters as a deterministic listing of matching objects
 - limits results with `--top`, defaulting to `10`
-- supports `--format text|json`
+- supports `--format auto|plain|styled|json`
 
 See [docs/v1-retrieval.md](docs/v1-retrieval.md) for retrieval workflow, citation guidance, model-swap behavior, and retrieval-set maintenance.
 
@@ -304,8 +340,8 @@ fn main() {}
 
 Current limitations:
 
-- `adoc search` is lexical-only and reads `docs.agent.json` only
-- `adoc init`, custom schemas, includes, config files, semantic search, hybrid ranking, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, web app, and permissions are deferred
+- custom schemas, includes, migrations, graph exports, semantic diff, CI/PR integrations, agent patching, hosted embedding adapters, web app, and permissions are deferred
+- config is intentionally minimal: strict mode only, one `docs_path`, output paths, and `embeddings.provider: local|none`
 
 ## Diagnostics
 
@@ -318,6 +354,7 @@ Examples:
 - raw HTML emits `error[parse.raw_html]`
 - unsafe links emit `error[parse.unsafe_link]`
 - broken object references and relation targets emit `error[ref.broken]`
+- parseable past `expires_at` values emit warning `lifecycle.expired`; the CLI reports only and does not edit source status or fields
 - unreadable directories emit `error[io.unreadable_directory]`
 - unsupported single-file source extensions emit `error[io.unsupported_source_extension]`
 
@@ -515,17 +552,18 @@ V0 is complete for the local source-to-artifact compiler loop. Implemented miles
 - standardized diagnostics and production-usable fixtures
 - a realistic billing pilot
 - artifact-backed `adoc explain <object-id>`
-- lexical-only `adoc search <query>` over `docs.agent.json`
+- hybrid `adoc search <query>` over `docs.agent.json` and `docs.search.json`
+- `adoc init` and minimal `agentdoc.config.yaml`
 
-Current V1 retrieval focuses on the existing flat agent artifact:
+Current local retrieval focuses on the existing flat agent artifact:
 
 - define the supported `docs.agent.json` read contract
 - support `adoc explain <object-id>` for object lookup and citation
-- support `adoc search <query>` for deterministic lexical local search
+- support `adoc search <query>` for deterministic lexical and local embedding-backed search
 - prove retrieval against the billing pilot
-- build `docs.search.json` with local FastEmbed embeddings for the next semantic retrieval slice
+- build `docs.search.json` with local FastEmbed embeddings
 
-Later milestones cover semantic and hybrid search, project ergonomics, migration, review workflows, patch safety, expanded schema, graph exports, composition, and team surfaces.
+Later milestones cover migration, review workflows, patch safety, expanded schema, graph exports, composition, hosted embedding adapters, and team surfaces.
 
 See [docs/ROADMAP.md](docs/ROADMAP.md) for the full sequence.
 

--- a/README.md
+++ b/README.md
@@ -198,11 +198,16 @@ adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | 
 - a single `.adoc` file
 - a directory, scanned recursively for `.adoc` files
 
+Config discovery walks upward from the current directory, checks for
+`agentdoc.config.yaml` in each directory, and stops after checking the first
+ancestor containing `.git` or `$HOME`. It never treats `/agentdoc.config.yaml`
+as global config.
+
 `adoc init`:
 
 - creates `agentdoc.config.yaml` and `docs/index.adoc` in the current directory
 - refuses to overwrite either target if it already exists
-- configures strict mode, `docs_path: docs`, `outputs.dir: dist`, exact default artifact paths, and `embeddings.provider: local`
+- configures strict mode, `docs_path: docs`, `outputs.dir: dist`, and `embeddings.provider: local`
 
 `adoc check`:
 
@@ -216,7 +221,7 @@ adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | 
 `adoc build`:
 
 - uses explicit `[path]` and `--out` when passed
-- otherwise discovers config defaults; without `--out`, config must provide `outputs.dir` or exact `outputs.html`, `outputs.agent_json`, and `outputs.search`
+- otherwise discovers config defaults; without `--out`, config must provide `outputs.dir` or exact `outputs.html` and `outputs.agent_json`; `outputs.search` is also required when embeddings are enabled
 - with `--out <directory>`, writes `<directory>/docs.html`, `<directory>/docs.agent.json`, and, when embeddings are enabled, `<directory>/docs.search.json`
 - with config outputs, paths are resolved relative to the config file; `outputs.dir` fills omitted artifact paths as `docs.html`, `docs.agent.json`, and `docs.search.json`; exact artifact paths override the `outputs.dir` defaults
 - runs the same compile path as `check`

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -15,7 +15,9 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 clap = { version = "4", features = ["derive"] }
 is-terminal = "0.4"
 owo-colors = "4"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde-saphyr = "0.0.21"
 thiserror = "1"
 
 [features]
@@ -26,6 +28,4 @@ adoc-core = { path = "../adoc-core", features = ["test-embedding-provider"] }
 assert_cmd = "2"
 insta = { version = "1", features = ["filters"] }
 predicates = "3"
-serde = { version = "1", features = ["derive"] }
-serde-saphyr = "0.0.21"
 strip-ansi-escapes = "0.2"

--- a/crates/adoc-cli/src/config.rs
+++ b/crates/adoc-cli/src/config.rs
@@ -54,14 +54,23 @@ impl ProjectConfig {
     pub(crate) fn discover() -> Result<Option<Self>, CliError> {
         let mut current_dir =
             std::env::current_dir().map_err(|source| CliError::CurrentDir { source })?;
+        let home_boundary = home_boundary();
 
         loop {
+            if current_dir.parent().is_none() {
+                return Ok(None);
+            }
+
             let candidate = current_dir.join(CONFIG_FILE_NAME);
             if candidate.exists() {
                 return Self::read(&candidate).map(Some);
             }
 
             if is_git_boundary(&current_dir) {
+                return Ok(None);
+            }
+
+            if home_boundary.as_deref() == Some(current_dir.as_path()) {
                 return Ok(None);
             }
 
@@ -158,4 +167,15 @@ fn resolve_config_path(config_dir: &Path, path: PathBuf) -> PathBuf {
 
 fn is_git_boundary(path: &Path) -> bool {
     path.join(".git").exists()
+}
+
+fn home_boundary() -> Option<PathBuf> {
+    std::env::var_os("HOME").and_then(|home| {
+        let home = PathBuf::from(home);
+        if home.as_os_str().is_empty() {
+            None
+        } else {
+            Some(fs::canonicalize(&home).unwrap_or(home))
+        }
+    })
 }

--- a/crates/adoc-cli/src/config.rs
+++ b/crates/adoc-cli/src/config.rs
@@ -29,6 +29,7 @@ pub(crate) enum EmbeddingsProvider {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawProjectConfig {
     version: u32,
     mode: String,
@@ -38,6 +39,7 @@ struct RawProjectConfig {
 }
 
 #[derive(Debug, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 struct RawOutputs {
     dir: Option<PathBuf>,
     html: Option<PathBuf>,
@@ -46,6 +48,7 @@ struct RawOutputs {
 }
 
 #[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RawEmbeddings {
     provider: String,
 }

--- a/crates/adoc-cli/src/config.rs
+++ b/crates/adoc-cli/src/config.rs
@@ -9,6 +9,7 @@ const CONFIG_FILE_NAME: &str = "agentdoc.config.yaml";
 
 #[derive(Debug, Clone)]
 pub(crate) struct ProjectConfig {
+    pub(crate) path: PathBuf,
     pub(crate) docs_path: PathBuf,
     pub(crate) outputs: ConfigOutputs,
     pub(crate) embeddings_provider: EmbeddingsProvider,
@@ -119,6 +120,7 @@ impl RawProjectConfig {
         };
 
         Ok(ProjectConfig {
+            path: path.to_path_buf(),
             docs_path: resolve_config_path(config_dir, self.docs_path),
             outputs,
             embeddings_provider,

--- a/crates/adoc-cli/src/config.rs
+++ b/crates/adoc-cli/src/config.rs
@@ -60,6 +60,10 @@ impl ProjectConfig {
                 return Self::read(&candidate).map(Some);
             }
 
+            if is_git_boundary(&current_dir) {
+                return Ok(None);
+            }
+
             if !current_dir.pop() {
                 return Ok(None);
             }
@@ -148,4 +152,8 @@ fn resolve_config_path(config_dir: &Path, path: PathBuf) -> PathBuf {
     } else {
         config_dir.join(path)
     }
+}
+
+fn is_git_boundary(path: &Path) -> bool {
+    path.join(".git").exists()
 }

--- a/crates/adoc-cli/src/config.rs
+++ b/crates/adoc-cli/src/config.rs
@@ -1,0 +1,151 @@
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+
+use crate::error::CliError;
+
+const CONFIG_FILE_NAME: &str = "agentdoc.config.yaml";
+
+#[derive(Debug, Clone)]
+pub(crate) struct ProjectConfig {
+    pub(crate) docs_path: PathBuf,
+    pub(crate) outputs: ConfigOutputs,
+    pub(crate) embeddings_provider: EmbeddingsProvider,
+}
+
+#[derive(Debug, Clone, Default)]
+pub(crate) struct ConfigOutputs {
+    pub(crate) html: Option<PathBuf>,
+    pub(crate) agent_json: Option<PathBuf>,
+    pub(crate) search: Option<PathBuf>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum EmbeddingsProvider {
+    Local,
+    None,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawProjectConfig {
+    version: u32,
+    mode: String,
+    docs_path: PathBuf,
+    outputs: Option<RawOutputs>,
+    embeddings: Option<RawEmbeddings>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct RawOutputs {
+    dir: Option<PathBuf>,
+    html: Option<PathBuf>,
+    agent_json: Option<PathBuf>,
+    search: Option<PathBuf>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawEmbeddings {
+    provider: String,
+}
+
+impl ProjectConfig {
+    pub(crate) fn discover() -> Result<Option<Self>, CliError> {
+        let mut current_dir =
+            std::env::current_dir().map_err(|source| CliError::CurrentDir { source })?;
+
+        loop {
+            let candidate = current_dir.join(CONFIG_FILE_NAME);
+            if candidate.exists() {
+                return Self::read(&candidate).map(Some);
+            }
+
+            if !current_dir.pop() {
+                return Ok(None);
+            }
+        }
+    }
+
+    fn read(path: &Path) -> Result<Self, CliError> {
+        let text = fs::read_to_string(path).map_err(|source| CliError::ConfigRead {
+            path: path.to_path_buf(),
+            source,
+        })?;
+        let raw: RawProjectConfig =
+            serde_saphyr::from_str(&text).map_err(|source| CliError::ConfigParse {
+                path: path.to_path_buf(),
+                source: Box::new(source),
+            })?;
+        raw.validate_and_resolve(path)
+    }
+}
+
+impl RawProjectConfig {
+    fn validate_and_resolve(self, path: &Path) -> Result<ProjectConfig, CliError> {
+        if self.version != 1 {
+            return Err(CliError::ConfigInvalid {
+                path: path.to_path_buf(),
+                message: format!("unsupported version {}; expected 1", self.version),
+            });
+        }
+
+        if self.mode != "strict" {
+            return Err(CliError::ConfigInvalid {
+                path: path.to_path_buf(),
+                message: format!("unsupported mode {:?}; expected \"strict\"", self.mode),
+            });
+        }
+
+        let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
+        let outputs = self.outputs.unwrap_or_default().resolve(config_dir);
+        let embeddings_provider = match self.embeddings {
+            Some(embeddings) => match embeddings.provider.as_str() {
+                "local" => EmbeddingsProvider::Local,
+                "none" => EmbeddingsProvider::None,
+                provider => {
+                    return Err(CliError::ConfigInvalid {
+                        path: path.to_path_buf(),
+                        message: format!(
+                            "unsupported embeddings provider {provider:?}; expected \"local\" or \"none\""
+                        ),
+                    });
+                }
+            },
+            None => EmbeddingsProvider::Local,
+        };
+
+        Ok(ProjectConfig {
+            docs_path: resolve_config_path(config_dir, self.docs_path),
+            outputs,
+            embeddings_provider,
+        })
+    }
+}
+
+impl RawOutputs {
+    fn resolve(self, config_dir: &Path) -> ConfigOutputs {
+        let dir = self.dir.map(|path| resolve_config_path(config_dir, path));
+        ConfigOutputs {
+            html: self
+                .html
+                .map(|path| resolve_config_path(config_dir, path))
+                .or_else(|| dir.as_ref().map(|dir| dir.join("docs.html"))),
+            agent_json: self
+                .agent_json
+                .map(|path| resolve_config_path(config_dir, path))
+                .or_else(|| dir.as_ref().map(|dir| dir.join("docs.agent.json"))),
+            search: self
+                .search
+                .map(|path| resolve_config_path(config_dir, path))
+                .or_else(|| dir.as_ref().map(|dir| dir.join("docs.search.json"))),
+        }
+    }
+}
+
+fn resolve_config_path(config_dir: &Path, path: PathBuf) -> PathBuf {
+    if path.is_absolute() {
+        path
+    } else {
+        config_dir.join(path)
+    }
+}

--- a/crates/adoc-cli/src/error.rs
+++ b/crates/adoc-cli/src/error.rs
@@ -28,8 +28,11 @@ pub(crate) enum CliError {
     #[error("error[config.invalid] invalid config {}: {message}", path.display())]
     ConfigInvalid { path: PathBuf, message: String },
 
-    #[error("error[config.missing] {message}")]
-    ConfigMissing { message: String },
+    #[error("error[config.missing] {message}{}", format_config_path(config_path))]
+    ConfigMissing {
+        message: String,
+        config_path: Option<PathBuf>,
+    },
 
     #[error("error[io.output_not_directory] output path exists as a file: {}", path.display())]
     OutputPathIsFile { path: PathBuf },
@@ -68,6 +71,13 @@ pub(crate) enum CliError {
         #[source]
         source: std::io::Error,
     },
+}
+
+fn format_config_path(config_path: &Option<PathBuf>) -> String {
+    config_path
+        .as_ref()
+        .map(|path| format!(" in {}", path.display()))
+        .unwrap_or_default()
 }
 
 impl CliError {

--- a/crates/adoc-cli/src/error.rs
+++ b/crates/adoc-cli/src/error.rs
@@ -2,8 +2,34 @@ use std::path::PathBuf;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CliError {
+    #[error("error[io.current_dir] could not read current directory: {source}")]
+    CurrentDir {
+        #[source]
+        source: std::io::Error,
+    },
+
     #[error("error[init.already_exists] target already exists: {}", path.display())]
     InitTargetExists { path: PathBuf },
+
+    #[error("error[config.read] could not read config {}: {source}", path.display())]
+    ConfigRead {
+        path: PathBuf,
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("error[config.parse] could not parse config {}: {source}", path.display())]
+    ConfigParse {
+        path: PathBuf,
+        #[source]
+        source: Box<serde_saphyr::Error>,
+    },
+
+    #[error("error[config.invalid] invalid config {}: {message}", path.display())]
+    ConfigInvalid { path: PathBuf, message: String },
+
+    #[error("error[config.missing] {message}")]
+    ConfigMissing { message: String },
 
     #[error("error[io.output_not_directory] output path exists as a file: {}", path.display())]
     OutputPathIsFile { path: PathBuf },

--- a/crates/adoc-cli/src/error.rs
+++ b/crates/adoc-cli/src/error.rs
@@ -2,6 +2,9 @@ use std::path::PathBuf;
 
 #[derive(Debug, thiserror::Error)]
 pub(crate) enum CliError {
+    #[error("error[init.already_exists] target already exists: {}", path.display())]
+    InitTargetExists { path: PathBuf },
+
     #[error("error[io.output_not_directory] output path exists as a file: {}", path.display())]
     OutputPathIsFile { path: PathBuf },
 

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -37,9 +37,6 @@ mode: strict
 docs_path: docs
 outputs:
   dir: dist
-  html: dist/docs.html
-  agent_json: dist/docs.agent.json
-  search: dist/docs.search.json
 embeddings:
   provider: local
 ";

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -4,6 +4,7 @@ mod error;
 mod presentation;
 
 use std::fs;
+use std::io::{self, Write};
 use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::process::ExitCode;
@@ -15,6 +16,7 @@ use adoc_core::{
     SearchResult, Severity, build_workspace, compile_workspace, embed_query,
     load_retrieval_session, search,
 };
+use chrono::{Local, Months, NaiveDate};
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 
 use crate::adapters::{ArtifactRecordResolver, SystemClock};
@@ -41,7 +43,13 @@ outputs:
 embeddings:
   provider: local
 ";
-const INIT_INDEX_TEMPLATE: &str = "\
+fn init_index_template(verified_at: NaiveDate) -> String {
+    let expires_at = verified_at
+        .checked_add_months(Months::new(12))
+        .expect("current date plus 12 months is representable");
+
+    format!(
+        "\
 # AgentDoc Project @doc(project.index)
 
 This project was initialized with AgentDoc.
@@ -49,13 +57,15 @@ This project was initialized with AgentDoc.
 ::claim project.initialized
 status: verified
 owner: team-docs
-verified_at: 2026-05-08
+verified_at: {verified_at}
 source: adoc init template
-expires_at: 2027-05-08
+expires_at: {expires_at}
 --
 The project has an initialized AgentDoc source tree.
 ::
-";
+"
+    )
+}
 
 fn main() -> ExitCode {
     ExitCode::from(run(std::env::args()) as u8)
@@ -243,7 +253,11 @@ enum Commands {
 
 fn init() -> i32 {
     match write_init_files() {
-        Ok(()) => 0,
+        Ok(()) => {
+            println!("Created {INIT_CONFIG_PATH} and {INIT_INDEX_PATH}");
+            println!("Next: adoc check");
+            0
+        }
         Err(error) => report(error),
     }
 }
@@ -267,16 +281,49 @@ fn write_init_files() -> Result<(), CliError> {
         })?;
     }
 
-    fs::write(&config_path, INIT_CONFIG_TEMPLATE).map_err(|source| CliError::WriteFailed {
-        path: config_path,
-        source,
-    })?;
-    fs::write(&index_path, INIT_INDEX_TEMPLATE).map_err(|source| CliError::WriteFailed {
-        path: index_path,
-        source,
-    })?;
+    let index_template = init_index_template(Local::now().date_naive());
+    write_new_file(&config_path, INIT_CONFIG_TEMPLATE.as_bytes())?;
+    if let Err(error) = write_new_file(&index_path, index_template.as_bytes()) {
+        cleanup_init_paths([&config_path]);
+        return Err(error);
+    }
 
     Ok(())
+}
+
+fn write_new_file(path: &Path, contents: &[u8]) -> Result<(), CliError> {
+    let mut file = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(path)
+        .map_err(|source| {
+            if source.kind() == io::ErrorKind::AlreadyExists {
+                CliError::InitTargetExists {
+                    path: path.to_path_buf(),
+                }
+            } else {
+                CliError::WriteFailed {
+                    path: path.to_path_buf(),
+                    source,
+                }
+            }
+        })?;
+
+    if let Err(source) = file.write_all(contents) {
+        cleanup_init_paths([path]);
+        return Err(CliError::WriteFailed {
+            path: path.to_path_buf(),
+            source,
+        });
+    }
+
+    Ok(())
+}
+
+fn cleanup_init_paths<P: AsRef<Path>>(paths: impl IntoIterator<Item = P>) {
+    for path in paths {
+        let _ = fs::remove_file(path.as_ref());
+    }
 }
 
 fn check(path: Option<PathBuf>) -> i32 {

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -1,4 +1,5 @@
 mod adapters;
+mod config;
 mod error;
 mod presentation;
 
@@ -17,6 +18,7 @@ use adoc_core::{
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 
 use crate::adapters::{ArtifactRecordResolver, SystemClock};
+use crate::config::{EmbeddingsProvider, ProjectConfig};
 use crate::error::CliError;
 use crate::presentation::{
     ColorChoice, FormatChoice, ResolvedFormat, json as json_presentation, make_presenter,
@@ -25,6 +27,8 @@ use crate::presentation::{
 
 const INIT_CONFIG_PATH: &str = "agentdoc.config.yaml";
 const INIT_INDEX_PATH: &str = "docs/index.adoc";
+const DEFAULT_AGENT_ARTIFACT_PATH: &str = "dist/docs.agent.json";
+const DEFAULT_SEARCH_ARTIFACT_PATH: &str = "dist/docs.search.json";
 const INIT_CONFIG_TEMPLATE: &str = "\
 version: 1
 mode: strict
@@ -189,26 +193,35 @@ struct Cli {
 enum Commands {
     Init,
     Check {
-        path: PathBuf,
+        path: Option<PathBuf>,
     },
     Build {
-        path: PathBuf,
+        path: Option<PathBuf>,
         #[arg(long)]
-        out: PathBuf,
+        out: Option<PathBuf>,
         #[arg(long)]
         no_embeddings: bool,
     },
     Explain {
         object_id: String,
-        #[arg(long, default_value = "dist/docs.agent.json")]
-        artifact: PathBuf,
+        #[arg(
+            long,
+            help = "Agent JSON artifact path (default: config outputs.agent_json, then dist/docs.agent.json)"
+        )]
+        artifact: Option<PathBuf>,
     },
     Search {
         query: String,
-        #[arg(long, default_value = "dist/docs.agent.json")]
-        artifact: PathBuf,
-        #[arg(long, default_value = "dist/docs.search.json")]
-        search_artifact: PathBuf,
+        #[arg(
+            long,
+            help = "Agent JSON artifact path (default: config outputs.agent_json, then dist/docs.agent.json)"
+        )]
+        artifact: Option<PathBuf>,
+        #[arg(
+            long,
+            help = "Search artifact path (default: config outputs.search, then dist/docs.search.json)"
+        )]
+        search_artifact: Option<PathBuf>,
         #[arg(long, conflicts_with = "lexical")]
         semantic: bool,
         /// Reserved for the V1.5/V1.6 hybrid slice; today this is the default
@@ -266,7 +279,12 @@ fn write_init_files() -> Result<(), CliError> {
     Ok(())
 }
 
-fn check(path: PathBuf) -> i32 {
+fn check(path: Option<PathBuf>) -> i32 {
+    let path = match resolve_docs_path(path) {
+        Ok(path) => path,
+        Err(error) => return report(error),
+    };
+
     let result = compile_workspace(CompileInput { root: path });
     print_diagnostics(&result.diagnostics);
     print_summary(&result.diagnostics);
@@ -274,12 +292,30 @@ fn check(path: PathBuf) -> i32 {
     if result.has_errors() { 1 } else { 0 }
 }
 
-fn build(path: PathBuf, out: PathBuf, no_embeddings: bool) -> i32 {
-    let embedding_mode = if no_embeddings {
-        BuildEmbeddingMode::Skipped
-    } else {
-        BuildEmbeddingMode::Enabled
+fn build(path: Option<PathBuf>, out: Option<PathBuf>, no_embeddings: bool) -> i32 {
+    let config = match ProjectConfig::discover() {
+        Ok(config) => config,
+        Err(error) => return report(error),
     };
+    let path = match resolve_docs_path_with_config(path, config.as_ref()) {
+        Ok(path) => path,
+        Err(error) => return report(error),
+    };
+    let embedding_mode = resolve_embedding_mode(config.as_ref(), no_embeddings);
+
+    match out {
+        Some(out) => build_to_dir(path, out, embedding_mode),
+        None => {
+            let output_paths = match resolve_build_output_paths(config.as_ref()) {
+                Ok(paths) => paths,
+                Err(error) => return report(error),
+            };
+            build_to_paths(path, output_paths, embedding_mode)
+        }
+    }
+}
+
+fn build_to_dir(path: PathBuf, out: PathBuf, embedding_mode: BuildEmbeddingMode) -> i32 {
     let result = build_workspace(BuildInput {
         root: path,
         embeddings: embedding_mode,
@@ -289,6 +325,115 @@ fn build(path: PathBuf, out: PathBuf, no_embeddings: bool) -> i32 {
     print_summary(&result.diagnostics);
 
     finish_build_result(result, &out)
+}
+
+fn build_to_paths(
+    path: PathBuf,
+    output_paths: BuildOutputPaths,
+    embedding_mode: BuildEmbeddingMode,
+) -> i32 {
+    let result = build_workspace(BuildInput {
+        root: path,
+        embeddings: embedding_mode,
+        prior_search_artifact_path: Some(output_paths.search.clone()),
+    });
+    print_diagnostics(&result.diagnostics);
+    print_summary(&result.diagnostics);
+
+    finish_build_result_at_paths(result, &output_paths)
+}
+
+#[derive(Debug, Clone)]
+struct BuildOutputPaths {
+    html: PathBuf,
+    agent_json: PathBuf,
+    search: PathBuf,
+}
+
+fn resolve_docs_path(path: Option<PathBuf>) -> Result<PathBuf, CliError> {
+    if let Some(path) = path {
+        return Ok(path);
+    }
+
+    let config = ProjectConfig::discover()?;
+    resolve_docs_path_with_config(path, config.as_ref())
+}
+
+fn resolve_docs_path_with_config(
+    path: Option<PathBuf>,
+    config: Option<&ProjectConfig>,
+) -> Result<PathBuf, CliError> {
+    path.or_else(|| config.map(|config| config.docs_path.clone()))
+        .ok_or_else(|| CliError::ConfigMissing {
+            message: "adoc check/build requires a path or agentdoc.config.yaml with docs_path"
+                .to_string(),
+        })
+}
+
+fn resolve_embedding_mode(
+    config: Option<&ProjectConfig>,
+    no_embeddings: bool,
+) -> BuildEmbeddingMode {
+    if no_embeddings
+        || config
+            .map(|config| config.embeddings_provider == EmbeddingsProvider::None)
+            .unwrap_or(false)
+    {
+        BuildEmbeddingMode::Skipped
+    } else {
+        BuildEmbeddingMode::Enabled
+    }
+}
+
+fn resolve_build_output_paths(
+    config: Option<&ProjectConfig>,
+) -> Result<BuildOutputPaths, CliError> {
+    let Some(config) = config else {
+        return Err(CliError::ConfigMissing {
+            message: "adoc build requires --out or agentdoc.config.yaml outputs".to_string(),
+        });
+    };
+
+    match (
+        config.outputs.html.clone(),
+        config.outputs.agent_json.clone(),
+        config.outputs.search.clone(),
+    ) {
+        (Some(html), Some(agent_json), Some(search)) => Ok(BuildOutputPaths {
+            html,
+            agent_json,
+            search,
+        }),
+        _ => Err(CliError::ConfigMissing {
+            message:
+                "adoc build requires outputs.dir or exact html, agent_json, and search outputs"
+                    .to_string(),
+        }),
+    }
+}
+
+fn resolve_agent_artifact_path(path: Option<PathBuf>) -> Result<PathBuf, CliError> {
+    if let Some(path) = path {
+        return Ok(path);
+    }
+
+    let config = ProjectConfig::discover()?;
+    Ok(config
+        .as_ref()
+        .and_then(|config| config.outputs.agent_json.clone())
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_AGENT_ARTIFACT_PATH)))
+}
+
+fn resolve_search_artifact_path(path: Option<PathBuf>) -> Result<PathBuf, CliError> {
+    if let Some(path) = path {
+        return Ok(path);
+    }
+
+    let config = ProjectConfig::discover()?;
+    Ok(config
+        .as_ref()
+        .and_then(|config| config.outputs.search.clone())
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SEARCH_ARTIFACT_PATH)))
 }
 
 fn finish_build_result(result: CompileResult, out: &Path) -> i32 {
@@ -312,7 +457,32 @@ fn finish_build_result(result: CompileResult, out: &Path) -> i32 {
     }
 }
 
-fn explain(object_id: String, artifact: PathBuf, resolved: ResolvedFormat) -> i32 {
+fn finish_build_result_at_paths(result: CompileResult, paths: &BuildOutputPaths) -> i32 {
+    let has_errors = result.has_errors();
+
+    let artifacts = match result.artifacts {
+        Some(artifacts) => artifacts,
+        None if has_errors => return 1,
+        None => return report(CliError::BuildMissingArtifacts),
+    };
+
+    match write_artifacts_to_paths(
+        paths,
+        &artifacts.html,
+        &artifacts.agent_json,
+        artifacts.search_json.as_ref(),
+    ) {
+        Ok(()) if has_errors => 1,
+        Ok(()) => 0,
+        Err(error) => report(error),
+    }
+}
+
+fn explain(object_id: String, artifact: Option<PathBuf>, resolved: ResolvedFormat) -> i32 {
+    let artifact = match resolve_agent_artifact_path(artifact) {
+        Ok(path) => path,
+        Err(error) => return report(error),
+    };
     let load_result = load_retrieval_session(RetrievalInput {
         artifact_path: artifact.clone(),
         search_artifact_path: None,
@@ -400,8 +570,8 @@ fn explain(object_id: String, artifact: PathBuf, resolved: ResolvedFormat) -> i3
 
 struct SearchCommandInput {
     query: String,
-    artifact: PathBuf,
-    search_artifact: PathBuf,
+    artifact: Option<PathBuf>,
+    search_artifact: Option<PathBuf>,
     semantic: bool,
     lexical: bool,
     filters: SearchFilters,
@@ -417,13 +587,22 @@ fn search_command(input: SearchCommandInput, resolved: ResolvedFormat) -> i32 {
         SearchMode::Hybrid
     };
 
+    let artifact = match resolve_agent_artifact_path(input.artifact) {
+        Ok(path) => path,
+        Err(error) => return report(error),
+    };
     let search_artifact_path = match requested_mode {
         SearchMode::Lexical => None,
-        SearchMode::Hybrid | SearchMode::Semantic => Some(input.search_artifact),
+        SearchMode::Hybrid | SearchMode::Semantic => {
+            match resolve_search_artifact_path(input.search_artifact) {
+                Ok(path) => Some(path),
+                Err(error) => return report(error),
+            }
+        }
     };
 
     let load_result = load_retrieval_session(RetrievalInput {
-        artifact_path: input.artifact,
+        artifact_path: artifact,
         search_artifact_path,
     });
     let RetrievalLoadResult {
@@ -668,6 +847,46 @@ fn write_artifacts(
     }
 
     Ok(())
+}
+
+fn write_artifacts_to_paths(
+    paths: &BuildOutputPaths,
+    html: &str,
+    agent_json: &AgentJsonDocument,
+    search_json: Option<&SearchArtifactDocument>,
+) -> Result<(), CliError> {
+    write_file_with_parents(&paths.html, html.as_bytes())?;
+
+    let agent_json_text = agent_json
+        .to_pretty_json()
+        .map_err(|source| CliError::AgentJsonSerialize { source })?;
+    write_file_with_parents(&paths.agent_json, agent_json_text.as_bytes())?;
+
+    if let Some(search_json) = search_json {
+        let search_json_text = search_json
+            .to_pretty_json()
+            .map_err(|source| CliError::SearchJsonSerialize { source })?;
+        write_file_with_parents(&paths.search, search_json_text.as_bytes())?;
+    }
+
+    Ok(())
+}
+
+fn write_file_with_parents(path: &Path, contents: &[u8]) -> Result<(), CliError> {
+    if let Some(parent) = path
+        .parent()
+        .filter(|parent| !parent.as_os_str().is_empty())
+    {
+        fs::create_dir_all(parent).map_err(|source| CliError::CreateOutputDirectory {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    fs::write(path, contents).map_err(|source| CliError::WriteFailed {
+        path: path.to_path_buf(),
+        source,
+    })
 }
 
 fn print_diagnostics(diagnostics: &[Diagnostic]) {

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -418,6 +418,7 @@ fn resolve_docs_path_with_config(
         .ok_or_else(|| CliError::ConfigMissing {
             message: "adoc check/build requires a path or agentdoc.config.yaml with docs_path"
                 .to_string(),
+            config_path: config.map(|config| config.path.clone()),
         })
 }
 
@@ -442,6 +443,7 @@ fn resolve_build_output_paths(
     let Some(config) = config else {
         return Err(CliError::ConfigMissing {
             message: "adoc build requires --out or agentdoc.config.yaml outputs".to_string(),
+            config_path: None,
         });
     };
 
@@ -459,6 +461,7 @@ fn resolve_build_output_paths(
             message:
                 "adoc build requires outputs.dir or exact html, agent_json, and search outputs"
                     .to_string(),
+            config_path: Some(config.path.clone()),
         }),
     }
 }

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -327,7 +327,11 @@ fn cleanup_init_paths<P: AsRef<Path>>(paths: impl IntoIterator<Item = P>) {
 }
 
 fn check(path: Option<PathBuf>) -> i32 {
-    let path = match resolve_docs_path(path) {
+    let config = match discover_project_config_if(path.is_none()) {
+        Ok(config) => config,
+        Err(error) => return report(error),
+    };
+    let path = match resolve_docs_path_with_config(path, config.as_ref()) {
         Ok(path) => path,
         Err(error) => return report(error),
     };
@@ -340,7 +344,8 @@ fn check(path: Option<PathBuf>) -> i32 {
 }
 
 fn build(path: Option<PathBuf>, out: Option<PathBuf>, no_embeddings: bool) -> i32 {
-    let config = match ProjectConfig::discover() {
+    let needs_config = path.is_none() || out.is_none() || !no_embeddings;
+    let config = match discover_project_config_if(needs_config) {
         Ok(config) => config,
         Err(error) => return report(error),
     };
@@ -397,13 +402,12 @@ struct BuildOutputPaths {
     search: PathBuf,
 }
 
-fn resolve_docs_path(path: Option<PathBuf>) -> Result<PathBuf, CliError> {
-    if let Some(path) = path {
-        return Ok(path);
+fn discover_project_config_if(needed: bool) -> Result<Option<ProjectConfig>, CliError> {
+    if needed {
+        ProjectConfig::discover()
+    } else {
+        Ok(None)
     }
-
-    let config = ProjectConfig::discover()?;
-    resolve_docs_path_with_config(path, config.as_ref())
 }
 
 fn resolve_docs_path_with_config(
@@ -459,28 +463,32 @@ fn resolve_build_output_paths(
     }
 }
 
-fn resolve_agent_artifact_path(path: Option<PathBuf>) -> Result<PathBuf, CliError> {
+fn resolve_agent_artifact_path_with_config(
+    path: Option<PathBuf>,
+    config: Option<&ProjectConfig>,
+) -> PathBuf {
     if let Some(path) = path {
-        return Ok(path);
+        return path;
     }
 
-    let config = ProjectConfig::discover()?;
-    Ok(config
+    config
         .as_ref()
         .and_then(|config| config.outputs.agent_json.clone())
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_AGENT_ARTIFACT_PATH)))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_AGENT_ARTIFACT_PATH))
 }
 
-fn resolve_search_artifact_path(path: Option<PathBuf>) -> Result<PathBuf, CliError> {
+fn resolve_search_artifact_path_with_config(
+    path: Option<PathBuf>,
+    config: Option<&ProjectConfig>,
+) -> PathBuf {
     if let Some(path) = path {
-        return Ok(path);
+        return path;
     }
 
-    let config = ProjectConfig::discover()?;
-    Ok(config
+    config
         .as_ref()
         .and_then(|config| config.outputs.search.clone())
-        .unwrap_or_else(|| PathBuf::from(DEFAULT_SEARCH_ARTIFACT_PATH)))
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_SEARCH_ARTIFACT_PATH))
 }
 
 fn finish_build_result(result: CompileResult, out: &Path) -> i32 {
@@ -526,10 +534,11 @@ fn finish_build_result_at_paths(result: CompileResult, paths: &BuildOutputPaths)
 }
 
 fn explain(object_id: String, artifact: Option<PathBuf>, resolved: ResolvedFormat) -> i32 {
-    let artifact = match resolve_agent_artifact_path(artifact) {
-        Ok(path) => path,
+    let config = match discover_project_config_if(artifact.is_none()) {
+        Ok(config) => config,
         Err(error) => return report(error),
     };
+    let artifact = resolve_agent_artifact_path_with_config(artifact, config.as_ref());
     let load_result = load_retrieval_session(RetrievalInput {
         artifact_path: artifact.clone(),
         search_artifact_path: None,
@@ -634,18 +643,18 @@ fn search_command(input: SearchCommandInput, resolved: ResolvedFormat) -> i32 {
         SearchMode::Hybrid
     };
 
-    let artifact = match resolve_agent_artifact_path(input.artifact) {
-        Ok(path) => path,
+    let needs_search_config = matches!(requested_mode, SearchMode::Hybrid | SearchMode::Semantic)
+        && input.search_artifact.is_none();
+    let config = match discover_project_config_if(input.artifact.is_none() || needs_search_config) {
+        Ok(config) => config,
         Err(error) => return report(error),
     };
+    let artifact = resolve_agent_artifact_path_with_config(input.artifact, config.as_ref());
     let search_artifact_path = match requested_mode {
         SearchMode::Lexical => None,
-        SearchMode::Hybrid | SearchMode::Semantic => {
-            match resolve_search_artifact_path(input.search_artifact) {
-                Ok(path) => Some(path),
-                Err(error) => return report(error),
-            }
-        }
+        SearchMode::Hybrid | SearchMode::Semantic => Some(
+            resolve_search_artifact_path_with_config(input.search_artifact, config.as_ref()),
+        ),
     };
 
     let load_result = load_retrieval_session(RetrievalInput {

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -16,7 +16,6 @@ use adoc_core::{
     SearchResult, Severity, build_workspace, compile_workspace, embed_query,
     load_retrieval_session, search,
 };
-use chrono::{Local, Months, NaiveDate};
 use clap::{Parser, Subcommand, ValueEnum, error::ErrorKind};
 
 use crate::adapters::{ArtifactRecordResolver, SystemClock};
@@ -40,28 +39,18 @@ outputs:
 embeddings:
   provider: local
 ";
-fn init_index_template(verified_at: NaiveDate) -> String {
-    let expires_at = verified_at
-        .checked_add_months(Months::new(12))
-        .expect("current date plus 12 months is representable");
-
-    format!(
-        "\
+fn init_index_template() -> &'static str {
+    "\
 # AgentDoc Project @doc(project.index)
 
 This project was initialized with AgentDoc.
 
 ::claim project.initialized
-status: verified
-owner: team-docs
-verified_at: {verified_at}
-source: adoc init template
-expires_at: {expires_at}
+status: draft
 --
 The project has an initialized AgentDoc source tree.
 ::
 "
-    )
 }
 
 fn main() -> ExitCode {
@@ -278,7 +267,7 @@ fn write_init_files() -> Result<(), CliError> {
         })?;
     }
 
-    let index_template = init_index_template(Local::now().date_naive());
+    let index_template = init_index_template();
     write_new_file(&config_path, INIT_CONFIG_TEMPLATE.as_bytes())?;
     if let Err(error) = write_new_file(&index_path, index_template.as_bytes()) {
         cleanup_init_paths([&config_path]);

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -355,7 +355,7 @@ fn build(path: Option<PathBuf>, out: Option<PathBuf>, no_embeddings: bool) -> i3
     match out {
         Some(out) => build_to_dir(path, out, embedding_mode),
         None => {
-            let output_paths = match resolve_build_output_paths(config.as_ref()) {
+            let output_paths = match resolve_build_output_paths(config.as_ref(), embedding_mode) {
                 Ok(paths) => paths,
                 Err(error) => return report(error),
             };
@@ -384,7 +384,7 @@ fn build_to_paths(
     let result = build_workspace(BuildInput {
         root: path,
         embeddings: embedding_mode,
-        prior_search_artifact_path: Some(output_paths.search.clone()),
+        prior_search_artifact_path: output_paths.search.clone(),
     });
     print_diagnostics(&result.diagnostics);
     print_summary(&result.diagnostics);
@@ -396,7 +396,7 @@ fn build_to_paths(
 struct BuildOutputPaths {
     html: PathBuf,
     agent_json: PathBuf,
-    search: PathBuf,
+    search: Option<PathBuf>,
 }
 
 fn discover_project_config_if(needed: bool) -> Result<Option<ProjectConfig>, CliError> {
@@ -436,6 +436,7 @@ fn resolve_embedding_mode(
 
 fn resolve_build_output_paths(
     config: Option<&ProjectConfig>,
+    embedding_mode: BuildEmbeddingMode,
 ) -> Result<BuildOutputPaths, CliError> {
     let Some(config) = config else {
         return Err(CliError::ConfigMissing {
@@ -444,20 +445,29 @@ fn resolve_build_output_paths(
         });
     };
 
-    match (
-        config.outputs.html.clone(),
-        config.outputs.agent_json.clone(),
-        config.outputs.search.clone(),
-    ) {
-        (Some(html), Some(agent_json), Some(search)) => Ok(BuildOutputPaths {
+    let search_required = embedding_mode == BuildEmbeddingMode::Enabled;
+    let html = config.outputs.html.clone();
+    let agent_json = config.outputs.agent_json.clone();
+    let search = config.outputs.search.clone();
+
+    match (html, agent_json, search_required, search) {
+        (Some(html), Some(agent_json), true, Some(search)) => Ok(BuildOutputPaths {
+            html,
+            agent_json,
+            search: Some(search),
+        }),
+        (Some(html), Some(agent_json), false, search) => Ok(BuildOutputPaths {
             html,
             agent_json,
             search,
         }),
         _ => Err(CliError::ConfigMissing {
-            message:
+            message: if search_required {
                 "adoc build requires outputs.dir or exact html, agent_json, and search outputs"
-                    .to_string(),
+            } else {
+                "adoc build requires outputs.dir or exact html and agent_json outputs"
+            }
+            .to_string(),
             config_path: Some(config.path.clone()),
         }),
     }
@@ -918,11 +928,11 @@ fn write_artifacts_to_paths(
         .map_err(|source| CliError::AgentJsonSerialize { source })?;
     write_file_with_parents(&paths.agent_json, agent_json_text.as_bytes())?;
 
-    if let Some(search_json) = search_json {
+    if let (Some(search_json), Some(search_path)) = (search_json, paths.search.as_ref()) {
         let search_json_text = search_json
             .to_pretty_json()
             .map_err(|source| CliError::SearchJsonSerialize { source })?;
-        write_file_with_parents(&paths.search, search_json_text.as_bytes())?;
+        write_file_with_parents(search_path, search_json_text.as_bytes())?;
     }
 
     Ok(())

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -23,6 +23,36 @@ use crate::presentation::{
     plain as plain_presentation, terminal,
 };
 
+const INIT_CONFIG_PATH: &str = "agentdoc.config.yaml";
+const INIT_INDEX_PATH: &str = "docs/index.adoc";
+const INIT_CONFIG_TEMPLATE: &str = "\
+version: 1
+mode: strict
+docs_path: docs
+outputs:
+  dir: dist
+  html: dist/docs.html
+  agent_json: dist/docs.agent.json
+  search: dist/docs.search.json
+embeddings:
+  provider: local
+";
+const INIT_INDEX_TEMPLATE: &str = "\
+# AgentDoc Project @doc(project.index)
+
+This project was initialized with AgentDoc.
+
+::claim project.initialized
+status: verified
+owner: team-docs
+verified_at: 2026-05-08
+source: adoc init template
+expires_at: 2027-05-08
+--
+The project has an initialized AgentDoc source tree.
+::
+";
+
 fn main() -> ExitCode {
     ExitCode::from(run(std::env::args()) as u8)
 }
@@ -32,6 +62,7 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
         Ok(cli) => {
             let resolved = terminal::detect(cli.format.into(), cli.color.into());
             match cli.command {
+                Commands::Init => init(),
                 Commands::Check { path } => check(path),
                 Commands::Build {
                     path,
@@ -156,6 +187,7 @@ struct Cli {
 
 #[derive(Subcommand)]
 enum Commands {
+    Init,
     Check {
         path: PathBuf,
     },
@@ -194,6 +226,44 @@ enum Commands {
         #[arg(long, default_value = "10")]
         top: NonZeroUsize,
     },
+}
+
+fn init() -> i32 {
+    match write_init_files() {
+        Ok(()) => 0,
+        Err(error) => report(error),
+    }
+}
+
+fn write_init_files() -> Result<(), CliError> {
+    let config_path = PathBuf::from(INIT_CONFIG_PATH);
+    let index_path = PathBuf::from(INIT_INDEX_PATH);
+
+    for target in [&config_path, &index_path] {
+        if target.exists() {
+            return Err(CliError::InitTargetExists {
+                path: target.to_path_buf(),
+            });
+        }
+    }
+
+    if let Some(parent) = index_path.parent() {
+        fs::create_dir_all(parent).map_err(|source| CliError::CreateOutputDirectory {
+            path: parent.to_path_buf(),
+            source,
+        })?;
+    }
+
+    fs::write(&config_path, INIT_CONFIG_TEMPLATE).map_err(|source| CliError::WriteFailed {
+        path: config_path,
+        source,
+    })?;
+    fs::write(&index_path, INIT_INDEX_TEMPLATE).map_err(|source| CliError::WriteFailed {
+        path: index_path,
+        source,
+    })?;
+
+    Ok(())
 }
 
 fn check(path: PathBuf) -> i32 {

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -484,8 +484,8 @@ fn build_reuses_search_artifact_cache_for_unchanged_source() {
 }
 
 #[test]
-fn build_missing_out_exits_1_with_parse_error() {
-    let workspace = TestWorkspace::new("build-invalid-usage-missing-out");
+fn build_missing_out_without_config_exits_1_with_config_error() {
+    let workspace = TestWorkspace::new("build-missing-out-without-config");
     let source = workspace.write(
         "guide.adoc",
         "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
@@ -499,17 +499,13 @@ fn build_missing_out_exits_1_with_parse_error() {
     assert_eq!(output.status.code(), Some(1));
     assert!(
         output.stdout.is_empty(),
-        "parse errors should render to stderr, stdout was:\n{}",
+        "config errors should render to stderr, stdout was:\n{}",
         String::from_utf8_lossy(&output.stdout)
     );
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        stderr.contains("required arguments were not provided"),
-        "expected required-argument parse error, got:\n{stderr}"
-    );
-    assert!(
-        stderr.contains("--out <OUT>"),
-        "expected missing --out in parse error, got:\n{stderr}"
+        stderr.contains("error[config.missing]"),
+        "expected config-missing error, got:\n{stderr}"
     );
 }
 

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -3,6 +3,7 @@ mod support;
 use std::fs;
 use std::process::Command;
 
+use chrono::{Local, Months};
 use support::{TestWorkspace, fixture_path};
 
 fn adoc_command() -> Command {
@@ -12,9 +13,16 @@ fn adoc_command() -> Command {
 }
 
 fn write_valid_source(workspace: &TestWorkspace, relative_path: &str) {
+    let verified_at = Local::now().date_naive();
+    let expires_at = verified_at
+        .checked_add_months(Months::new(12))
+        .expect("verified_at plus 12 months is valid");
+
     workspace.write(
         relative_path,
-        "# Billing Guide @doc(billing.guide)\n\n::claim billing.ready\nstatus: verified\nowner: team-docs\nverified_at: 2026-05-08\nsource: test\nexpires_at: 2027-05-08\n--\nBilling docs are ready.\n::\n",
+        &format!(
+            "# Billing Guide @doc(billing.guide)\n\n::claim billing.ready\nstatus: verified\nowner: team-docs\nverified_at: {verified_at}\nsource: test\nexpires_at: {expires_at}\n--\nBilling docs are ready.\n::\n"
+        ),
     );
 }
 

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -161,6 +161,45 @@ fn config_build_explicit_path_and_out_ignore_config_outputs() {
 }
 
 #[test]
+fn config_build_fully_explicit_no_embeddings_ignores_malformed_config() {
+    let workspace = TestWorkspace::new("config-build-explicit-malformed-ignored");
+    write_valid_source(&workspace, "explicit/source.adoc");
+    workspace.write("agentdoc.config.yaml", "version: [\n");
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args([
+            "build",
+            "explicit/source.adoc",
+            "--out",
+            "explicit-dist",
+            "--no-embeddings",
+        ])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected fully explicit build to ignore malformed config\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(workspace.root.join("explicit-dist/docs.html").is_file());
+    assert!(
+        workspace
+            .root
+            .join("explicit-dist/docs.agent.json")
+            .is_file()
+    );
+    assert!(
+        !workspace
+            .root
+            .join("explicit-dist/docs.search.json")
+            .exists()
+    );
+}
+
+#[test]
 fn config_explain_and_search_use_configured_artifacts_unless_args_are_explicit() {
     let workspace = TestWorkspace::new("config-retrieval-artifacts");
     copy_valid_artifact(&workspace, "configured/docs.agent.json");

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -1,0 +1,228 @@
+mod support;
+
+use std::fs;
+use std::process::Command;
+
+use support::{TestWorkspace, fixture_path};
+
+fn adoc_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+    command.env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory");
+    command
+}
+
+fn write_valid_source(workspace: &TestWorkspace, relative_path: &str) {
+    workspace.write(
+        relative_path,
+        "# Billing Guide @doc(billing.guide)\n\n::claim billing.ready\nstatus: verified\nowner: team-docs\nverified_at: 2026-05-08\nsource: test\nexpires_at: 2027-05-08\n--\nBilling docs are ready.\n::\n",
+    );
+}
+
+fn copy_valid_artifact(workspace: &TestWorkspace, relative_path: &str) {
+    let artifact = fs::read_to_string(fixture_path("v1_1_explain/valid_artifact.agent.json"))
+        .expect("fixture artifact is readable");
+    workspace.write(relative_path, &artifact);
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+#[test]
+fn config_check_without_path_uses_nearest_docs_path_resolved_from_config_dir() {
+    let workspace = TestWorkspace::new("config-check-docs-path");
+    write_valid_source(&workspace, "docs/index.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: local\n",
+    );
+    fs::create_dir_all(workspace.root.join("nested/deeper")).expect("nested cwd can be created");
+
+    let output = adoc_command()
+        .current_dir(workspace.root.join("nested/deeper"))
+        .args(["check"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected config-backed check to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(stdout(&output).contains("0 errors"));
+}
+
+#[test]
+fn config_build_uses_exact_output_paths_and_dir_fills_omitted_paths() {
+    let workspace = TestWorkspace::new("config-build-output-paths");
+    write_valid_source(&workspace, "docs/index.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: bundled\n  html: public/site.html\n  agent_json: artifacts/agent.json\nembeddings:\n  provider: local\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected config-backed build to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(workspace.root.join("public/site.html").is_file());
+    assert!(workspace.root.join("artifacts/agent.json").is_file());
+    assert!(workspace.root.join("bundled/docs.search.json").is_file());
+    assert!(!workspace.root.join("bundled/docs.html").exists());
+    assert!(!workspace.root.join("bundled/docs.agent.json").exists());
+}
+
+#[test]
+fn config_build_explicit_path_and_out_ignore_config_outputs() {
+    let workspace = TestWorkspace::new("config-build-explicit-wins");
+    write_valid_source(&workspace, "configured/index.adoc");
+    write_valid_source(&workspace, "explicit/source.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: configured\noutputs:\n  dir: configured-dist\n  html: configured-html/custom.html\nembeddings:\n  provider: none\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "explicit/source.adoc", "--out", "explicit-dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected explicit build to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(workspace.root.join("explicit-dist/docs.html").is_file());
+    assert!(
+        workspace
+            .root
+            .join("explicit-dist/docs.agent.json")
+            .is_file()
+    );
+    assert!(!workspace.root.join("configured-html/custom.html").exists());
+    assert!(!workspace.root.join("configured-dist/docs.html").exists());
+}
+
+#[test]
+fn config_explain_and_search_use_configured_artifacts_unless_args_are_explicit() {
+    let workspace = TestWorkspace::new("config-retrieval-artifacts");
+    copy_valid_artifact(&workspace, "configured/docs.agent.json");
+    copy_valid_artifact(&workspace, "explicit/docs.agent.json");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\n  agent_json: configured/docs.agent.json\n  search: configured/docs.search.json\nembeddings:\n  provider: local\n",
+    );
+
+    let explain = adoc_command()
+        .current_dir(&workspace.root)
+        .args([
+            "explain",
+            "billing.refunds.issue-credit",
+            "--format",
+            "plain",
+        ])
+        .output()
+        .expect("adoc explain runs");
+    assert!(
+        explain.status.success(),
+        "expected config artifact explain to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&explain),
+        stderr(&explain)
+    );
+    assert!(stdout(&explain).contains("Object: billing.refunds.issue-credit"));
+
+    let explicit_explain = adoc_command()
+        .current_dir(&workspace.root)
+        .args([
+            "explain",
+            "billing.refunds.fraud-window",
+            "--artifact",
+            "explicit/docs.agent.json",
+            "--format",
+            "plain",
+        ])
+        .output()
+        .expect("adoc explain runs");
+    assert!(
+        explicit_explain.status.success(),
+        "expected explicit explain to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&explicit_explain),
+        stderr(&explicit_explain)
+    );
+    assert!(stdout(&explicit_explain).contains("Object: billing.refunds.fraud-window"));
+
+    let search = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["search", "ledger", "--lexical"])
+        .output()
+        .expect("adoc search runs");
+    assert!(
+        search.status.success(),
+        "expected config artifact lexical search to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&search),
+        stderr(&search)
+    );
+    assert!(stdout(&search).contains("Object: billing.refunds.issue-credit"));
+}
+
+#[test]
+fn config_invalid_mode_provider_and_version_exit_with_config_errors() {
+    let cases = [
+        (
+            "unsupported-mode",
+            "version: 1\nmode: loose\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: local\n",
+            "unsupported mode",
+        ),
+        (
+            "unsupported-provider",
+            "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: hosted\n",
+            "unsupported embeddings provider",
+        ),
+        (
+            "unsupported-version",
+            "version: 2\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: local\n",
+            "unsupported version",
+        ),
+    ];
+
+    for (name, config, expected) in cases {
+        let workspace = TestWorkspace::new(&format!("config-{name}"));
+        write_valid_source(&workspace, "docs/index.adoc");
+        workspace.write("agentdoc.config.yaml", config);
+
+        let output = adoc_command()
+            .current_dir(&workspace.root)
+            .args(["check"])
+            .output()
+            .expect("adoc check runs");
+
+        assert!(
+            !output.status.success(),
+            "expected invalid config to fail for {name}"
+        );
+        let stderr = stderr(&output);
+        assert!(
+            stderr.contains("error[config.invalid]"),
+            "expected config error for {name}, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(expected),
+            "expected {expected:?} for {name}, got:\n{stderr}"
+        );
+    }
+}

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -187,6 +187,97 @@ fn config_build_uses_exact_output_paths_and_dir_fills_omitted_paths() {
 }
 
 #[test]
+fn config_build_provider_none_allows_exact_html_and_agent_json_without_search() {
+    let workspace = TestWorkspace::new("config-build-provider-none-no-search");
+    write_valid_source(&workspace, "docs/index.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  html: public/site.html\n  agent_json: artifacts/agent.json\nembeddings:\n  provider: none\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected config-backed skipped embedding build to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(
+        stdout(&output).contains("info[build.embeddings_skipped]"),
+        "expected skipped embedding info diagnostic in stdout:\n{}",
+        stdout(&output)
+    );
+    assert!(workspace.root.join("public/site.html").is_file());
+    assert!(workspace.root.join("artifacts/agent.json").is_file());
+    assert!(!workspace.root.join("docs.search.json").exists());
+}
+
+#[test]
+fn config_build_no_embeddings_allows_exact_html_and_agent_json_without_search() {
+    let workspace = TestWorkspace::new("config-build-no-embeddings-no-search");
+    write_valid_source(&workspace, "docs/index.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  html: public/site.html\n  agent_json: artifacts/agent.json\nembeddings:\n  provider: local\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "--no-embeddings"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected config-backed --no-embeddings build to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(
+        stdout(&output).contains("info[build.embeddings_skipped]"),
+        "expected skipped embedding info diagnostic in stdout:\n{}",
+        stdout(&output)
+    );
+    assert!(workspace.root.join("public/site.html").is_file());
+    assert!(workspace.root.join("artifacts/agent.json").is_file());
+    assert!(!workspace.root.join("docs.search.json").exists());
+}
+
+#[test]
+fn config_build_enabled_embeddings_requires_search_output_path() {
+    let workspace = TestWorkspace::new("config-build-enabled-missing-search");
+    write_valid_source(&workspace, "docs/index.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  html: public/site.html\n  agent_json: artifacts/agent.json\nembeddings:\n  provider: local\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build"])
+        .output()
+        .expect("adoc build runs");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = stderr(&output);
+    assert!(
+        stderr.contains("error[config.missing]"),
+        "expected config.missing, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("html, agent_json, and search outputs"),
+        "expected missing search guidance, got:\n{stderr}"
+    );
+    assert!(!workspace.root.join("public/site.html").exists());
+    assert!(!workspace.root.join("artifacts/agent.json").exists());
+}
+
+#[test]
 fn config_build_explicit_path_and_out_ignore_config_outputs() {
     let workspace = TestWorkspace::new("config-build-explicit-wins");
     write_valid_source(&workspace, "configured/index.adoc");

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -100,6 +100,65 @@ fn config_discovery_stops_at_git_boundary_before_parent_config() {
 }
 
 #[test]
+fn config_discovery_stops_at_home_boundary_before_parent_config() {
+    let workspace = TestWorkspace::new("config-home-boundary");
+    let home = workspace.root.join("home");
+    write_valid_source(&workspace, "parent-docs/index.adoc");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: parent-docs\noutputs:\n  dir: dist\nembeddings:\n  provider: local\n",
+    );
+    fs::create_dir_all(home.join("nested/deeper")).expect("nested cwd can be created");
+
+    let output = adoc_command()
+        .current_dir(home.join("nested/deeper"))
+        .env("HOME", &home)
+        .args(["check"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "check should not use config above HOME\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(
+        stderr(&output).contains("error[config.missing]"),
+        "expected config.missing when no config exists before HOME boundary, got:\n{}",
+        stderr(&output)
+    );
+}
+
+#[test]
+fn config_discovery_allows_config_at_home_boundary() {
+    let workspace = TestWorkspace::new("config-home-boundary-config");
+    let home = workspace.root.join("home");
+    write_valid_source(&workspace, "home/docs/index.adoc");
+    workspace.write(
+        "home/agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: local\n",
+    );
+    fs::create_dir_all(home.join("nested/deeper")).expect("nested cwd can be created");
+
+    let output = adoc_command()
+        .current_dir(home.join("nested/deeper"))
+        .env("HOME", &home)
+        .args(["check"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected config at HOME boundary to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    assert!(stdout(&output).contains("0 errors"));
+}
+
+#[test]
 fn config_build_uses_exact_output_paths_and_dir_fills_omitted_paths() {
     let workspace = TestWorkspace::new("config-build-output-paths");
     write_valid_source(&workspace, "docs/index.adoc");

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -200,6 +200,37 @@ fn config_build_fully_explicit_no_embeddings_ignores_malformed_config() {
 }
 
 #[test]
+fn config_build_missing_outputs_error_names_loaded_config_path() {
+    let workspace = TestWorkspace::new("config-build-missing-outputs-path");
+    write_valid_source(&workspace, "docs/index.adoc");
+    let config_path = workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\nembeddings:\n  provider: local\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build"])
+        .output()
+        .expect("adoc build runs");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = stderr(&output);
+    assert!(
+        stderr.contains("error[config.missing]"),
+        "expected config.missing, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("outputs.dir"),
+        "expected missing outputs guidance, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains(&config_path.display().to_string()),
+        "expected loaded config path in error, got:\n{stderr}"
+    );
+}
+
+#[test]
 fn config_explain_and_search_use_configured_artifacts_unless_args_are_explicit() {
     let workspace = TestWorkspace::new("config-retrieval-artifacts");
     copy_valid_artifact(&workspace, "configured/docs.agent.json");

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -488,3 +488,53 @@ fn config_invalid_mode_provider_and_version_exit_with_config_errors() {
         );
     }
 }
+
+#[test]
+fn config_rejects_unknown_config_fields() {
+    let cases = [
+        (
+            "top-level-typo",
+            "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembedings:\n  provider: none\n",
+            ["check"].as_slice(),
+            "embedings",
+        ),
+        (
+            "outputs-typo",
+            "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dyr: dist\nembeddings:\n  provider: none\n",
+            ["build"].as_slice(),
+            "dyr",
+        ),
+        (
+            "embeddings-extra",
+            "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: none\n  mode: local\n",
+            ["check"].as_slice(),
+            "mode",
+        ),
+    ];
+
+    for (name, config, args, expected_field) in cases {
+        let workspace = TestWorkspace::new(&format!("config-unknown-{name}"));
+        write_valid_source(&workspace, "docs/index.adoc");
+        workspace.write("agentdoc.config.yaml", config);
+
+        let output = adoc_command()
+            .current_dir(&workspace.root)
+            .args(args)
+            .output()
+            .expect("adoc command runs");
+
+        assert!(
+            !output.status.success(),
+            "expected unknown config field to fail for {name}"
+        );
+        let stderr = stderr(&output);
+        assert!(
+            stderr.contains("error[config.parse]"),
+            "expected parse error for {name}, got:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(expected_field),
+            "expected parse error to name {expected_field:?} for {name}, got:\n{stderr}"
+        );
+    }
+}

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -58,6 +58,48 @@ fn config_check_without_path_uses_nearest_docs_path_resolved_from_config_dir() {
 }
 
 #[test]
+fn config_discovery_stops_at_git_boundary_before_parent_config() {
+    for git_boundary in ["directory", "file"] {
+        let workspace = TestWorkspace::new(&format!("config-git-boundary-{git_boundary}"));
+        write_valid_source(&workspace, "parent-docs/index.adoc");
+        workspace.write(
+            "agentdoc.config.yaml",
+            "version: 1\nmode: strict\ndocs_path: parent-docs\noutputs:\n  dir: dist\nembeddings:\n  provider: local\n",
+        );
+
+        match git_boundary {
+            "directory" => fs::create_dir_all(workspace.root.join("nested/repo/.git"))
+                .expect(".git directory can be created"),
+            "file" => {
+                workspace.write("nested/repo/.git", "gitdir: ../.git/worktrees/repo\n");
+            }
+            _ => unreachable!("covered git boundary cases"),
+        }
+        fs::create_dir_all(workspace.root.join("nested/repo/deeper"))
+            .expect("nested repo cwd can be created");
+
+        let output = adoc_command()
+            .current_dir(workspace.root.join("nested/repo/deeper"))
+            .args(["check"])
+            .output()
+            .expect("adoc check runs");
+
+        assert_eq!(
+            output.status.code(),
+            Some(1),
+            "check should not use parent config across .git {git_boundary}\nstdout:\n{}\nstderr:\n{}",
+            stdout(&output),
+            stderr(&output)
+        );
+        assert!(
+            stderr(&output).contains("error[config.missing]"),
+            "expected config.missing when no config exists inside repo boundary, got:\n{}",
+            stderr(&output)
+        );
+    }
+}
+
+#[test]
 fn config_build_uses_exact_output_paths_and_dir_fills_omitted_paths() {
     let workspace = TestWorkspace::new("config-build-output-paths");
     write_valid_source(&workspace, "docs/index.adoc");

--- a/crates/adoc-cli/tests/init_cli.rs
+++ b/crates/adoc-cli/tests/init_cli.rs
@@ -18,11 +18,9 @@ struct InitConfig {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
+#[serde(deny_unknown_fields)]
 struct InitOutputs {
     dir: String,
-    html: String,
-    agent_json: String,
-    search: String,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Eq)]
@@ -78,9 +76,9 @@ fn init_creates_config_and_example_docs_in_current_directory() {
     assert!(config_text.contains("docs_path: docs"));
     assert!(config_text.contains("outputs:"));
     assert!(config_text.contains("  dir: dist"));
-    assert!(config_text.contains("  html: dist/docs.html"));
-    assert!(config_text.contains("  agent_json: dist/docs.agent.json"));
-    assert!(config_text.contains("  search: dist/docs.search.json"));
+    assert!(!config_text.contains("  html:"));
+    assert!(!config_text.contains("  agent_json:"));
+    assert!(!config_text.contains("  search:"));
     assert!(config_text.contains("embeddings:"));
     assert!(config_text.contains("  provider: local"));
 
@@ -94,9 +92,6 @@ fn init_creates_config_and_example_docs_in_current_directory() {
             docs_path: "docs".to_string(),
             outputs: InitOutputs {
                 dir: "dist".to_string(),
-                html: "dist/docs.html".to_string(),
-                agent_json: "dist/docs.agent.json".to_string(),
-                search: "dist/docs.search.json".to_string(),
             },
             embeddings: InitEmbeddings {
                 provider: "local".to_string(),

--- a/crates/adoc-cli/tests/init_cli.rs
+++ b/crates/adoc-cli/tests/init_cli.rs
@@ -3,6 +3,7 @@ mod support;
 use std::fs;
 
 use assert_cmd::Command;
+use chrono::{Local, Months, NaiveDate};
 use predicates::prelude::*;
 use serde::Deserialize;
 use support::TestWorkspace;
@@ -35,15 +36,40 @@ fn adoc() -> Command {
     cmd
 }
 
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn field_value<'a>(text: &'a str, field: &str) -> &'a str {
+    text.lines()
+        .find_map(|line| line.strip_prefix(field))
+        .unwrap_or_else(|| panic!("expected {field} in generated docs"))
+        .trim()
+}
+
 #[test]
 fn init_creates_config_and_example_docs_in_current_directory() {
     let workspace = TestWorkspace::new("init-creates-project");
+    let earliest_today = Local::now().date_naive();
 
-    adoc()
+    let init = adoc()
         .current_dir(&workspace.root)
         .arg("init")
-        .assert()
-        .success();
+        .output()
+        .expect("adoc init runs");
+    assert!(
+        init.status.success(),
+        "expected init to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&init),
+        stderr(&init)
+    );
+    let latest_today = Local::now().date_naive();
+    assert!(stdout(&init).contains("Created agentdoc.config.yaml and docs/index.adoc"));
+    assert!(stdout(&init).contains("Next: adoc check"));
 
     let config_text = fs::read_to_string(workspace.root.join("agentdoc.config.yaml"))
         .expect("config file is written");
@@ -84,9 +110,22 @@ fn init_creates_config_and_example_docs_in_current_directory() {
     assert!(docs_text.contains("::claim project.initialized"));
     assert!(docs_text.contains("status: verified"));
     assert!(docs_text.contains("owner: team-docs"));
-    assert!(docs_text.contains("verified_at: 2026-05-08"));
+    let verified_at =
+        NaiveDate::parse_from_str(field_value(&docs_text, "verified_at:"), "%Y-%m-%d")
+            .expect("verified_at is an ISO date");
+    assert!(
+        (earliest_today..=latest_today).contains(&verified_at),
+        "verified_at should be today's date, got {verified_at}"
+    );
     assert!(docs_text.contains("source: adoc init template"));
-    assert!(docs_text.contains("expires_at: 2027-05-08"));
+    let expires_at = NaiveDate::parse_from_str(field_value(&docs_text, "expires_at:"), "%Y-%m-%d")
+        .expect("expires_at is an ISO date");
+    assert_eq!(
+        expires_at,
+        verified_at
+            .checked_add_months(Months::new(12))
+            .expect("verified_at plus 12 months is valid")
+    );
 
     adoc()
         .current_dir(&workspace.root)
@@ -101,6 +140,37 @@ fn init_creates_config_and_example_docs_in_current_directory() {
         .success()
         .stdout(predicate::str::contains("Object: project.initialized"))
         .stdout(predicate::str::contains("Kind: claim"));
+}
+
+#[cfg(unix)]
+#[test]
+fn init_cleans_up_config_when_index_write_fails() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let workspace = TestWorkspace::new("init-index-write-fails");
+    let docs_dir = workspace.root.join("docs");
+    fs::create_dir_all(&docs_dir).expect("docs dir can be created");
+    fs::set_permissions(&docs_dir, fs::Permissions::from_mode(0o555))
+        .expect("docs dir can be made read-only");
+
+    let init = adoc()
+        .current_dir(&workspace.root)
+        .arg("init")
+        .output()
+        .expect("adoc init runs");
+
+    fs::set_permissions(&docs_dir, fs::Permissions::from_mode(0o755))
+        .expect("docs dir permissions can be restored");
+
+    assert_eq!(init.status.code(), Some(1));
+    assert!(
+        !workspace.root.join("agentdoc.config.yaml").exists(),
+        "failed init must remove config so rerun is not blocked"
+    );
+    assert!(
+        !workspace.root.join("docs/index.adoc").exists(),
+        "failed init must not leave index behind"
+    );
 }
 
 #[test]

--- a/crates/adoc-cli/tests/init_cli.rs
+++ b/crates/adoc-cli/tests/init_cli.rs
@@ -3,7 +3,6 @@ mod support;
 use std::fs;
 
 use assert_cmd::Command;
-use chrono::{Local, Months, NaiveDate};
 use predicates::prelude::*;
 use serde::Deserialize;
 use support::TestWorkspace;
@@ -42,17 +41,9 @@ fn stderr(output: &std::process::Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
-fn field_value<'a>(text: &'a str, field: &str) -> &'a str {
-    text.lines()
-        .find_map(|line| line.strip_prefix(field))
-        .unwrap_or_else(|| panic!("expected {field} in generated docs"))
-        .trim()
-}
-
 #[test]
 fn init_creates_config_and_example_docs_in_current_directory() {
     let workspace = TestWorkspace::new("init-creates-project");
-    let earliest_today = Local::now().date_naive();
 
     let init = adoc()
         .current_dir(&workspace.root)
@@ -65,7 +56,6 @@ fn init_creates_config_and_example_docs_in_current_directory() {
         stdout(&init),
         stderr(&init)
     );
-    let latest_today = Local::now().date_naive();
     assert!(stdout(&init).contains("Created agentdoc.config.yaml and docs/index.adoc"));
     assert!(stdout(&init).contains("Next: adoc check"));
 
@@ -103,24 +93,11 @@ fn init_creates_config_and_example_docs_in_current_directory() {
         fs::read_to_string(workspace.root.join("docs/index.adoc")).expect("example doc is written");
     assert!(docs_text.contains("# AgentDoc Project"));
     assert!(docs_text.contains("::claim project.initialized"));
-    assert!(docs_text.contains("status: verified"));
-    assert!(docs_text.contains("owner: team-docs"));
-    let verified_at =
-        NaiveDate::parse_from_str(field_value(&docs_text, "verified_at:"), "%Y-%m-%d")
-            .expect("verified_at is an ISO date");
-    assert!(
-        (earliest_today..=latest_today).contains(&verified_at),
-        "verified_at should be today's date, got {verified_at}"
-    );
-    assert!(docs_text.contains("source: adoc init template"));
-    let expires_at = NaiveDate::parse_from_str(field_value(&docs_text, "expires_at:"), "%Y-%m-%d")
-        .expect("expires_at is an ISO date");
-    assert_eq!(
-        expires_at,
-        verified_at
-            .checked_add_months(Months::new(12))
-            .expect("verified_at plus 12 months is valid")
-    );
+    assert!(docs_text.contains("status: draft"));
+    assert!(!docs_text.contains("owner:"));
+    assert!(!docs_text.contains("verified_at:"));
+    assert!(!docs_text.contains("source:"));
+    assert!(!docs_text.contains("expires_at:"));
 
     adoc()
         .current_dir(&workspace.root)

--- a/crates/adoc-cli/tests/init_cli.rs
+++ b/crates/adoc-cli/tests/init_cli.rs
@@ -1,0 +1,144 @@
+mod support;
+
+use std::fs;
+
+use assert_cmd::Command;
+use predicates::prelude::*;
+use serde::Deserialize;
+use support::TestWorkspace;
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct InitConfig {
+    version: u8,
+    mode: String,
+    docs_path: String,
+    outputs: InitOutputs,
+    embeddings: InitEmbeddings,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct InitOutputs {
+    dir: String,
+    html: String,
+    agent_json: String,
+    search: String,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Eq)]
+struct InitEmbeddings {
+    provider: String,
+}
+
+fn adoc() -> Command {
+    let mut cmd = Command::cargo_bin("adoc").expect("adoc binary is available");
+    cmd.env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory");
+    cmd
+}
+
+#[test]
+fn init_creates_config_and_example_docs_in_current_directory() {
+    let workspace = TestWorkspace::new("init-creates-project");
+
+    adoc()
+        .current_dir(&workspace.root)
+        .arg("init")
+        .assert()
+        .success();
+
+    let config_text = fs::read_to_string(workspace.root.join("agentdoc.config.yaml"))
+        .expect("config file is written");
+    assert!(config_text.contains("version: 1"));
+    assert!(config_text.contains("mode: strict"));
+    assert!(config_text.contains("docs_path: docs"));
+    assert!(config_text.contains("outputs:"));
+    assert!(config_text.contains("  dir: dist"));
+    assert!(config_text.contains("  html: dist/docs.html"));
+    assert!(config_text.contains("  agent_json: dist/docs.agent.json"));
+    assert!(config_text.contains("  search: dist/docs.search.json"));
+    assert!(config_text.contains("embeddings:"));
+    assert!(config_text.contains("  provider: local"));
+
+    let config: InitConfig =
+        serde_saphyr::from_str(&config_text).expect("generated config is valid YAML");
+    assert_eq!(
+        config,
+        InitConfig {
+            version: 1,
+            mode: "strict".to_string(),
+            docs_path: "docs".to_string(),
+            outputs: InitOutputs {
+                dir: "dist".to_string(),
+                html: "dist/docs.html".to_string(),
+                agent_json: "dist/docs.agent.json".to_string(),
+                search: "dist/docs.search.json".to_string(),
+            },
+            embeddings: InitEmbeddings {
+                provider: "local".to_string(),
+            },
+        }
+    );
+
+    let docs_text =
+        fs::read_to_string(workspace.root.join("docs/index.adoc")).expect("example doc is written");
+    assert!(docs_text.contains("# AgentDoc Project"));
+    assert!(docs_text.contains("::claim project.initialized"));
+    assert!(docs_text.contains("status: verified"));
+    assert!(docs_text.contains("owner: team-docs"));
+    assert!(docs_text.contains("verified_at: 2026-05-08"));
+    assert!(docs_text.contains("source: adoc init template"));
+    assert!(docs_text.contains("expires_at: 2027-05-08"));
+
+    adoc()
+        .current_dir(&workspace.root)
+        .args(["build", "docs", "--out", "dist"])
+        .assert()
+        .success();
+
+    adoc()
+        .current_dir(&workspace.root)
+        .args(["explain", "project.initialized"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Object: project.initialized"))
+        .stdout(predicate::str::contains("Kind: claim"));
+}
+
+#[test]
+fn init_refuses_to_overwrite_existing_config() {
+    let workspace = TestWorkspace::new("init-existing-config");
+    workspace.write("agentdoc.config.yaml", "version: 1\n");
+
+    adoc()
+        .current_dir(&workspace.root)
+        .arg("init")
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("already exists"))
+        .stderr(predicate::str::contains("agentdoc.config.yaml"));
+
+    assert!(
+        !workspace.root.join("docs/index.adoc").exists(),
+        "init must not partially create docs when config exists"
+    );
+}
+
+#[test]
+fn init_refuses_to_overwrite_existing_index() {
+    let workspace = TestWorkspace::new("init-existing-index");
+    workspace.write("docs/index.adoc", "# Existing\n");
+
+    adoc()
+        .current_dir(&workspace.root)
+        .arg("init")
+        .assert()
+        .failure()
+        .code(1)
+        .stderr(predicate::str::contains("already exists"))
+        .stderr(predicate::str::contains("docs/index.adoc"));
+
+    assert!(
+        !workspace.root.join("agentdoc.config.yaml").exists(),
+        "init must not partially create config when index exists"
+    );
+}

--- a/crates/adoc-cli/tests/v1_5_local_workflow_cli.rs
+++ b/crates/adoc-cli/tests/v1_5_local_workflow_cli.rs
@@ -1,0 +1,146 @@
+mod support;
+
+use std::fs;
+use std::process::Command;
+
+use support::TestWorkspace;
+
+fn adoc_command() -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+    command.env("ADOC_TEST_EMBEDDING_PROVIDER", "in-memory");
+    command
+}
+
+fn stdout(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stdout).into_owned()
+}
+
+fn stderr(output: &std::process::Output) -> String {
+    String::from_utf8_lossy(&output.stderr).into_owned()
+}
+
+fn assert_success(command: &str, output: &std::process::Output) {
+    assert!(
+        output.status.success(),
+        "expected `{command}` to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(output),
+        stderr(output)
+    );
+}
+
+fn write_valid_source(workspace: &TestWorkspace, relative_path: &str, object_id: &str) {
+    workspace.write(
+        relative_path,
+        &format!(
+            "# Billing Guide @doc({object_id}.doc)\n\n::claim {object_id}\nstatus: verified\nowner: team-docs\nverified_at: 2026-05-08\nsource: test\nexpires_at: 2027-05-08\n--\nBilling docs are ready for local workflow validation.\n::\n"
+        ),
+    );
+}
+
+#[test]
+fn v1_5_init_check_build_explain_and_search_use_config_defaults_end_to_end() {
+    let workspace = TestWorkspace::new("v1-5-local-workflow");
+
+    let init = adoc_command()
+        .current_dir(&workspace.root)
+        .arg("init")
+        .output()
+        .expect("adoc init runs");
+    assert_success("adoc init", &init);
+
+    let generated_source = fs::read_to_string(workspace.root.join("docs/index.adoc"))
+        .expect("init writes generated example source");
+    assert!(
+        generated_source.contains("::claim project.initialized"),
+        "generated example should contain the object used by retrieval commands"
+    );
+
+    let check = adoc_command()
+        .current_dir(&workspace.root)
+        .arg("check")
+        .output()
+        .expect("adoc check runs");
+    assert_success("adoc check", &check);
+    assert!(stdout(&check).contains("0 errors"));
+
+    let build = adoc_command()
+        .current_dir(&workspace.root)
+        .arg("build")
+        .output()
+        .expect("adoc build runs");
+    assert_success("adoc build", &build);
+
+    assert!(workspace.root.join("dist/docs.html").is_file());
+    assert!(workspace.root.join("dist/docs.agent.json").is_file());
+    assert!(workspace.root.join("dist/docs.search.json").is_file());
+
+    let explain = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["explain", "project.initialized"])
+        .output()
+        .expect("adoc explain runs");
+    assert_success("adoc explain project.initialized", &explain);
+    assert!(stdout(&explain).contains("Object: project.initialized"));
+
+    let search = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["search", "initialized"])
+        .output()
+        .expect("adoc search runs");
+    assert_success("adoc search initialized", &search);
+    assert!(stdout(&search).contains("Object: project.initialized"));
+}
+
+#[test]
+fn v1_5_explicit_check_path_and_build_out_ignore_config_defaults() {
+    let workspace = TestWorkspace::new("v1-5-explicit-workflow");
+    write_valid_source(&workspace, "configured/index.adoc", "configured.ready");
+    write_valid_source(&workspace, "explicit/index.adoc", "explicit.ready");
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: configured\noutputs:\n  dir: configured-dist\n  html: configured-html/custom.html\n  agent_json: configured-artifacts/docs.agent.json\n  search: configured-artifacts/docs.search.json\nembeddings:\n  provider: local\n",
+    );
+
+    let check = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "explicit"])
+        .output()
+        .expect("adoc check explicit path runs");
+    assert_success("adoc check explicit", &check);
+    assert!(stdout(&check).contains("0 errors"));
+
+    let build = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "explicit", "--out", "explicit-dist"])
+        .output()
+        .expect("adoc build explicit path runs");
+    assert_success("adoc build explicit --out explicit-dist", &build);
+
+    assert!(workspace.root.join("explicit-dist/docs.html").is_file());
+    assert!(
+        workspace
+            .root
+            .join("explicit-dist/docs.agent.json")
+            .is_file()
+    );
+    assert!(
+        workspace
+            .root
+            .join("explicit-dist/docs.search.json")
+            .is_file()
+    );
+    assert!(!workspace.root.join("configured-html/custom.html").exists());
+    assert!(!workspace.root.join("configured-dist/docs.html").exists());
+    assert!(
+        !workspace
+            .root
+            .join("configured-artifacts/docs.agent.json")
+            .exists()
+    );
+    assert!(
+        !workspace
+            .root
+            .join("configured-artifacts/docs.search.json")
+            .exists()
+    );
+}

--- a/crates/adoc-cli/tests/v1_5_local_workflow_cli.rs
+++ b/crates/adoc-cli/tests/v1_5_local_workflow_cli.rs
@@ -3,6 +3,7 @@ mod support;
 use std::fs;
 use std::process::Command;
 
+use chrono::{Local, Months};
 use support::TestWorkspace;
 
 fn adoc_command() -> Command {
@@ -29,10 +30,15 @@ fn assert_success(command: &str, output: &std::process::Output) {
 }
 
 fn write_valid_source(workspace: &TestWorkspace, relative_path: &str, object_id: &str) {
+    let verified_at = Local::now().date_naive();
+    let expires_at = verified_at
+        .checked_add_months(Months::new(12))
+        .expect("verified_at plus 12 months is valid");
+
     workspace.write(
         relative_path,
         &format!(
-            "# Billing Guide @doc({object_id}.doc)\n\n::claim {object_id}\nstatus: verified\nowner: team-docs\nverified_at: 2026-05-08\nsource: test\nexpires_at: 2027-05-08\n--\nBilling docs are ready for local workflow validation.\n::\n"
+            "# Billing Guide @doc({object_id}.doc)\n\n::claim {object_id}\nstatus: verified\nowner: team-docs\nverified_at: {verified_at}\nsource: test\nexpires_at: {expires_at}\n--\nBilling docs are ready for local workflow validation.\n::\n"
         ),
     );
 }

--- a/crates/adoc-cli/tests/v1_5_local_workflow_cli.rs
+++ b/crates/adoc-cli/tests/v1_5_local_workflow_cli.rs
@@ -61,7 +61,7 @@ fn v1_5_init_check_build_explain_and_search_use_config_defaults_end_to_end() {
         .output()
         .expect("adoc check runs");
     assert_success("adoc check", &check);
-    assert!(stdout(&check).contains("0 errors"));
+    assert!(stdout(&check).contains("0 errors, 0 warnings"));
 
     let build = adoc_command()
         .current_dir(&workspace.root)
@@ -107,7 +107,7 @@ fn v1_5_explicit_check_path_and_build_out_ignore_config_defaults() {
         .output()
         .expect("adoc check explicit path runs");
     assert_success("adoc check explicit", &check);
-    assert!(stdout(&check).contains("0 errors"));
+    assert!(stdout(&check).contains("0 errors, 0 warnings"));
 
     let build = adoc_command()
         .current_dir(&workspace.root)

--- a/crates/adoc-core/Cargo.toml
+++ b/crates/adoc-core/Cargo.toml
@@ -12,7 +12,7 @@ fastembed-it = ["embeddings"]
 test-embedding-provider = []
 
 [dependencies]
-chrono = { version = "0.4", default-features = false }
+chrono = { version = "0.4", default-features = false, features = ["clock"] }
 fastembed = { version = "5", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -2,6 +2,8 @@ use std::cmp::Ordering;
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
+use chrono::NaiveDate;
+
 use crate::application::hashing::sha256_prefixed;
 use crate::application::resolve_knowledge_objects::{
     resolve_knowledge_objects, suppress_unknown_kind_shape_diagnostics,
@@ -75,14 +77,21 @@ pub struct BuildArtifacts {
 }
 
 pub(crate) fn compile_with_provider<P: SourceProvider>(provider: &P) -> CompileResult {
-    run_compile_pipeline(provider, None)
+    compile_with_provider_for_date(provider, local_today())
+}
+
+pub(crate) fn compile_with_provider_for_date<P: SourceProvider>(
+    provider: &P,
+    today: NaiveDate,
+) -> CompileResult {
+    run_compile_pipeline(provider, None, today)
 }
 
 pub(crate) fn build_with_provider<P: SourceProvider>(
     provider: &P,
     options: BuildOptions<'_>,
 ) -> CompileResult {
-    run_compile_pipeline(provider, Some(options))
+    run_compile_pipeline(provider, Some(options), local_today())
 }
 
 pub(crate) struct BuildOptions<'a> {
@@ -104,6 +113,7 @@ pub(crate) enum BuildEmbeddingBehavior<'a> {
 fn run_compile_pipeline<P: SourceProvider>(
     provider: &P,
     mut build_options: Option<BuildOptions<'_>>,
+    today: NaiveDate,
 ) -> CompileResult {
     // Pipeline stages: load → validate-source-pages → resolve-KOs →
     // resolve-object-references → validate-resolved-pages → assemble →
@@ -120,7 +130,7 @@ fn run_compile_pipeline<P: SourceProvider>(
         &mut parsed,
         &resolved_knowledge_objects.declared_ids,
     ));
-    diagnostics.extend(validate_resolved_pages(&parsed));
+    diagnostics.extend(validate_resolved_pages(&parsed, today));
     let workspace = assemble_workspace(parsed);
     diagnostics.extend(validate_workspace(&workspace));
     if let Some(options) = &build_options {
@@ -135,6 +145,10 @@ fn run_compile_pipeline<P: SourceProvider>(
         diagnostics,
         artifacts,
     }
+}
+
+fn local_today() -> NaiveDate {
+    chrono::Local::now().date_naive()
 }
 
 fn build_embedding_diagnostics(options: &BuildOptions<'_>) -> Vec<Diagnostic> {
@@ -210,10 +224,10 @@ fn validate_source_pages(parsed: &[(SourceFile, PageAst)]) -> Vec<Diagnostic> {
 
 /// Run every resolved-page rule after Knowledge Object resolution. Rules in
 /// this phase can rely on typed aggregate data instead of pending parser shells.
-fn validate_resolved_pages(parsed: &[(SourceFile, PageAst)]) -> Vec<Diagnostic> {
+fn validate_resolved_pages(parsed: &[(SourceFile, PageAst)], today: NaiveDate) -> Vec<Diagnostic> {
     let mut diagnostics = Vec::new();
     for (source, page) in parsed {
-        diagnostics.extend(validate_resolved_page(page, source));
+        diagnostics.extend(validate_resolved_page(page, source, today));
     }
     diagnostics
 }
@@ -607,6 +621,7 @@ mod tests {
     use crate::infrastructure::artifact::search_json::SUPPORTED_SEARCH_SCHEMA_VERSION;
     use crate::infrastructure::embedding::in_memory::InMemoryProvider;
     use crate::infrastructure::source::in_memory::InMemorySourceProvider;
+    use chrono::NaiveDate;
     use std::cell::RefCell;
     use std::fs;
 
@@ -616,6 +631,10 @@ mod tests {
             text.to_string(),
             PathBuf::from(identity),
         )
+    }
+
+    fn fixed_today() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid test date")
     }
 
     #[test]
@@ -676,6 +695,69 @@ mod tests {
         assert!(!result.has_errors());
         let artifacts = result.artifacts.expect("empty workspace still builds");
         assert!(artifacts.agent_json.pages.is_empty());
+    }
+
+    #[test]
+    fn lifecycle_expired_warning_is_emitted_for_parseable_past_expires_at() {
+        let provider = InMemorySourceProvider::new().with_source(source_file(
+            "guide.adoc",
+            "# Guide @doc(team.guide)\n\n::claim billing.credits\nstatus: draft\nexpires_at: 2026-05-07\n--\nCredits expire before today.\n::\n",
+        ));
+
+        let result = compile_with_provider_for_date(&provider, fixed_today());
+
+        assert!(
+            !result.has_errors(),
+            "expiry warning must not block compile"
+        );
+        assert!(
+            result.artifacts.is_some(),
+            "warning diagnostics must not block artifact generation"
+        );
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::LifecycleExpired)
+            .expect("expected lifecycle.expired warning");
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert_eq!(diagnostic.object_id.as_deref(), Some("billing.credits"));
+        assert_eq!(
+            diagnostic.span.as_ref().map(|span| (
+                span.file.as_path(),
+                span.start.line,
+                span.start.column
+            )),
+            Some((std::path::Path::new("/work/guide.adoc"), 3, 1))
+        );
+        assert!(
+            diagnostic.message.contains("billing.credits")
+                && diagnostic.message.contains("2026-05-07")
+                && diagnostic.message.contains("expired"),
+            "message should name the object, date, and expiry: {}",
+            diagnostic.message
+        );
+    }
+
+    #[test]
+    fn lifecycle_expired_warning_ignores_today_future_and_invalid_expires_at() {
+        let provider = InMemorySourceProvider::new().with_source(source_file(
+            "guide.adoc",
+            "# Guide @doc(team.guide)\n\n::claim billing.today\nstatus: draft\nexpires_at: 2026-05-08\n--\nToday is still valid.\n::\n\n::claim billing.future\nstatus: draft\nexpires_at: 2026-05-09\n--\nFuture is still valid.\n::\n\n::claim billing.invalid\nstatus: draft\nexpires_at: not-a-date\n--\nInvalid dates are ignored in this slice.\n::\n",
+        ));
+
+        let result = compile_with_provider_for_date(&provider, fixed_today());
+
+        assert!(
+            !result
+                .diagnostics
+                .iter()
+                .any(|diagnostic| diagnostic.code == DiagnosticCode::LifecycleExpired),
+            "today, future, and invalid expires_at values must not warn"
+        );
+        assert!(
+            result.artifacts.is_some(),
+            "ignored lifecycle fields must not block artifact generation"
+        );
     }
 
     // --- stage-level pipeline tests (TB-7) ---
@@ -745,7 +827,7 @@ mod tests {
         ));
 
         let (parsed, _) = load_pages(&provider);
-        let diagnostics = validate_resolved_pages(&parsed);
+        let diagnostics = validate_resolved_pages(&parsed, fixed_today());
 
         assert!(diagnostics.is_empty());
     }

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -739,10 +739,10 @@ mod tests {
     }
 
     #[test]
-    fn lifecycle_expired_warning_ignores_today_future_and_invalid_expires_at() {
+    fn lifecycle_expired_warning_ignores_today_and_future_expires_at() {
         let provider = InMemorySourceProvider::new().with_source(source_file(
             "guide.adoc",
-            "# Guide @doc(team.guide)\n\n::claim billing.today\nstatus: draft\nexpires_at: 2026-05-08\n--\nToday is still valid.\n::\n\n::claim billing.future\nstatus: draft\nexpires_at: 2026-05-09\n--\nFuture is still valid.\n::\n\n::claim billing.invalid\nstatus: draft\nexpires_at: not-a-date\n--\nInvalid dates are ignored in this slice.\n::\n",
+            "# Guide @doc(team.guide)\n\n::claim billing.today\nstatus: draft\nexpires_at: 2026-05-08\n--\nToday is still valid.\n::\n\n::claim billing.future\nstatus: draft\nexpires_at: 2026-05-09\n--\nFuture is still valid.\n::\n",
         ));
 
         let result = compile_with_provider_for_date(&provider, fixed_today());
@@ -752,11 +752,52 @@ mod tests {
                 .diagnostics
                 .iter()
                 .any(|diagnostic| diagnostic.code == DiagnosticCode::LifecycleExpired),
-            "today, future, and invalid expires_at values must not warn"
+            "today and future expires_at values must not warn"
         );
         assert!(
             result.artifacts.is_some(),
-            "ignored lifecycle fields must not block artifact generation"
+            "valid lifecycle fields must not block artifact generation"
+        );
+    }
+
+    #[test]
+    fn lifecycle_invalid_expires_at_warning_is_emitted_for_unparseable_value() {
+        let provider = InMemorySourceProvider::new().with_source(source_file(
+            "guide.adoc",
+            "# Guide @doc(team.guide)\n\n::claim billing.invalid\nstatus: draft\nexpires_at: not-a-date\n--\nInvalid dates should be reported.\n::\n",
+        ));
+
+        let result = compile_with_provider_for_date(&provider, fixed_today());
+
+        assert!(
+            !result.has_errors(),
+            "invalid expires_at warning must not block compile"
+        );
+        assert!(
+            result.artifacts.is_some(),
+            "warning diagnostics must not block artifact generation"
+        );
+        let diagnostic = result
+            .diagnostics
+            .iter()
+            .find(|diagnostic| diagnostic.code == DiagnosticCode::LifecycleInvalidExpiresAt)
+            .expect("expected lifecycle.invalid_expires_at warning");
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert_eq!(diagnostic.object_id.as_deref(), Some("billing.invalid"));
+        assert_eq!(
+            diagnostic.span.as_ref().map(|span| (
+                span.file.as_path(),
+                span.start.line,
+                span.start.column
+            )),
+            Some((std::path::Path::new("/work/guide.adoc"), 3, 1))
+        );
+        assert!(
+            diagnostic.message.contains("billing.invalid")
+                && diagnostic.message.contains("not-a-date")
+                && diagnostic.message.contains("YYYY-MM-DD"),
+            "message should name the object, value, and expected format: {}",
+            diagnostic.message
         );
     }
 

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -37,6 +37,7 @@ pub enum DiagnosticCode {
     ClaimVerifiedMissingEvidence,
     ClaimStatusCasing,
     LifecycleExpired,
+    LifecycleInvalidExpiresAt,
     IdDuplicate,
     IdInvalid,
     RefBroken,
@@ -78,6 +79,7 @@ impl DiagnosticCode {
             DiagnosticCode::ClaimVerifiedMissingEvidence,
             DiagnosticCode::ClaimStatusCasing,
             DiagnosticCode::LifecycleExpired,
+            DiagnosticCode::LifecycleInvalidExpiresAt,
             DiagnosticCode::IdDuplicate,
             DiagnosticCode::IdInvalid,
             DiagnosticCode::RefBroken,
@@ -119,6 +121,7 @@ impl DiagnosticCode {
             DiagnosticCode::ClaimVerifiedMissingEvidence => "claim.verified_missing_evidence",
             DiagnosticCode::ClaimStatusCasing => "claim.status_casing",
             DiagnosticCode::LifecycleExpired => "lifecycle.expired",
+            DiagnosticCode::LifecycleInvalidExpiresAt => "lifecycle.invalid_expires_at",
             DiagnosticCode::IdDuplicate => "id.duplicate",
             DiagnosticCode::IdInvalid => "id.invalid",
             DiagnosticCode::RefBroken => "ref.broken",
@@ -183,6 +186,9 @@ impl DiagnosticCode {
             DiagnosticCode::ClaimStatusCasing => "Use the canonical lowercase claim status value.",
             DiagnosticCode::LifecycleExpired => {
                 "Update `expires_at` or remove it if this Knowledge Object is still valid."
+            }
+            DiagnosticCode::LifecycleInvalidExpiresAt => {
+                "Use `YYYY-MM-DD` for `expires_at`, or remove the field."
             }
             DiagnosticCode::IdDuplicate => {
                 "Give each object a unique ID across the compiled workspace."
@@ -296,6 +302,7 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "claim.verified_missing_evidence",
     "claim.status_casing",
     "lifecycle.expired",
+    "lifecycle.invalid_expires_at",
     "id.duplicate",
     "id.invalid",
     "ref.broken",

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -36,6 +36,7 @@ pub enum DiagnosticCode {
     SchemaInvalidStatus,
     ClaimVerifiedMissingEvidence,
     ClaimStatusCasing,
+    LifecycleExpired,
     IdDuplicate,
     IdInvalid,
     RefBroken,
@@ -76,6 +77,7 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaInvalidStatus,
             DiagnosticCode::ClaimVerifiedMissingEvidence,
             DiagnosticCode::ClaimStatusCasing,
+            DiagnosticCode::LifecycleExpired,
             DiagnosticCode::IdDuplicate,
             DiagnosticCode::IdInvalid,
             DiagnosticCode::RefBroken,
@@ -116,6 +118,7 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaInvalidStatus => "schema.invalid_status",
             DiagnosticCode::ClaimVerifiedMissingEvidence => "claim.verified_missing_evidence",
             DiagnosticCode::ClaimStatusCasing => "claim.status_casing",
+            DiagnosticCode::LifecycleExpired => "lifecycle.expired",
             DiagnosticCode::IdDuplicate => "id.duplicate",
             DiagnosticCode::IdInvalid => "id.invalid",
             DiagnosticCode::RefBroken => "ref.broken",
@@ -178,6 +181,9 @@ impl DiagnosticCode {
                 "Add evidence entries before marking the claim as verified."
             }
             DiagnosticCode::ClaimStatusCasing => "Use the canonical lowercase claim status value.",
+            DiagnosticCode::LifecycleExpired => {
+                "Update `expires_at` or remove it if this Knowledge Object is still valid."
+            }
             DiagnosticCode::IdDuplicate => {
                 "Give each object a unique ID across the compiled workspace."
             }
@@ -289,6 +295,7 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "schema.invalid_status",
     "claim.verified_missing_evidence",
     "claim.status_casing",
+    "lifecycle.expired",
     "id.duplicate",
     "id.invalid",
     "ref.broken",

--- a/crates/adoc-core/src/infrastructure/validate/knowledge_object_lifecycle.rs
+++ b/crates/adoc-core/src/infrastructure/validate/knowledge_object_lifecycle.rs
@@ -32,16 +32,27 @@ impl ValidationRule for KnowledgeObjectLifecycle {
                 continue;
             };
 
-            let Ok(expires_at) = NaiveDate::parse_from_str(expires_at, "%Y-%m-%d") else {
+            let Ok(expires_at_date) = NaiveDate::parse_from_str(expires_at, "%Y-%m-%d") else {
+                let object_id = knowledge_object.id().as_str();
+                sink.push(
+                    Diagnostic::warning(
+                        DiagnosticCode::LifecycleInvalidExpiresAt,
+                        format!(
+                            "Knowledge Object `{object_id}` has invalid expires_at `{expires_at}`; expected YYYY-MM-DD."
+                        ),
+                    )
+                    .with_span(knowledge_object.span().clone())
+                    .with_object_id(object_id),
+                );
                 continue;
             };
 
-            if expires_at < self.today {
+            if expires_at_date < self.today {
                 let object_id = knowledge_object.id().as_str();
                 sink.push(
                     Diagnostic::warning(
                         DiagnosticCode::LifecycleExpired,
-                        format!("Knowledge Object `{object_id}` expired on {expires_at}."),
+                        format!("Knowledge Object `{object_id}` expired on {expires_at_date}."),
                     )
                     .with_span(knowledge_object.span().clone())
                     .with_object_id(object_id),

--- a/crates/adoc-core/src/infrastructure/validate/knowledge_object_lifecycle.rs
+++ b/crates/adoc-core/src/infrastructure/validate/knowledge_object_lifecycle.rs
@@ -1,0 +1,52 @@
+use chrono::NaiveDate;
+
+use crate::domain::ast::{BlockAst, PageAst};
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::domain::rules::ValidationRule;
+use crate::domain::source::SourceFile;
+
+const EXPIRES_AT_FIELD: &str = "expires_at";
+
+pub(crate) struct KnowledgeObjectLifecycle {
+    today: NaiveDate,
+}
+
+impl KnowledgeObjectLifecycle {
+    pub(crate) fn new(today: NaiveDate) -> Self {
+        Self { today }
+    }
+}
+
+impl ValidationRule for KnowledgeObjectLifecycle {
+    fn check(&self, page: &PageAst, _source: &SourceFile, sink: &mut Vec<Diagnostic>) {
+        for block in &page.blocks {
+            let BlockAst::KnowledgeObject(knowledge_object) = block else {
+                continue;
+            };
+
+            let Some(expires_at) = knowledge_object
+                .fields()
+                .iter()
+                .find_map(|(key, value)| (key == EXPIRES_AT_FIELD).then_some(value))
+            else {
+                continue;
+            };
+
+            let Ok(expires_at) = NaiveDate::parse_from_str(expires_at, "%Y-%m-%d") else {
+                continue;
+            };
+
+            if expires_at < self.today {
+                let object_id = knowledge_object.id().as_str();
+                sink.push(
+                    Diagnostic::warning(
+                        DiagnosticCode::LifecycleExpired,
+                        format!("Knowledge Object `{object_id}` expired on {expires_at}."),
+                    )
+                    .with_span(knowledge_object.span().clone())
+                    .with_object_id(object_id),
+                );
+            }
+        }
+    }
+}

--- a/crates/adoc-core/src/infrastructure/validate/mod.rs
+++ b/crates/adoc-core/src/infrastructure/validate/mod.rs
@@ -14,11 +14,14 @@
 //! needed.
 
 mod knowledge_object_body_unsafe_links_forbidden;
+mod knowledge_object_lifecycle;
 mod knowledge_object_unique_ids;
 mod raw_html_forbidden;
 mod unsafe_link_forbidden;
 
+use chrono::NaiveDate;
 use knowledge_object_body_unsafe_links_forbidden::KnowledgeObjectBodyUnsafeLinksForbidden;
+use knowledge_object_lifecycle::KnowledgeObjectLifecycle;
 use knowledge_object_unique_ids::KnowledgeObjectUniqueIds;
 use raw_html_forbidden::RawHtmlForbidden;
 use unsafe_link_forbidden::UnsafeLinkForbidden;
@@ -32,10 +35,6 @@ use crate::domain::source::SourceFile;
 /// Objects are resolved. They are allowed to inspect parser-owned source spans.
 const SOURCE_PAGE_RULES: &[&dyn ValidationRule] = &[&RawHtmlForbidden, &UnsafeLinkForbidden];
 
-/// Resolved-page rules run after pending Knowledge Objects have been converted
-/// into typed aggregates.
-const RESOLVED_PAGE_RULES: &[&dyn ValidationRule] = &[&KnowledgeObjectBodyUnsafeLinksForbidden];
-
 /// Workspace-level rules, applied in registration order after knowledge object
 /// resolution and workspace assembly.
 const WORKSPACE_RULES: &[&dyn WorkspaceRule] = &[&KnowledgeObjectUniqueIds];
@@ -48,8 +47,14 @@ pub(crate) fn validate_source_page(page: &PageAst, source: &SourceFile) -> Vec<D
 
 /// Run every resolved-page rule against `page` after Knowledge Object
 /// resolution.
-pub(crate) fn validate_resolved_page(page: &PageAst, source: &SourceFile) -> Vec<Diagnostic> {
-    validate_page_with_rules(page, source, RESOLVED_PAGE_RULES)
+pub(crate) fn validate_resolved_page(
+    page: &PageAst,
+    source: &SourceFile,
+    today: NaiveDate,
+) -> Vec<Diagnostic> {
+    let lifecycle = KnowledgeObjectLifecycle::new(today);
+    let rules: [&dyn ValidationRule; 2] = [&KnowledgeObjectBodyUnsafeLinksForbidden, &lifecycle];
+    validate_page_with_rules(page, source, &rules)
 }
 
 fn validate_page_with_rules(

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -76,6 +76,7 @@ fn public_surface_compiles_with_only_documented_imports() {
     let _ = DiagnosticCode::SchemaInvalidStatus;
     let _ = DiagnosticCode::ClaimVerifiedMissingEvidence;
     let _ = DiagnosticCode::ClaimStatusCasing;
+    let _ = DiagnosticCode::LifecycleExpired;
     let _ = DiagnosticCode::IdDuplicate;
     let _ = DiagnosticCode::IdInvalid;
     let _ = DiagnosticCode::RefBroken;
@@ -116,6 +117,10 @@ fn public_surface_compiles_with_only_documented_imports() {
     assert_eq!(
         DiagnosticCode::ClaimStatusCasing.as_str(),
         "claim.status_casing"
+    );
+    assert_eq!(
+        DiagnosticCode::LifecycleExpired.as_str(),
+        "lifecycle.expired"
     );
     assert_eq!(DiagnosticCode::IdDuplicate.as_str(), "id.duplicate");
     assert_eq!(DiagnosticCode::RefBroken.as_str(), "ref.broken");

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -77,6 +77,7 @@ fn public_surface_compiles_with_only_documented_imports() {
     let _ = DiagnosticCode::ClaimVerifiedMissingEvidence;
     let _ = DiagnosticCode::ClaimStatusCasing;
     let _ = DiagnosticCode::LifecycleExpired;
+    let _ = DiagnosticCode::LifecycleInvalidExpiresAt;
     let _ = DiagnosticCode::IdDuplicate;
     let _ = DiagnosticCode::IdInvalid;
     let _ = DiagnosticCode::RefBroken;
@@ -121,6 +122,10 @@ fn public_surface_compiles_with_only_documented_imports() {
     assert_eq!(
         DiagnosticCode::LifecycleExpired.as_str(),
         "lifecycle.expired"
+    );
+    assert_eq!(
+        DiagnosticCode::LifecycleInvalidExpiresAt.as_str(),
+        "lifecycle.invalid_expires_at"
     );
     assert_eq!(DiagnosticCode::IdDuplicate.as_str(), "id.duplicate");
     assert_eq!(DiagnosticCode::RefBroken.as_str(), "ref.broken");

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap converts the broad PRD into small tracer-bullet milestones. A milestone is not complete just because one subsystem exists; it is complete when a user can start with `.adoc` source, run the `adoc` CLI, receive useful diagnostics, and get both human HTML and agent JSON outputs.
 
-The initial product is a local CLI for native AgentDoc authoring in Git repositories. Web app, Markdown migration, compatibility mode, config files, graph exports, nested blocks, includes, custom schemas, enterprise governance, and agent patching are intentionally deferred until the compiler loop proves itself.
+The initial product is a local CLI for native AgentDoc authoring in Git repositories. A minimal local config now exists for `adoc init`, default docs paths, output paths, and embedding provider selection. Web app, Markdown migration, compatibility mode, graph exports, nested blocks, includes, custom schemas, enterprise governance, hosted embedding adapters, and agent patching remain intentionally deferred until the local compiler and retrieval loop proves itself.
 
 V0 implementation stack: Rust for the `adoc` CLI, parser, validator, compiler, HTML renderer, and agent JSON emitter. The Rust project starts as a Cargo workspace with `crates/adoc-cli` for command-line behavior and `crates/adoc-core` for reusable compiler behavior. Future editor, web, and agent integrations should consume the compiled artifacts or core library rather than own the source grammar.
 
@@ -182,8 +182,11 @@ Acceptance:
 Deferred:
 
 - `@include`.
-- Config files.
 - Ignore patterns.
+
+Closed later in V1.5:
+
+- Minimal config defaults.
 - Project initializer.
 
 ### V0.7: Diagnostics and Fixtures Slice
@@ -245,7 +248,7 @@ V1 product surface:
 - `adoc build` produces a third artifact, `dist/docs.search.json`, alongside `dist/docs.html` and `dist/docs.agent.json`.
 - `adoc explain <object-id>` reads the agent artifact only and prints a structured object explanation.
 - `adoc search "<query>"` reads both artifacts and ranks Knowledge Objects via Reciprocal Rank Fusion over BM25 and brute-force cosine, with exact and prefix Object ID matches pinned to the top.
-- Both new commands accept `--format text|json`. The `adoc.retrieval.v0` JSON envelope is the wire format any future MCP wrapper consumes.
+- Both new commands accept `--format auto|plain|styled|json`. The `adoc.retrieval.v0` JSON envelope is the wire format any future MCP wrapper consumes.
 
 V1 hard rules:
 
@@ -264,7 +267,7 @@ Scope:
 - Treat `dist/docs.agent.json` as a supported read model. Add an artifact reader that validates `schema_version: adoc.agent.v0`, top-level `objects`, and the in-artifact uniqueness of every Object ID.
 - Add a `RetrievalSession`-owned exact lookup keyed by Object ID.
 - Add diagnostics: `io.artifact_missing`, `io.artifact_unreadable`, `io.artifact_malformed`, `schema.unsupported_version`, `id.duplicate_in_artifact`, `retrieval.object_not_found`.
-- Implement `adoc explain <id>` with `--artifact <path>` and `--format text|json`.
+- Implement `adoc explain <id>` with `--artifact <path>` and `--format auto|plain|styled|json`.
 - Pretty text output mirrors PRD §21.5: kind, status, owner, verified date, body, evidence, source, relations.
 - `--format json` emits an `adoc.retrieval.v0` envelope with one record.
 
@@ -408,7 +411,7 @@ V1-wide design guidance:
 - Keep citation by Object ID as the center of the workflow; the retrieval record is a projection of the agent JSON object plus a small `match` block.
 - Treat V1 as local retrieval, not RAG infrastructure: no chunking, no scope-based retrieval, no permissions.
 - Keep source parsing, validation, and artifact emission behind the existing compiler path. Retrieval is a pure read of compiled outputs.
-- Avoid config-file assumptions until V1.5+ creates a project initializer.
+- Keep V1 retrieval artifact-first; config-backed source defaults start in V1.5.
 
 Resolved V1 decisions:
 
@@ -423,14 +426,14 @@ Resolved V1 decisions:
 
 V1.5 closes small local-tooling gaps before migration and team workflows expand the product surface. The search artifact already ships in V1, so V1.5 focuses on author ergonomics: an initializer, a minimal config, and the first lifecycle diagnostic.
 
-Suggested tracer-bullet slices:
+Implemented tracer-bullet slices:
 
-- Add `adoc init` only after the no-config V1 workflow is proven.
+- Add `adoc init` after the no-config V1 workflow is proven.
 - Introduce a minimal `agentdoc.config.yaml` with strict mode, docs path, output paths, and the embedding provider selection.
 - Keep custom schemas, remote sources, permissions, and team ownership out of the first config version.
-- Let `adoc check`, `adoc build`, and the V1 retrieval commands use config defaults when no path is passed.
-- Add basic stale-by-expiration diagnostics for objects that carry `expires_at`.
-- Add a hosted `EmbeddingProvider` adapter behind a feature flag once an external user has asked for one; until then the local default remains the only shipped provider.
+- Let `adoc check` and `adoc build` use config defaults when no source path is passed; let retrieval commands use config artifact paths when artifact flags are omitted.
+- Add basic stale-by-expiration diagnostics for objects that carry parseable past `expires_at` dates.
+- Keep hosted `EmbeddingProvider` adapters deferred until an external user asks for one; the local provider remains the only shipped provider.
 - Update docs and examples around the default local workflow.
 
 Design guidance:
@@ -444,7 +447,7 @@ Acceptance:
 
 - A user can run `adoc init`, edit the generated example, run `adoc check`, run `adoc build`, then run `adoc explain` and `adoc search`.
 - Existing explicit `adoc check <path>` and `adoc build <path> --out <directory>` workflows continue to work.
-- Expired verified claims produce useful diagnostics without mutating source.
+- Expired Knowledge Objects produce useful warning diagnostics without mutating source.
 
 ## V2: Migration and Compatibility
 
@@ -636,25 +639,21 @@ The currently resolved and implemented first cut is:
 - Build output directory: created automatically when missing.
 - Source extension: `.adoc`.
 - Authoring workflow: native AgentDoc Source first.
-- Commands: `adoc check`, `adoc build`.
+- Commands: `adoc init`, `adoc check`, `adoc build`, `adoc explain`, `adoc search`.
 - Modes: strict mode only.
-- Config: none.
+- Config: minimal `agentdoc.config.yaml` for local docs path, outputs, and `embeddings.provider: local|none`.
 - Initial objects: `claim`, `decision`, `warning`, `glossary`.
 - Verified support: verified claims only.
 - V0 evidence: `source`, `test`, `reviewed_by`.
 - Relations: `depends_on`, `supersedes`, `related_to`.
 - Block structure: top-level typed blocks only.
 - Composition: scan files directly, no includes.
-- Outputs: `dist/docs.html`, `dist/docs.agent.json`.
+- Outputs: `dist/docs.html`, `dist/docs.agent.json`, `dist/docs.search.json`.
 - Agent JSON shape: flat object list plus diagnostics.
 
 ## Explicitly Deferred From V0
 
 - Markdown migration and compatibility mode.
-- `adoc init`.
-- Config files.
-- Search and explain commands.
-- Search index artifacts such as `docs.search.json`.
 - Graph artifacts and graph traversal.
 - Nested typed blocks.
 - Includes.

--- a/docs/adr/0005-use-single-v0-core-compile-api.md
+++ b/docs/adr/0005-use-single-v0-core-compile-api.md
@@ -11,3 +11,5 @@ V0.5 adds `DiagnosticCode::RefBroken` with wire code `ref.broken` for object ref
 V0.5 also adds `DiagnosticCode::IoUnsupportedSourceExtension` with wire code `io.unsupported_source_extension` for existing single-file compile roots whose extension is not exactly `.adoc`. Directory scans continue to ignore non-`.adoc` files silently; missing paths and ordinary read failures remain `io.unreadable_file`.
 
 V0.5 also adds `DiagnosticCode::IoUnreadableDirectory` with wire code `io.unreadable_directory` for directories that exist but cannot be traversed during recursive source discovery. Missing roots and ordinary file read failures remain `io.unreadable_file`.
+
+V1.5 adds `DiagnosticCode::LifecycleInvalidExpiresAt` with wire code `lifecycle.invalid_expires_at` for Knowledge Objects whose `expires_at` field is present but not parseable as `YYYY-MM-DD`.

--- a/docs/v1-retrieval.md
+++ b/docs/v1-retrieval.md
@@ -22,6 +22,31 @@ is the sidecar vector index. By default it uses the local FastEmbed
 `bge-small-en-v1.5` provider. The first build may download model weights through
 `fastembed-rs`; later builds reuse the local model cache.
 
+With `agentdoc.config.yaml`, the same workflow can omit paths:
+
+```bash
+adoc init
+adoc check
+adoc build
+```
+
+`check` and `build` use config `docs_path` when no source path is passed.
+`build` uses config outputs when `--out` is omitted. Config paths are resolved
+relative to the config file; `outputs.dir` fills `docs.html`,
+`docs.agent.json`, and `docs.search.json` unless exact output paths override
+them.
+
+Config embedding mode is:
+
+```yaml
+embeddings:
+  provider: local # or none
+```
+
+Missing `embeddings` defaults to `local`. `none` is equivalent to skipping
+embedding generation for config-backed builds. Hosted embedding adapters remain
+deferred; the shipped provider is local.
+
 Use `--no-embeddings` when you only need HTML and agent JSON:
 
 ```bash
@@ -29,6 +54,10 @@ adoc build examples/billing-pilot --out dist --no-embeddings
 ```
 
 That skips model loading and leaves any prior `docs.search.json` untouched.
+
+If a Knowledge Object has a parseable `expires_at` date before the local build
+date, `check` and `build` emit warning `lifecycle.expired`. The warning does
+not block artifacts and does not mutate source.
 
 ## Explain
 

--- a/docs/v1-retrieval.md
+++ b/docs/v1-retrieval.md
@@ -34,7 +34,8 @@ adoc build
 `build` uses config outputs when `--out` is omitted. Config paths are resolved
 relative to the config file; `outputs.dir` fills `docs.html`,
 `docs.agent.json`, and `docs.search.json` unless exact output paths override
-them.
+them. Exact config outputs need `html` and `agent_json`; `search` is required
+only when embeddings are enabled.
 
 Config embedding mode is:
 
@@ -54,6 +55,8 @@ adoc build examples/billing-pilot --out dist --no-embeddings
 ```
 
 That skips model loading and leaves any prior `docs.search.json` untouched.
+Config-backed skipped-embedding builds can omit `outputs.search` when exact
+HTML and agent JSON paths are configured.
 
 If a Knowledge Object has a parseable `expires_at` date before the local build
 date, `check` and `build` emit warning `lifecycle.expired`. The warning does

--- a/examples/billing-pilot/agentdoc.config.yaml
+++ b/examples/billing-pilot/agentdoc.config.yaml
@@ -1,0 +1,7 @@
+version: 1
+mode: strict
+docs_path: .
+outputs:
+  dir: dist
+embeddings:
+  provider: local


### PR DESCRIPTION
## Summary

Implements the V1.5 local project ergonomics tracer bullets from the PRD:

- add `adoc init` with a minimal starter config and example source
- add `agentdoc.config.yaml` defaults for local `check`, `build`, `explain`, and `search` workflows
- add warning-only `lifecycle.expired` diagnostics for parseable expired `expires_at` values
- preserve explicit legacy `adoc check <path>` and `adoc build <path> --out <dir>` behavior
- document the V1.5 local workflow and add a billing pilot config example

## User Impact

Users can now start a local AgentDoc project with:

```bash
adoc init
adoc check
adoc build
adoc explain docs.getting-started.local-workflow
adoc search "local workflow"
```

Config remains intentionally small: strict mode only, one docs path, output paths, and `embeddings.provider: local|none`.

## Validation

```bash
cargo test -p adoc-core
cargo test -p adoc-cli
cargo test --workspace
cargo clippy --workspace --all-targets --all-features -- -D warnings
```

All passed locally.

## Notes

Hosted embedding adapters, custom schemas, remotes, permissions, migration, graph output, and team ownership remain deferred.