### PR TITLE
feat: adoc stale lifecycle-signal query (V6.1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -364,6 +364,14 @@ _Avoid_: silently dropping unknown kinds at the v2 boundary, claiming the v3 bum
 The V5.9 evaluation fixture (implemented): `examples/expanded-pilot/` carries 11 hand-curated `.adoc` files across auth, billing, and security domains, exercising every new V5 kind, the **Severity** value object, the **V5 Evidence Model**, **Disjoint Action Sets**, and a **Contradiction Object** referencing two pre-existing `claim` objects. 18 Knowledge Objects; a stable `0 errors, 2 warnings` budget (two `lifecycle.expired`). Paired end-to-end test in `crates/adoc-cli/tests/expanded_pilot.rs`; maintenance contract in `docs/expanded-pilot.md`. Mirrors the Billing Pilot (V1.6) and **Markdown Pilot** (V4.4) pattern.
 _Avoid_: ad-hoc V5 fixtures scattered across crates, V5 fixtures without the contradiction case, drift between the pilot and the `docs/expanded-pilot.md` maintenance contract
 
+**Lifecycle Signal**:
+A derived, clock-dependent fact about a **Knowledge Object**'s trustworthiness right now: stale (past `expires_at`), review-overdue (active policy past `effective_at + review_interval`), expiring-soon (verified, expiry within a requested horizon), or contradicted. Derived from authored fields, never authored itself, and re-derived **at read time** against the query date by the V6.1+ signal commands (`derive_effective_status_from_fields` is the single shared rule; ADR-0038). Signals are data for agents and humans to act on — not validation errors, not gates.
+_Avoid_: health score, validation error, trusting the artifact's build-time `effective_status` at read time, treating stale findings as build failures
+
+**Stale Query**:
+The V6.1 read command `adoc stale` / MCP tool `adoc_stale` (implemented): a graph-artifact reader emitting `adoc.stale.v0` — `evaluated_at` plus records categorized `stale | review_overdue | expiring_soon`, sorted most-overdue first then Object ID. The `stale` category lists any object with a past expiry (the `lifecycle.expired` breadth); the record's `effective_status` re-derives `stale` only for verified objects and otherwise echoes the authored status. Exit 0 with or without records; logic in `application/signals.rs`. See `docs/V6-DESIGN.md` §V6.1.
+_Avoid_: recompiling source to answer staleness, exit codes that gate on findings, `--fail-on` thresholds before measured demand
+
 ## Relationships
 
 - **AgentDoc Source** contains prose and typed blocks that compile into **Knowledge Objects**.

--- a/crates/adoc-cli/src/cli.rs
+++ b/crates/adoc-cli/src/cli.rs
@@ -15,6 +15,7 @@ Examples:
   adoc patch --check patch.json
   adoc diff main
   adoc search \"refund policy\"
+  adoc stale --within 30d
 ";
 const INIT_LONG_HELP: &str = "\
 Examples:
@@ -71,6 +72,28 @@ Examples:
   adoc search \"refund policy\" --related-to billing.refunds.issue-credit --relation depends_on
   adoc search billing.refunds --lexical
 ";
+const STALE_LONG_HELP: &str = "\
+Staleness and review-overdue-ness are re-derived from authored fields at the
+time of the query, not read from the artifact's build-time projection. The
+command is a query, not a gate: it exits 0 whether or not records exist.
+
+Examples:
+  adoc stale
+  adoc stale --within 30d
+  adoc stale --within 30d --format json
+  adoc stale --artifact dist/docs.graph.json
+";
+
+/// Parse the `--within <N>d` horizon grammar (same `[0-9]+d` shape as the
+/// `review_interval:` field) into a day count.
+fn parse_within_days(value: &str) -> Result<u32, String> {
+    let error = || format!("expected a day count like `30d`, got `{value}`");
+    let days = value.strip_suffix('d').ok_or_else(error)?;
+    if days.is_empty() || !days.bytes().all(|byte| byte.is_ascii_digit()) {
+        return Err(error());
+    }
+    days.parse::<u32>().map_err(|_| error())
+}
 
 /// The output format requested on the command line (`--format`).
 #[derive(Clone, Copy, Default, ValueEnum)]
@@ -243,6 +266,21 @@ pub(crate) enum Commands {
         relation: Option<CliGraphRelation>,
         #[arg(long, value_enum)]
         direction: Option<CliGraphDirection>,
+    },
+    #[command(
+        about = "List stale, review-overdue, and expiring Knowledge Objects from graph artifacts.",
+        after_long_help = STALE_LONG_HELP
+    )]
+    Stale {
+        #[arg(
+            long,
+            help = "Graph JSON artifact path (default: config outputs.graph, then dist/docs.graph.json)"
+        )]
+        artifact: Option<PathBuf>,
+        /// Additionally list verified objects expiring within the next N days,
+        /// e.g. `--within 30d`.
+        #[arg(long, value_name = "Nd", value_parser = parse_within_days)]
+        within: Option<u32>,
     },
     #[command(
         about = "Validate one AgentDoc patch document against graph artifacts.",

--- a/crates/adoc-cli/src/commands/mod.rs
+++ b/crates/adoc-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ mod init;
 mod patch;
 mod review;
 mod search;
+mod stale;
 mod why;
 
 use std::path::PathBuf;
@@ -26,6 +27,7 @@ pub(crate) use init::init;
 pub(crate) use patch::{PatchCommandInput, patch};
 pub(crate) use review::{ReviewCommandInput, review};
 pub(crate) use search::{SearchCommandInput, search_command};
+pub(crate) use stale::{StaleCommandInput, stale};
 pub(crate) use why::why;
 
 fn emit_retrieval_error(

--- a/crates/adoc-cli/src/commands/stale.rs
+++ b/crates/adoc-cli/src/commands/stale.rs
@@ -1,0 +1,149 @@
+use std::fmt::Write as FmtWrite;
+use std::io;
+use std::path::PathBuf;
+
+use adoc_core::{StaleCategory, StaleEnvelope, StaleRecord};
+use adoc_local::{
+    LocalContext, StaleInput as LocalStaleInput, StaleUseCase, UnrestrictedPathPolicy,
+};
+
+use crate::error::CliError;
+use crate::presentation::style::key::cyan_key;
+use crate::presentation::style::kv::faint_label;
+use crate::presentation::{ResolvedFormat, json as json_presentation};
+
+use super::{current_dir, eprint_diagnostics, report};
+
+pub(crate) struct StaleCommandInput {
+    pub(crate) artifact: Option<PathBuf>,
+    pub(crate) within_days: Option<u32>,
+}
+
+pub(crate) fn stale(input: StaleCommandInput, resolved: ResolvedFormat) -> i32 {
+    let config_start = match current_dir() {
+        Ok(path) => path,
+        Err(error) => return report(error),
+    };
+    let context = LocalContext::new(config_start, UnrestrictedPathPolicy);
+    let outcome = match StaleUseCase::new(context).run(LocalStaleInput {
+        artifact: input.artifact,
+        within_days: input.within_days,
+    }) {
+        Ok(outcome) => outcome,
+        Err(error) => return report(error.into()),
+    };
+    let exit_code = outcome.exit_code;
+    if exit_code != 0 {
+        return emit_stale_error(outcome.envelope, resolved, exit_code);
+    }
+    if resolved != ResolvedFormat::Json && !outcome.envelope.diagnostics.is_empty() {
+        eprint_diagnostics(&outcome.envelope.diagnostics);
+    }
+    match resolved {
+        ResolvedFormat::Json => write_stale_json(&outcome.envelope, exit_code),
+        ResolvedFormat::Plain => write_stale_text(&outcome.envelope, false),
+        ResolvedFormat::Styled => write_stale_text(&outcome.envelope, true),
+        ResolvedFormat::Markdown => {
+            unreachable!("main.rs rejects markdown format for `adoc stale` before dispatch")
+        }
+    }
+}
+
+fn emit_stale_error(envelope: StaleEnvelope, resolved: ResolvedFormat, exit_code: i32) -> i32 {
+    if resolved == ResolvedFormat::Json {
+        return write_stale_json(&envelope, exit_code);
+    }
+    eprint_diagnostics(&envelope.diagnostics);
+    exit_code
+}
+
+fn write_stale_json(envelope: &StaleEnvelope, exit_code: i32) -> i32 {
+    json_presentation::write_json(envelope, &mut io::stdout()).map_or_else(
+        |source| report(CliError::RetrievalIo { source }),
+        |()| exit_code,
+    )
+}
+
+fn write_stale_text(envelope: &StaleEnvelope, styled: bool) -> i32 {
+    let mut output = String::new();
+    render_stale_text(&mut output, envelope, styled);
+    print!("{output}");
+    0
+}
+
+fn render_stale_text(output: &mut String, envelope: &StaleEnvelope, styled: bool) {
+    let header = format!(
+        "{} record(s) as of {}",
+        envelope.records.len(),
+        envelope.evaluated_at
+    );
+    if styled {
+        writeln!(output, "{} {header}", faint_label("Stale:"))
+            .expect("writing to String cannot fail");
+    } else {
+        writeln!(output, "Stale: {header}").expect("writing to String cannot fail");
+    }
+
+    if envelope.records.is_empty() {
+        writeln!(output, "(none)").expect("writing to String cannot fail");
+        return;
+    }
+    for record in &envelope.records {
+        render_record(output, record, styled);
+    }
+}
+
+fn render_record(output: &mut String, record: &StaleRecord, styled: bool) {
+    let category = category_str(record.category);
+    let status = match (&record.authored_status, &record.effective_status) {
+        (Some(authored), Some(effective)) if authored != effective => {
+            format!(", {authored} -> {effective}")
+        }
+        (Some(authored), _) => format!(", {authored}"),
+        (None, Some(effective)) => format!(", {effective}"),
+        (None, None) => String::new(),
+    };
+    let days = match record.category {
+        StaleCategory::Stale | StaleCategory::ReviewOverdue => record
+            .days_overdue
+            .map(|days| format!(", {days} days overdue"))
+            .unwrap_or_default(),
+        StaleCategory::ExpiringSoon => record
+            .days_remaining
+            .map(|days| format!(", {days} days remaining"))
+            .unwrap_or_default(),
+    };
+    let owner = record
+        .owner
+        .as_ref()
+        .map(|owner| format!(", owner: {owner}"))
+        .unwrap_or_default();
+    if styled {
+        writeln!(
+            output,
+            "- {} ({} {category}, {} {}{status}, {}{days}{owner}, {})",
+            record.id,
+            cyan_key("category"),
+            cyan_key("kind"),
+            record.kind,
+            record.reason,
+            record.source_path,
+        )
+        .expect("writing to String cannot fail");
+    } else {
+        writeln!(
+            output,
+            "- {} ({category}, {}{status}, {}{days}{owner}, {})",
+            record.id, record.kind, record.reason, record.source_path,
+        )
+        .expect("writing to String cannot fail");
+    }
+}
+
+fn category_str(category: StaleCategory) -> &'static str {
+    match category {
+        StaleCategory::Stale => "stale",
+        StaleCategory::ReviewOverdue => "review_overdue",
+        StaleCategory::ExpiringSoon => "expiring_soon",
+    }
+}

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -10,7 +10,7 @@ use clap::{Parser, error::ErrorKind};
 use crate::cli::{Cli, Commands};
 use crate::commands::{
     DiffCommandInput, GraphCommandInput, PatchCommandInput, ReviewCommandInput, SearchCommandInput,
-    build, check, diff, graph, init, patch, review, search_command, why,
+    StaleCommandInput, build, check, diff, graph, init, patch, review, search_command, stale, why,
 };
 use crate::presentation::{ResolvedFormat, terminal};
 
@@ -57,6 +57,13 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
                         artifact,
                         relation: relation.map(Into::into),
                         direction: direction.map(Into::into),
+                    },
+                    resolved,
+                ),
+                Commands::Stale { artifact, within } => stale(
+                    StaleCommandInput {
+                        artifact,
+                        within_days: within,
                     },
                     resolved,
                 ),

--- a/crates/adoc-cli/tests/expanded_pilot.rs
+++ b/crates/adoc-cli/tests/expanded_pilot.rs
@@ -633,3 +633,185 @@ fn run_git(workspace: &TestWorkspace, args: &[&str]) {
         String::from_utf8_lossy(&output.stderr)
     );
 }
+
+/// V6.1 acceptance: `adoc stale` re-derives lifecycle signals at read time
+/// from the built graph artifact (docs/ROADMAP-V6.md §V6.1).
+///
+/// The default listing must contain exactly 3 records sorted most-overdue
+/// first (fixed due dates 2020-03-31 / 2024-01-01 / 2026-01-15 keep the order
+/// clock-stable); `--within 36500d` additionally lists the two far-future
+/// verified objects as `expiring_soon`. The command is a query: exit 0 with
+/// records, exit 2 only on artifact-load failure, and `--format markdown`
+/// stays diff/review-only.
+#[test]
+fn expanded_pilot_stale_query() {
+    let repo_root = repo_root();
+    let workspace = TestWorkspace::new("expanded-pilot-stale");
+    let dist = workspace.root.join("dist");
+    let build = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&repo_root)
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "deterministic")
+        .args([
+            "build",
+            PILOT_PATH,
+            "--out",
+            dist.to_str().expect("dist path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+    assert!(
+        build.status.success(),
+        "stale prerequisite build must succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let graph = dist.join("docs.graph.json");
+    let graph_arg = graph.to_str().expect("graph path is utf-8");
+
+    // --- default listing: exactly 3 records, most-overdue first ---
+    let stale = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["stale", "--artifact", graph_arg, "--format", "json"])
+        .output()
+        .expect("adoc stale runs");
+    assert!(
+        stale.status.success(),
+        "adoc stale is a query and must exit 0 even with records\nstderr:\n{}",
+        String::from_utf8_lossy(&stale.stderr)
+    );
+    let envelope: Value = serde_json::from_slice(&stale.stdout).expect("stale stdout is JSON");
+    assert_eq!(envelope["schema_version"], "adoc.stale.v0");
+    assert_eq!(
+        envelope["evaluated_at"].as_str().map(str::len),
+        Some(10),
+        "evaluated_at must be a YYYY-MM-DD date: {:?}",
+        envelope["evaluated_at"]
+    );
+    let records = envelope["records"].as_array().expect("records array");
+    assert_eq!(records.len(), 3, "expected exactly 3 records: {records:#?}");
+
+    assert_eq!(records[0]["id"], "security.production-db-access");
+    assert_eq!(records[0]["category"], "review_overdue");
+    assert_eq!(records[0]["reason"], "review_due:2020-03-31");
+    assert_eq!(records[0]["kind"], "policy");
+    assert_eq!(records[0]["authored_status"], "active");
+    assert_eq!(records[0]["effective_status"], "active");
+    assert!(
+        records[0]["days_overdue"].as_u64().expect("days_overdue") > 0,
+        "review_overdue must carry positive days_overdue"
+    );
+    assert!(
+        records[0]["source_path"]
+            .as_str()
+            .expect("source_path")
+            .contains("security/policies.adoc")
+    );
+
+    assert_eq!(records[1]["id"], "security.audit.retention");
+    assert_eq!(records[1]["category"], "stale");
+    assert_eq!(records[1]["authored_status"], "verified");
+    assert_eq!(
+        records[1]["effective_status"], "stale",
+        "verified + expired must re-derive stale at read time"
+    );
+    assert_eq!(records[1]["reason"], "expired:2024-01-01");
+    assert_eq!(records[1]["expires_at"], "2024-01-01");
+
+    assert_eq!(records[2]["id"], "billing.credits.legacy-export");
+    assert_eq!(records[2]["category"], "stale");
+    assert_eq!(records[2]["authored_status"], "draft");
+    assert_eq!(
+        records[2]["effective_status"], "draft",
+        "draft + expired is listed by category but derives no effective status"
+    );
+    assert_eq!(records[2]["reason"], "expired:2026-01-15");
+
+    // --- --within horizon adds the two far-future verified objects ---
+    let within = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "stale",
+            "--artifact",
+            graph_arg,
+            "--within",
+            "36500d",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("adoc stale --within runs");
+    assert!(within.status.success(), "adoc stale --within must exit 0");
+    let within_env: Value =
+        serde_json::from_slice(&within.stdout).expect("stale --within stdout is JSON");
+    let within_records = within_env["records"].as_array().expect("records array");
+    assert_eq!(
+        within_records.len(),
+        5,
+        "expected the 3 default records plus 2 expiring_soon: {within_records:#?}"
+    );
+    assert_eq!(within_records[3]["id"], "billing.credits.consume");
+    assert_eq!(within_records[3]["category"], "expiring_soon");
+    assert_eq!(within_records[3]["reason"], "expires:2120-01-01");
+    assert!(
+        within_records[3]["days_remaining"]
+            .as_u64()
+            .expect("days_remaining")
+            > 0
+    );
+    assert_eq!(within_records[4]["id"], "auth.mfa.enforced");
+    assert_eq!(within_records[4]["category"], "expiring_soon");
+    assert!(within_records[4].get("days_overdue").is_none());
+
+    // --- plain output smoke ---
+    let plain = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["stale", "--artifact", graph_arg, "--format", "plain"])
+        .output()
+        .expect("adoc stale --format plain runs");
+    assert!(plain.status.success(), "plain stale must exit 0");
+    let plain_stdout = String::from_utf8_lossy(&plain.stdout);
+    assert!(
+        plain_stdout.contains("Stale: 3 record(s) as of"),
+        "plain output must lead with the record count header:\n{plain_stdout}"
+    );
+    assert!(plain_stdout.contains("security.audit.retention"));
+    assert!(
+        plain_stdout.contains("verified -> stale"),
+        "plain output must show the authored -> effective transition:\n{plain_stdout}"
+    );
+
+    // --- markdown stays diff/review-only ---
+    let markdown = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["stale", "--artifact", graph_arg, "--format", "markdown"])
+        .output()
+        .expect("adoc stale --format markdown runs");
+    assert_eq!(
+        markdown.status.code(),
+        Some(2),
+        "markdown format must be rejected for adoc stale"
+    );
+    assert!(
+        String::from_utf8_lossy(&markdown.stderr).contains("cli.format"),
+        "markdown rejection must name the cli.format diagnostic"
+    );
+
+    // --- artifact-load failure exits 2 with an empty-records envelope ---
+    let missing = dist.join("does-not-exist.graph.json");
+    let missing_arg = missing.to_str().expect("missing path is utf-8");
+    let failed = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args(["stale", "--artifact", missing_arg, "--format", "json"])
+        .output()
+        .expect("adoc stale with missing artifact runs");
+    assert_eq!(
+        failed.status.code(),
+        Some(2),
+        "artifact-load failure must exit 2"
+    );
+    let failed_env: Value =
+        serde_json::from_slice(&failed.stdout).expect("failure envelope is JSON");
+    assert_eq!(failed_env["schema_version"], "adoc.stale.v0");
+    assert_eq!(failed_env["records"], serde_json::json!([]));
+    assert!(
+        !failed_env["diagnostics"]
+            .as_array()
+            .expect("diagnostics array")
+            .is_empty(),
+        "failure envelope must carry fix-oriented diagnostics"
+    );
+}

--- a/crates/adoc-cli/tests/help_cli.rs
+++ b/crates/adoc-cli/tests/help_cli.rs
@@ -25,6 +25,7 @@ fn long_top_level_help_lists_command_descriptions_and_examples() {
     assert!(stdout.contains("Traverse Knowledge Object relations from graph artifacts"));
     assert!(stdout.contains("Validate one AgentDoc patch document against graph artifacts"));
     assert!(stdout.contains("Search compiled Knowledge Objects"));
+    assert!(stdout.contains("List stale, review-overdue, and expiring Knowledge Objects"));
     assert!(stdout.contains("Examples:"));
     assert!(stdout.contains("adoc init"));
     assert!(stdout.contains("adoc check docs"));
@@ -33,6 +34,7 @@ fn long_top_level_help_lists_command_descriptions_and_examples() {
     assert!(stdout.contains("adoc graph billing.refunds.issue-credit"));
     assert!(stdout.contains("adoc patch --check patch.json"));
     assert!(stdout.contains("adoc search \"refund policy\""));
+    assert!(stdout.contains("adoc stale --within 30d"));
 }
 
 #[test]

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -17,6 +17,7 @@ use crate::infrastructure::render::HtmlRenderer;
 use crate::infrastructure::validate::mode_pipeline::pipeline_for;
 use crate::infrastructure::validate::validate_workspace;
 
+use super::local_today;
 use super::search_artifact::{
     build_search_artifact, cache_count_diagnostic, embedding_error_diagnostic,
 };
@@ -154,10 +155,6 @@ fn run_compile_pipeline<P: SourceProvider>(
         diagnostics,
         artifacts,
     }
-}
-
-fn local_today() -> NaiveDate {
-    chrono::Local::now().date_naive()
 }
 
 fn build_embedding_diagnostics(options: &BuildOptions<'_>) -> Vec<Diagnostic> {

--- a/crates/adoc-core/src/application/mod.rs
+++ b/crates/adoc-core/src/application/mod.rs
@@ -10,3 +10,10 @@ pub(crate) mod retrieval;
 pub(crate) mod review;
 pub(crate) mod review_envelope;
 pub(crate) mod search_artifact;
+pub(crate) mod signals;
+
+/// The local calendar date used as `today` by clock-dependent derivations
+/// (compile-time lifecycle validation and the V6.1 read-time signal queries).
+pub(crate) fn local_today() -> chrono::NaiveDate {
+    chrono::Local::now().date_naive()
+}

--- a/crates/adoc-core/src/application/signals.rs
+++ b/crates/adoc-core/src/application/signals.rs
@@ -1,0 +1,629 @@
+//! V6.1 lifecycle-signal read queries over a loaded graph artifact.
+//!
+//! `adoc stale` (and, later, `adoc contradictions`) are read-only queries over
+//! `dist/docs.graph.json`. Staleness and overdue-ness are **re-derived at read
+//! time** from authored fields — an artifact built last week must not report
+//! stale-as-of-build-time — so this module never trusts the persisted
+//! `effective_status` projection. See ADR-0038 and docs/V6-DESIGN.md.
+
+use chrono::NaiveDate;
+use serde::Serialize;
+
+use crate::domain::diagnostic::Diagnostic;
+use crate::domain::graph::GraphKnowledgeObjectNode;
+use crate::domain::value_objects::review_interval::ReviewInterval;
+use crate::infrastructure::artifact::graph_json::derive_effective_status_from_fields;
+
+use super::graph::GraphSession;
+use super::local_today;
+
+pub const STALE_SCHEMA_VERSION: &str = "adoc.stale.v0";
+
+/// Why a Knowledge Object appears in the `adoc stale` listing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StaleCategory {
+    /// `expires_at` is strictly before the evaluation date (any status).
+    Stale,
+    /// An `active` policy whose `effective_at + review_interval` is strictly
+    /// before the evaluation date.
+    ReviewOverdue,
+    /// A verified object whose `expires_at` falls within the `--within`
+    /// horizon (evaluation date inclusive).
+    ExpiringSoon,
+}
+
+impl StaleCategory {
+    /// Fixed ordinal used only as the final sort tiebreak so that one object
+    /// yielding records in several categories stays deterministic.
+    fn ordinal(self) -> u8 {
+        match self {
+            Self::Stale => 0,
+            Self::ReviewOverdue => 1,
+            Self::ExpiringSoon => 2,
+        }
+    }
+}
+
+/// One `adoc.stale.v0` record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StaleRecord {
+    pub id: String,
+    pub kind: String,
+    pub category: StaleCategory,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authored_status: Option<String>,
+    /// Re-derived at read time; echoes the authored status when no derivation
+    /// applies (e.g. a draft object listed only because its expiry passed).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_status: Option<String>,
+    pub reason: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub days_overdue: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub days_remaining: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    pub source_path: String,
+}
+
+impl StaleRecord {
+    /// Signed urgency for the "most-overdue first" sort: overdue records are
+    /// positive (≥ 1 by the strict `<` derivations), expiring-soon records are
+    /// zero or negative.
+    fn urgency(&self) -> i64 {
+        match self.category {
+            StaleCategory::Stale | StaleCategory::ReviewOverdue => {
+                i64::from(self.days_overdue.unwrap_or(0))
+            }
+            StaleCategory::ExpiringSoon => -i64::from(self.days_remaining.unwrap_or(0)),
+        }
+    }
+}
+
+/// The `adoc.stale.v0` wire envelope.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct StaleEnvelope {
+    pub schema_version: &'static str,
+    /// `%Y-%m-%d` evaluation date — staleness is re-derived against this date,
+    /// not against the artifact's build date.
+    pub evaluated_at: String,
+    pub records: Vec<StaleRecord>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl StaleEnvelope {
+    pub fn new(
+        evaluated_at: NaiveDate,
+        records: Vec<StaleRecord>,
+        diagnostics: Vec<Diagnostic>,
+    ) -> Self {
+        Self {
+            schema_version: STALE_SCHEMA_VERSION,
+            evaluated_at: evaluated_at.format("%Y-%m-%d").to_string(),
+            records,
+            diagnostics,
+        }
+    }
+}
+
+/// Evaluate the stale query against today's date.
+pub(crate) fn evaluate_stale_today(
+    session: &GraphSession,
+    within_days: Option<u32>,
+    diagnostics: Vec<Diagnostic>,
+) -> StaleEnvelope {
+    let today = local_today();
+    StaleEnvelope::new(
+        today,
+        evaluate_stale_for_date(session, within_days, today),
+        diagnostics,
+    )
+}
+
+/// Empty envelope for the artifact-load-failure path: `evaluated_at` is still
+/// populated so consumers never special-case the field.
+pub(crate) fn empty_stale_envelope_today(diagnostics: Vec<Diagnostic>) -> StaleEnvelope {
+    StaleEnvelope::new(local_today(), Vec::new(), diagnostics)
+}
+
+/// Pure evaluation against an explicit date (unit-test entry point).
+pub(crate) fn evaluate_stale_for_date(
+    session: &GraphSession,
+    within_days: Option<u32>,
+    today: NaiveDate,
+) -> Vec<StaleRecord> {
+    let mut records = Vec::new();
+
+    for node in session.objects() {
+        records.extend(expiry_records(node, within_days, today));
+        records.extend(review_overdue_record(node, today));
+    }
+
+    records.sort_by(|a, b| {
+        b.urgency()
+            .cmp(&a.urgency())
+            .then_with(|| a.id.cmp(&b.id))
+            .then_with(|| a.category.ordinal().cmp(&b.category.ordinal()))
+    });
+    records
+}
+
+/// `stale` / `expiring_soon` records driven by the `expires_at` field.
+fn expiry_records(
+    node: &GraphKnowledgeObjectNode,
+    within_days: Option<u32>,
+    today: NaiveDate,
+) -> Option<StaleRecord> {
+    let expires_at_value = node.fields.get("expires_at")?;
+    let expires_at = NaiveDate::parse_from_str(expires_at_value, "%Y-%m-%d").ok()?;
+
+    if expires_at < today {
+        // Listed for ANY authored status (the lifecycle.expired rule's
+        // breadth); the re-derived effective_status stays verified-only.
+        let days_overdue = days_between(expires_at, today);
+        return Some(StaleRecord {
+            id: node.id.clone(),
+            kind: node.kind.clone(),
+            category: StaleCategory::Stale,
+            authored_status: node.status.clone(),
+            effective_status: rederived_effective_status(node, today),
+            reason: format!("expired:{expires_at}"),
+            expires_at: Some(expires_at_value.clone()),
+            days_overdue: Some(days_overdue),
+            days_remaining: None,
+            owner: node.fields.get("owner").cloned(),
+            source_path: node.source_span.path.clone(),
+        });
+    }
+
+    let horizon_days = within_days?;
+    if node.status.as_deref() != Some("verified") {
+        return None;
+    }
+    // A `None` horizon (date overflow) means "unbounded": everything counts.
+    let within_horizon = today
+        .checked_add_days(chrono::Days::new(u64::from(horizon_days)))
+        .is_none_or(|horizon| expires_at <= horizon);
+    if !within_horizon {
+        return None;
+    }
+
+    let days_remaining = days_between(today, expires_at);
+    Some(StaleRecord {
+        id: node.id.clone(),
+        kind: node.kind.clone(),
+        category: StaleCategory::ExpiringSoon,
+        authored_status: node.status.clone(),
+        effective_status: rederived_effective_status(node, today),
+        reason: format!("expires:{expires_at}"),
+        expires_at: Some(expires_at_value.clone()),
+        days_overdue: None,
+        days_remaining: Some(days_remaining),
+        owner: node.fields.get("owner").cloned(),
+        source_path: node.source_span.path.clone(),
+    })
+}
+
+/// `review_overdue` record for active policies, mirroring the compile-time
+/// `PolicyReviewDrift` rule's arithmetic (strict `<`).
+fn review_overdue_record(node: &GraphKnowledgeObjectNode, today: NaiveDate) -> Option<StaleRecord> {
+    if node.kind != "policy" || node.status.as_deref() != Some("active") {
+        return None;
+    }
+
+    let effective_at =
+        NaiveDate::parse_from_str(node.fields.get("effective_at")?, "%Y-%m-%d").ok()?;
+    let interval = ReviewInterval::try_new(node.fields.get("review_interval")?).ok()?;
+    let next_review = effective_at + chrono::Duration::days(i64::from(interval.days()));
+
+    if next_review >= today {
+        return None;
+    }
+
+    Some(StaleRecord {
+        id: node.id.clone(),
+        kind: node.kind.clone(),
+        category: StaleCategory::ReviewOverdue,
+        authored_status: node.status.clone(),
+        effective_status: rederived_effective_status(node, today),
+        reason: format!("review_due:{next_review}"),
+        expires_at: None,
+        days_overdue: Some(days_between(next_review, today)),
+        days_remaining: None,
+        owner: node.fields.get("owner").cloned(),
+        source_path: node.source_span.path.clone(),
+    })
+}
+
+/// Read-time effective status: the V5.10 expiry derivation when it applies,
+/// otherwise an echo of the authored status. Never trusts the persisted
+/// projection on the node.
+fn rederived_effective_status(node: &GraphKnowledgeObjectNode, today: NaiveDate) -> Option<String> {
+    derive_effective_status_from_fields(
+        node.status.as_deref(),
+        node.fields.get("expires_at").map(String::as_str),
+        today,
+    )
+    .map(|(status, _reason)| status)
+    .or_else(|| node.status.clone())
+}
+
+/// Whole days from `earlier` to `later` (`later` strictly after `earlier` at
+/// every call site, so the result is ≥ 1 for overdue and ≥ 0 for remaining).
+fn days_between(earlier: NaiveDate, later: NaiveDate) -> u32 {
+    u32::try_from((later - earlier).num_days()).unwrap_or(u32::MAX)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use crate::domain::graph::{
+        GraphArtifactDocument, GraphIndex, GraphNode, GraphPageNode, GraphRelations,
+        GraphSourceSpan,
+    };
+
+    fn fixed_today() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 6, 1).expect("valid date")
+    }
+
+    fn ko_node(id: &str, kind: &str, status: Option<&str>, fields: &[(&str, &str)]) -> GraphNode {
+        GraphNode::KnowledgeObject(GraphKnowledgeObjectNode {
+            id: id.to_string(),
+            kind: kind.to_string(),
+            content_hash: format!("sha256:{id}"),
+            status: status.map(str::to_string),
+            severity: None,
+            trust: None,
+            body: "Body.".to_string(),
+            page_id: "team.page".to_string(),
+            source_span: GraphSourceSpan {
+                path: "docs/team.adoc".to_string(),
+                line: 1,
+                column: 1,
+            },
+            fields: fields
+                .iter()
+                .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
+                .collect::<BTreeMap<_, _>>(),
+            relations: GraphRelations::default(),
+            impacts: Vec::new(),
+            approved_by: Vec::new(),
+            allowed_actions: Vec::new(),
+            forbidden_actions: Vec::new(),
+            contradiction_claims: Vec::new(),
+            evidence: Vec::new(),
+            // Deliberately never persisted: read-time re-derivation must not
+            // depend on the build-time projection.
+            effective_status: None,
+            effective_reason: None,
+            evidence_quality: None,
+        })
+    }
+
+    fn session_with(nodes: Vec<GraphNode>) -> GraphSession {
+        let mut all_nodes = vec![GraphNode::Page(GraphPageNode {
+            id: "team.page".to_string(),
+            order: 0,
+            title: None,
+            source_path: "docs/team.adoc".to_string(),
+        })];
+        all_nodes.extend(nodes);
+        let document = GraphArtifactDocument {
+            schema_version: "adoc.graph.v3".to_string(),
+            nodes: all_nodes,
+            edges: Vec::new(),
+            diagnostics: Vec::new(),
+        };
+        GraphSession::new(GraphIndex::from_document(document).expect("valid graph document"))
+    }
+
+    /// All three categories from one artifact pass, sorted most-overdue first
+    /// then id, with read-time re-derivation (no persisted effective_status).
+    #[test]
+    fn evaluate_stale_emits_all_three_categories_sorted_most_overdue_first() {
+        let session = session_with(vec![
+            ko_node(
+                "billing.legacy",
+                "claim",
+                Some("draft"),
+                &[("expires_at", "2026-01-15"), ("owner", "team-billing")],
+            ),
+            ko_node(
+                "security.retention",
+                "claim",
+                Some("verified"),
+                &[("expires_at", "2024-01-01"), ("owner", "security-lead")],
+            ),
+            ko_node(
+                "security.db-access",
+                "policy",
+                Some("active"),
+                &[
+                    ("effective_at", "2020-01-01"),
+                    ("review_interval", "90d"),
+                    ("owner", "security-lead"),
+                ],
+            ),
+            ko_node(
+                "billing.consume",
+                "claim",
+                Some("verified"),
+                &[("expires_at", "2120-01-01")],
+            ),
+        ]);
+
+        let records = evaluate_stale_for_date(&session, Some(36500), fixed_today());
+
+        let ids: Vec<&str> = records.iter().map(|record| record.id.as_str()).collect();
+        assert_eq!(
+            ids,
+            vec![
+                "security.db-access", // review due 2020-03-31 — most overdue
+                "security.retention", // expired 2024-01-01
+                "billing.legacy",     // expired 2026-01-15
+                "billing.consume",    // expiring 2120-01-01
+            ],
+            "records must sort most-overdue first, then id"
+        );
+
+        let policy = &records[0];
+        assert_eq!(policy.category, StaleCategory::ReviewOverdue);
+        assert_eq!(policy.reason, "review_due:2020-03-31");
+        assert_eq!(policy.authored_status.as_deref(), Some("active"));
+        assert_eq!(
+            policy.effective_status.as_deref(),
+            Some("active"),
+            "no derivation applies to an active policy — echo authored status"
+        );
+        assert!(policy.days_overdue.expect("days_overdue") > 0);
+        assert_eq!(policy.days_remaining, None);
+        assert_eq!(policy.owner.as_deref(), Some("security-lead"));
+        assert_eq!(policy.source_path, "docs/team.adoc");
+
+        let verified_stale = &records[1];
+        assert_eq!(verified_stale.category, StaleCategory::Stale);
+        assert_eq!(verified_stale.reason, "expired:2024-01-01");
+        assert_eq!(verified_stale.authored_status.as_deref(), Some("verified"));
+        assert_eq!(
+            verified_stale.effective_status.as_deref(),
+            Some("stale"),
+            "verified + expired must re-derive stale at read time even though \
+             the node carries no persisted effective_status"
+        );
+        assert_eq!(verified_stale.expires_at.as_deref(), Some("2024-01-01"));
+
+        let draft_stale = &records[2];
+        assert_eq!(draft_stale.category, StaleCategory::Stale);
+        assert_eq!(draft_stale.authored_status.as_deref(), Some("draft"));
+        assert_eq!(
+            draft_stale.effective_status.as_deref(),
+            Some("draft"),
+            "draft + expired is listed but derives no effective status — echo"
+        );
+
+        let expiring = &records[3];
+        assert_eq!(expiring.category, StaleCategory::ExpiringSoon);
+        assert_eq!(expiring.reason, "expires:2120-01-01");
+        assert!(expiring.days_remaining.expect("days_remaining") > 0);
+        assert_eq!(expiring.days_overdue, None);
+        assert_eq!(expiring.owner, None);
+    }
+
+    /// Policies are exempt from the review check when fields are missing or
+    /// unparseable, when the status is not `active`, or when the kind is not
+    /// `policy` at all.
+    #[test]
+    fn review_overdue_is_gated_to_active_policies_with_valid_fields() {
+        let session = session_with(vec![
+            ko_node(
+                "policy.no-interval",
+                "policy",
+                Some("active"),
+                &[("effective_at", "2020-01-01")],
+            ),
+            ko_node(
+                "policy.bad-interval",
+                "policy",
+                Some("active"),
+                &[("effective_at", "2020-01-01"), ("review_interval", "soon")],
+            ),
+            ko_node(
+                "policy.bad-date",
+                "policy",
+                Some("active"),
+                &[("effective_at", "not-a-date"), ("review_interval", "90d")],
+            ),
+            ko_node(
+                "policy.retired",
+                "policy",
+                Some("retired"),
+                &[("effective_at", "2020-01-01"), ("review_interval", "90d")],
+            ),
+            ko_node(
+                "claim.with-policy-fields",
+                "claim",
+                Some("verified"),
+                &[("effective_at", "2020-01-01"), ("review_interval", "90d")],
+            ),
+        ]);
+
+        let records = evaluate_stale_for_date(&session, None, fixed_today());
+
+        assert!(
+            records.is_empty(),
+            "none of these may produce a review_overdue record: {records:#?}"
+        );
+    }
+
+    /// `expires_at == today` is not stale (strict `<`) but IS expiring_soon
+    /// with `--within 0d` and `days_remaining: 0`.
+    #[test]
+    fn expiry_on_evaluation_day_is_expiring_soon_not_stale() {
+        let session = session_with(vec![ko_node(
+            "claim.today",
+            "claim",
+            Some("verified"),
+            &[("expires_at", "2026-06-01")],
+        )]);
+
+        let without_window = evaluate_stale_for_date(&session, None, fixed_today());
+        assert!(
+            without_window.is_empty(),
+            "boundary-day expiry must not be stale and must not appear without --within"
+        );
+
+        let with_zero_window = evaluate_stale_for_date(&session, Some(0), fixed_today());
+        assert_eq!(with_zero_window.len(), 1);
+        assert_eq!(with_zero_window[0].category, StaleCategory::ExpiringSoon);
+        assert_eq!(with_zero_window[0].days_remaining, Some(0));
+    }
+
+    /// Expiring-soon is gated to authored `verified`; future expiry outside the
+    /// window is excluded; unparseable expiry dates are skipped entirely.
+    #[test]
+    fn expiring_soon_is_gated_to_verified_within_window() {
+        let session = session_with(vec![
+            ko_node(
+                "claim.draft-future",
+                "claim",
+                Some("draft"),
+                &[("expires_at", "2026-06-10")],
+            ),
+            ko_node(
+                "claim.beyond-window",
+                "claim",
+                Some("verified"),
+                &[("expires_at", "2026-07-15")],
+            ),
+            ko_node(
+                "claim.garbage-date",
+                "claim",
+                Some("verified"),
+                &[("expires_at", "soonish")],
+            ),
+            ko_node(
+                "claim.inside-window",
+                "claim",
+                Some("verified"),
+                &[("expires_at", "2026-06-10")],
+            ),
+        ]);
+
+        let records = evaluate_stale_for_date(&session, Some(30), fixed_today());
+
+        assert_eq!(
+            records.len(),
+            1,
+            "only the verified in-window claim: {records:#?}"
+        );
+        assert_eq!(records[0].id, "claim.inside-window");
+        assert_eq!(records[0].days_remaining, Some(9));
+    }
+
+    /// A huge `--within` that overflows the date horizon is treated as
+    /// unbounded rather than panicking or silently excluding.
+    #[test]
+    fn within_horizon_overflow_is_unbounded() {
+        let session = session_with(vec![ko_node(
+            "claim.far-future",
+            "claim",
+            Some("verified"),
+            &[("expires_at", "2120-01-01")],
+        )]);
+
+        let records = evaluate_stale_for_date(&session, Some(u32::MAX), fixed_today());
+
+        assert_eq!(records.len(), 1);
+        assert_eq!(records[0].category, StaleCategory::ExpiringSoon);
+    }
+
+    /// An expired active policy with an overdue review yields TWO records,
+    /// deterministically ordered by urgency, then id, then category ordinal.
+    #[test]
+    fn one_object_can_yield_stale_and_review_overdue_records() {
+        let session = session_with(vec![ko_node(
+            "policy.doubly-flagged",
+            "policy",
+            Some("active"),
+            &[
+                ("expires_at", "2026-05-31"),
+                ("effective_at", "2026-04-01"),
+                ("review_interval", "30d"),
+            ],
+        )]);
+
+        let records = evaluate_stale_for_date(&session, None, fixed_today());
+
+        assert_eq!(records.len(), 2, "expected two records: {records:#?}");
+        // expired 2026-05-31 → 1 day overdue; review due 2026-05-01 → 31 days.
+        assert_eq!(records[0].category, StaleCategory::ReviewOverdue);
+        assert_eq!(records[0].days_overdue, Some(31));
+        assert_eq!(records[1].category, StaleCategory::Stale);
+        assert_eq!(records[1].days_overdue, Some(1));
+    }
+
+    /// Two objects expired on the same day tiebreak by id ascending.
+    #[test]
+    fn equal_urgency_tiebreaks_by_id() {
+        let session = session_with(vec![
+            ko_node(
+                "claim.zeta",
+                "claim",
+                Some("draft"),
+                &[("expires_at", "2026-01-15")],
+            ),
+            ko_node(
+                "claim.alpha",
+                "claim",
+                Some("draft"),
+                &[("expires_at", "2026-01-15")],
+            ),
+        ]);
+
+        let records = evaluate_stale_for_date(&session, None, fixed_today());
+
+        let ids: Vec<&str> = records.iter().map(|record| record.id.as_str()).collect();
+        assert_eq!(ids, vec!["claim.alpha", "claim.zeta"]);
+    }
+
+    /// The envelope carries the schema version, the formatted evaluation date,
+    /// and forwarded diagnostics.
+    #[test]
+    fn stale_envelope_serializes_schema_version_and_evaluated_at() {
+        let envelope = StaleEnvelope::new(fixed_today(), Vec::new(), Vec::new());
+
+        let value = serde_json::to_value(&envelope).expect("envelope serializes");
+
+        assert_eq!(value["schema_version"], "adoc.stale.v0");
+        assert_eq!(value["evaluated_at"], "2026-06-01");
+        assert_eq!(value["records"], serde_json::json!([]));
+        assert_eq!(value["diagnostics"], serde_json::json!([]));
+    }
+
+    /// Optional record fields are omitted from JSON, not serialized as null.
+    #[test]
+    fn stale_record_omits_absent_optional_fields() {
+        let session = session_with(vec![ko_node(
+            "claim.bare",
+            "claim",
+            None,
+            &[("expires_at", "2026-01-15")],
+        )]);
+
+        let records = evaluate_stale_for_date(&session, None, fixed_today());
+        let value = serde_json::to_value(&records[0]).expect("record serializes");
+        let object = value.as_object().expect("record is an object");
+
+        assert!(!object.contains_key("authored_status"));
+        assert!(!object.contains_key("effective_status"));
+        assert!(!object.contains_key("days_remaining"));
+        assert!(!object.contains_key("owner"));
+        assert_eq!(value["category"], "stale");
+        assert_eq!(value["days_overdue"], 137);
+    }
+}

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -463,16 +463,27 @@ pub(crate) fn derive_effective_status(
     knowledge_object: &KnowledgeObject,
     today: NaiveDate,
 ) -> Option<(String, String)> {
-    if status.as_deref() != Some("verified") {
+    let expires_at = knowledge_object
+        .fields()
+        .iter()
+        .find_map(|(key, value)| (key == "expires_at").then_some(value.as_str()));
+
+    derive_effective_status_from_fields(status.as_deref(), expires_at, today)
+}
+
+/// Field-string core of [`derive_effective_status`], shared with the V6.1
+/// read-time re-derivation in `application/signals.rs`, which works over graph
+/// artifact nodes (field maps) rather than domain Knowledge Objects.
+pub(crate) fn derive_effective_status_from_fields(
+    status: Option<&str>,
+    expires_at: Option<&str>,
+    today: NaiveDate,
+) -> Option<(String, String)> {
+    if status != Some("verified") {
         return None;
     }
 
-    let expires_at_value = knowledge_object
-        .fields()
-        .iter()
-        .find_map(|(key, value)| (key == "expires_at").then_some(value.as_str()))?;
-
-    let expires_at_date = NaiveDate::parse_from_str(expires_at_value, "%Y-%m-%d").ok()?;
+    let expires_at_date = NaiveDate::parse_from_str(expires_at?, "%Y-%m-%d").ok()?;
 
     if expires_at_date < today {
         Some(("stale".to_string(), format!("expired:{expires_at_date}")))
@@ -1897,6 +1908,78 @@ mod tests {
         assert!(
             result.is_none(),
             "expires_at equal to today must not produce effective_status"
+        );
+    }
+
+    // ── V6.1: field-based derivation core (read-time reuse) ───────────────────
+
+    /// `derive_effective_status_from_fields` mirrors the verified-past-expiry
+    /// stale derivation without needing a domain `KnowledgeObject`.
+    #[test]
+    fn derive_effective_status_from_fields_returns_stale_for_verified_past_expiry() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid date");
+
+        let result =
+            derive_effective_status_from_fields(Some("verified"), Some("2026-01-01"), today);
+
+        assert_eq!(
+            result,
+            Some(("stale".to_string(), "expired:2026-01-01".to_string())),
+            "verified status with past expires_at must return stale"
+        );
+    }
+
+    /// Non-verified statuses never derive stale, even with a past expiry.
+    #[test]
+    fn derive_effective_status_from_fields_returns_none_for_non_verified() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid date");
+
+        let result = derive_effective_status_from_fields(Some("draft"), Some("2026-01-01"), today);
+
+        assert!(
+            result.is_none(),
+            "non-verified status must not produce effective_status"
+        );
+    }
+
+    /// `expires_at` equal to `today` is not stale (strict `<`).
+    #[test]
+    fn derive_effective_status_from_fields_returns_none_on_boundary_day() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid date");
+
+        let result =
+            derive_effective_status_from_fields(Some("verified"), Some("2026-05-08"), today);
+
+        assert!(
+            result.is_none(),
+            "expires_at equal to today must not produce effective_status"
+        );
+    }
+
+    /// Unparseable `expires_at` values are silently ignored.
+    #[test]
+    fn derive_effective_status_from_fields_returns_none_for_unparseable_date() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid date");
+
+        let result =
+            derive_effective_status_from_fields(Some("verified"), Some("not-a-date"), today);
+
+        assert!(
+            result.is_none(),
+            "unparseable expires_at must not produce effective_status"
+        );
+    }
+
+    /// Missing `expires_at` produces nothing.
+    #[test]
+    fn derive_effective_status_from_fields_returns_none_for_missing_expires_at() {
+        let today = NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid date");
+
+        let result = derive_effective_status_from_fields(Some("verified"), None, today);
+
+        assert!(
+            result.is_none(),
+            "missing expires_at must not produce effective_status"
         );
     }
 

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -25,6 +25,7 @@ pub use application::review::{
     ReviewSession, diff_objects, proof_obligations, review_with_patch,
 };
 pub use application::review_envelope::{ObjectDiffEnvelope, ReviewEnvelope};
+pub use application::signals::{STALE_SCHEMA_VERSION, StaleCategory, StaleEnvelope, StaleRecord};
 pub use domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 pub use domain::graph::{
     GraphDirection, GraphRelationKind, GraphTraversalEdge, GraphTraversalNode, GraphTraversalQuery,
@@ -128,6 +129,22 @@ pub fn load_graph_session(input: GraphInput) -> GraphLoadResult {
         input,
         &infrastructure::artifact::GraphJsonArtifact,
     )
+}
+
+/// Evaluate the V6.1 `adoc stale` query against today's date, re-deriving
+/// staleness and review-overdue-ness from authored fields at read time.
+pub fn evaluate_stale(
+    session: &GraphSession,
+    within_days: Option<u32>,
+    diagnostics: Vec<Diagnostic>,
+) -> StaleEnvelope {
+    application::signals::evaluate_stale_today(session, within_days, diagnostics)
+}
+
+/// Empty `adoc.stale.v0` envelope for artifact-load-failure paths;
+/// `evaluated_at` is still populated.
+pub fn empty_stale_envelope(diagnostics: Vec<Diagnostic>) -> StaleEnvelope {
+    application::signals::empty_stale_envelope_today(diagnostics)
 }
 
 pub fn check_patch(input: PatchInput) -> PatchCheckResult {

--- a/crates/adoc-local/src/lib.rs
+++ b/crates/adoc-local/src/lib.rs
@@ -18,5 +18,6 @@ pub use use_cases::{
     ProjectStatusInput, ProjectStatusOutcome, ProjectStatusPaths, ProjectStatusReadiness,
     ProjectStatusRefresh, ProjectStatusRefreshReport, ProjectStatusUseCase,
     ResolvedRetrievalRecord, ReviewInput, ReviewOutcome, ReviewPatchSource, ReviewUseCase,
-    SearchInput, SearchOutcome, SearchUseCase, WhyInput, WhyOutcome, WhyUseCase,
+    SearchInput, SearchOutcome, SearchUseCase, StaleInput, StaleOutcome, StaleUseCase, WhyInput,
+    WhyOutcome, WhyUseCase,
 };

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -13,12 +13,13 @@ use adoc_core::{
     GraphTraversalResult, ObjectDiffEnvelope, PatchCheckResult, PatchInput, RetrievalEnvelope,
     RetrievalInput, RetrievalLoadResult, RetrievalRecord, ReviewEnvelope, ReviewError,
     ReviewInput as CoreReviewInput, SearchArtifactInspectionInput, SearchFilters, SearchMode,
-    SearchQuery, Severity, SnapshotSelector, build_workspace_with_embedding_provider,
-    check_patch as core_check_patch, compile_workspace, diff_objects,
-    embed_query_with_embedding_provider, git_review_available, inspect_graph_artifact,
-    inspect_search_artifact, load_graph_session, load_retrieval_session_with_embedding_provider,
-    load_review_from_git, load_review_with_changed_files_from_git, parse_patch_from_path,
-    parse_patch_from_value, review_with_patch, search as core_search, traverse_graph, why_object,
+    SearchQuery, Severity, SnapshotSelector, StaleEnvelope,
+    build_workspace_with_embedding_provider, check_patch as core_check_patch, compile_workspace,
+    diff_objects, embed_query_with_embedding_provider, empty_stale_envelope, evaluate_stale,
+    git_review_available, inspect_graph_artifact, inspect_search_artifact, load_graph_session,
+    load_retrieval_session_with_embedding_provider, load_review_from_git,
+    load_review_with_changed_files_from_git, parse_patch_from_path, parse_patch_from_value,
+    review_with_patch, search as core_search, traverse_graph, why_object,
 };
 use serde::Serialize;
 
@@ -114,6 +115,19 @@ pub struct GraphInput {
 #[derive(Debug, Clone, Serialize)]
 pub struct GraphOutcome {
     pub envelope: GraphTraversalEnvelope,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct StaleInput {
+    pub artifact: Option<PathBuf>,
+    /// `--within <N>d` horizon in days; `None` disables `expiring_soon`.
+    pub within_days: Option<u32>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct StaleOutcome {
+    pub envelope: StaleEnvelope,
     pub exit_code: i32,
 }
 
@@ -364,6 +378,27 @@ where
 
     pub fn run(&self, input: GraphInput) -> Result<GraphOutcome, LocalError> {
         graph_with_context(&self.context, input)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct StaleUseCase<P>
+where
+    P: PathPolicy,
+{
+    context: LocalContext<P>,
+}
+
+impl<P> StaleUseCase<P>
+where
+    P: PathPolicy,
+{
+    pub fn new(context: LocalContext<P>) -> Self {
+        Self { context }
+    }
+
+    pub fn run(&self, input: StaleInput) -> Result<StaleOutcome, LocalError> {
+        stale_with_context(&self.context, input)
     }
 }
 
@@ -665,6 +700,44 @@ where
 
     Ok(GraphOutcome {
         envelope: GraphTraversalEnvelope::from(result),
+        exit_code,
+    })
+}
+
+fn stale_with_context<P>(
+    context: &LocalContext<P>,
+    input: StaleInput,
+) -> Result<StaleOutcome, LocalError>
+where
+    P: PathPolicy,
+{
+    let artifact = input
+        .artifact
+        .as_deref()
+        .map(|path| context.path_policy().resolve_read_path(path))
+        .transpose()?;
+    let config = discover_project_config_if(artifact.is_none(), context.config_start())?;
+    let graph_artifact = resolve_graph_artifact_path_with_config(artifact, config.as_ref());
+    let graph_artifact = context.path_policy().resolve_read_path(&graph_artifact)?;
+    let load_result = load_graph_session(CoreGraphInput {
+        graph_artifact_path: graph_artifact,
+    });
+    let diagnostics = load_result.diagnostics;
+    let session = load_result
+        .session
+        .filter(|_| !diagnostics_have_errors(&diagnostics));
+    let Some(session) = session else {
+        let exit_code = stale_exit_code_for_diagnostics(&diagnostics);
+        return Ok(StaleOutcome {
+            envelope: empty_stale_envelope(diagnostics),
+            exit_code,
+        });
+    };
+
+    let envelope = evaluate_stale(&session, input.within_days, diagnostics);
+    let exit_code = stale_exit_code_for_diagnostics(&envelope.diagnostics);
+    Ok(StaleOutcome {
+        envelope,
         exit_code,
     })
 }
@@ -1516,6 +1589,19 @@ fn graph_diagnostic_exit_code(diagnostic: &Diagnostic) -> Option<i32> {
         (DiagnosticCode::IdInvalid, _) => Some(1),
         (DiagnosticCode::GraphObjectNotFound, _) => Some(3),
         (_, Severity::Error) => Some(2),
+        _ => None,
+    }
+}
+
+/// `adoc stale` is a query, not a gate: records never affect the exit code;
+/// only artifact-load errors do.
+fn stale_exit_code_for_diagnostics(diagnostics: &[Diagnostic]) -> i32 {
+    exit_code_for_diagnostics(diagnostics, stale_diagnostic_exit_code)
+}
+
+fn stale_diagnostic_exit_code(diagnostic: &Diagnostic) -> Option<i32> {
+    match diagnostic.severity {
+        Severity::Error => Some(2),
         _ => None,
     }
 }

--- a/crates/adoc-mcp/src/lib.rs
+++ b/crates/adoc-mcp/src/lib.rs
@@ -12,7 +12,7 @@ use adoc_local::{
     GraphUseCase, InitInput, InitUseCase, LocalContext, PatchCheckInput, PatchCheckUseCase,
     PathPolicy, ProjectConfig, ProjectRootPathPolicy, ProjectStatusInput, ProjectStatusRefresh,
     ProjectStatusUseCase, ReviewInput, ReviewPatchSource, ReviewUseCase, SearchInput,
-    SearchUseCase, WhyInput, WhyUseCase,
+    SearchUseCase, StaleInput, StaleUseCase, WhyInput, WhyUseCase,
 };
 use rmcp::{
     ServerHandler,
@@ -113,6 +113,15 @@ impl AgentDocMcpServer {
             artifact: params.artifact,
             relation: parse_relation(params.relation.as_deref())?,
             direction: parse_direction(params.direction.as_deref())?,
+        })?;
+        serde_json::to_value(outcome.envelope).map_err(Into::into)
+    }
+
+    pub fn run_stale(&self, params: StaleParams) -> McpAdapterResult<serde_json::Value> {
+        let context = self.context(params.project_root)?;
+        let outcome = StaleUseCase::new(context).run(StaleInput {
+            artifact: params.artifact,
+            within_days: params.within_days,
         })?;
         serde_json::to_value(outcome.envelope).map_err(Into::into)
     }
@@ -305,6 +314,19 @@ impl AgentDocMcpServer {
     }
 
     #[tool(
+        name = "adoc_stale",
+        description = "List stale, review-overdue, and (with within_days) expiring-soon Knowledge Objects, re-derived at read time from the graph artifact. Read-only query: records are data, not failures."
+    )]
+    pub fn adoc_stale(
+        &self,
+        Parameters(params): Parameters<StaleParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.run_stale(params)
+            .map(CallToolResult::structured)
+            .map_err(adapter_error)
+    }
+
+    #[tool(
         name = "adoc_search",
         description = "Search compiled AgentDoc graph and search artifacts."
     )]
@@ -463,6 +485,16 @@ pub struct GraphParams {
     pub artifact: Option<PathBuf>,
     pub relation: Option<String>,
     pub direction: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct StaleParams {
+    pub project_root: Option<PathBuf>,
+    pub artifact: Option<PathBuf>,
+    /// Additionally list verified objects whose `expires_at` falls within the
+    /// next N days as `expiring_soon` records.
+    pub within_days: Option<u32>,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -159,6 +159,14 @@ const RESOURCES: &[AgentResource] = &[
         contents: include_str!("../../../docs/agent/v0/schema/review.md"),
     },
     AgentResource {
+        uri: "adoc://agent/v0/schema/stale",
+        name: "schema-stale",
+        title: "Stale Query Schema Reference",
+        description: "Markdown reference for adoc.stale.v0.",
+        mime_type: MARKDOWN,
+        contents: include_str!("../../../docs/agent/v0/schema/stale.md"),
+    },
+    AgentResource {
         uri: "adoc://agent/v0/schema/retrieval-envelope.json",
         name: "schema-retrieval-envelope-json",
         title: "Retrieval Envelope JSON Schema",
@@ -221,6 +229,14 @@ const RESOURCES: &[AgentResource] = &[
         description: "JSON Schema for adoc.review.v0.",
         mime_type: JSON_SCHEMA,
         contents: include_str!("../../../docs/agent/v0/schema/adoc.review.v0.schema.json"),
+    },
+    AgentResource {
+        uri: "adoc://agent/v0/schema/adoc.stale.v0.schema.json",
+        name: "schema-adoc-stale-v0-json",
+        title: "Stale Query JSON Schema",
+        description: "JSON Schema for adoc.stale.v0.",
+        mime_type: JSON_SCHEMA,
+        contents: include_str!("../../../docs/agent/v0/schema/adoc.stale.v0.schema.json"),
     },
 ];
 

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -9,7 +9,7 @@ use adoc_core::{
 };
 use adoc_mcp::{
     AdocPatchCheckParams, AdocReviewParams, AgentDocMcpServer, BuildParams, GraphParams,
-    InitParams, PatchInput, ProjectStatusParams, SearchParams,
+    InitParams, PatchInput, ProjectStatusParams, SearchParams, StaleParams,
 };
 use serde_json::json;
 
@@ -190,6 +190,120 @@ fn validates_representative_serialized_agent_envelopes_against_contract_schemas(
         })
         .expect("project status succeeds");
     assert_valid("project-status.json", &project_status);
+
+    // An empty-records stale envelope is also a contract case: the fixture
+    // project has no expiry or review fields at all.
+    let stale = server
+        .run_stale(StaleParams {
+            project_root: None,
+            artifact: None,
+            within_days: None,
+        })
+        .expect("stale succeeds");
+    assert_valid("adoc.stale.v0.schema.json", &stale);
+    assert_eq!(stale["records"], serde_json::json!([]));
+}
+
+/// V6.1: `adoc_stale` envelopes with all three record categories validate
+/// against `adoc.stale.v0.schema.json`.
+#[test]
+fn validates_adoc_stale_v0_envelope_against_schema() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(
+        &root.join("docs/index.adoc"),
+        concat!(
+            "# Lifecycle @doc(team.lifecycle)\n",
+            "\n",
+            "::claim team.expired-verified\n",
+            "status: verified\n",
+            "owner: team-docs\n",
+            "verified_at: 2020-01-01\n",
+            "source: audit records 2020\n",
+            "expires_at: 2024-01-01\n",
+            "--\n",
+            "Verified but expired claim.\n",
+            "::\n",
+            "\n",
+            "::claim team.expired-draft\n",
+            "status: draft\n",
+            "owner: team-docs\n",
+            "expires_at: 2026-01-15\n",
+            "--\n",
+            "Draft with a past expiry.\n",
+            "::\n",
+            "\n",
+            "::policy team.review-policy\n",
+            "status: active\n",
+            "owner: team-docs\n",
+            "approved_by: [team-docs]\n",
+            "effective_at: 2020-01-01\n",
+            "review_interval: 30d\n",
+            "--\n",
+            "Policy overdue for review.\n",
+            "::\n",
+            "\n",
+            "::claim team.expiring\n",
+            "status: verified\n",
+            "owner: team-docs\n",
+            "verified_at: 2026-01-01\n",
+            "source: audit records 2026\n",
+            "expires_at: 2120-01-01\n",
+            "--\n",
+            "Verified claim expiring far in the future.\n",
+            "::\n",
+        ),
+    );
+    write(
+        &root.join("agentdoc.config.yaml"),
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: deterministic\n",
+    );
+    let server = AgentDocMcpServer::new(root.to_path_buf());
+    server
+        .run_build(BuildParams {
+            project_root: None,
+            path: None,
+            out: None,
+            no_embeddings: false,
+        })
+        .expect("build succeeds");
+
+    let stale = server
+        .run_stale(StaleParams {
+            project_root: None,
+            artifact: None,
+            within_days: None,
+        })
+        .expect("stale succeeds");
+    assert_valid("adoc.stale.v0.schema.json", &stale);
+    let records = stale["records"].as_array().expect("records array");
+    assert_eq!(
+        records.len(),
+        3,
+        "two stale + one review_overdue: {records:#?}"
+    );
+
+    let stale_within = server
+        .run_stale(StaleParams {
+            project_root: None,
+            artifact: None,
+            within_days: Some(36500),
+        })
+        .expect("stale with horizon succeeds");
+    assert_valid("adoc.stale.v0.schema.json", &stale_within);
+    let within_records = stale_within["records"].as_array().expect("records array");
+    assert_eq!(
+        within_records.len(),
+        4,
+        "plus one expiring_soon: {within_records:#?}"
+    );
+    let categories: Vec<&str> = within_records
+        .iter()
+        .filter_map(|record| record["category"].as_str())
+        .collect();
+    assert!(categories.contains(&"stale"));
+    assert!(categories.contains(&"review_overdue"));
+    assert!(categories.contains(&"expiring_soon"));
 }
 
 #[test]

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -277,6 +277,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/schema/mcp-command",
         "adoc://agent/v0/schema/diff",
         "adoc://agent/v0/schema/review",
+        "adoc://agent/v0/schema/stale",
         "adoc://agent/v0/schema/retrieval-envelope.json",
         "adoc://agent/v0/schema/graph-traversal-envelope.json",
         "adoc://agent/v0/schema/patch-input.json",
@@ -285,6 +286,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/schema/mcp-command.json",
         "adoc://agent/v0/schema/adoc.diff.v0.schema.json",
         "adoc://agent/v0/schema/adoc.review.v0.schema.json",
+        "adoc://agent/v0/schema/adoc.stale.v0.schema.json",
     ];
 
     let resources = server.list_agent_resources();

--- a/docs/ROADMAP-V6.md
+++ b/docs/ROADMAP-V6.md
@@ -1,0 +1,380 @@
+# AgentDoc Roadmap — V6 Cycle: The Agent Editing Loop
+
+This roadmap continues [ROADMAP.md](ROADMAP.md) past V5.10. It covers three milestones: **V6 — Agent Editing Loop**, **V6.5 — Vocabulary Completion**, and **V1.7 — Prose Retrieval**.
+
+The previously sketched "V6: Composition and Advanced Graphs" (`@include`, nested typed blocks, custom schema registry, automated contradiction detection) is postponed to Later status; this file takes over the V6 name for the editing loop. The old V6 section's design guidance and open questions in [ROADMAP.md](ROADMAP.md) remain valid for whenever composition earns its slot.
+
+The product bet: AgentDoc has proven the read half of the agent contract (retrieval, citation, diff, review) and the propose half (patch validation). The missing half is the close of the loop — an agent that notices stale or contradicted knowledge, finds what a code change impacts, proposes a patch, and **applies it to source** under the same validation discipline, with a human reviewing a normal Git diff. V6 ships that loop. V6.5 finishes the PRD §13 vocabulary so the loop covers all fifteen kinds. V1.7 makes prose retrievable so agents stop being blind to the majority of real docs content.
+
+Implementation contracts follow at implementation time as `V6-DESIGN.md` in the V5-DESIGN style; the ADRs to record are listed per milestone below.
+
+## Roadmap Rules
+
+All rules from [ROADMAP.md](ROADMAP.md) continue to apply. Three new rules for this cycle:
+
+- Patch application writes to the working tree only. `adoc` never stages, commits, or touches Git history. Git remains the review and rollback mechanism.
+- Apply is formatting-preserving: rewrite only the source spans the patch targets, byte-identical everywhere else. No reformat-on-write, ever.
+- Agent-initiated writes are opt-in. The MCP apply tool exists always, refuses by default, and is enabled only by explicit project config. CLI apply is human-initiated and is not gated.
+
+## Sequencing Rationale
+
+- **V6.1 and V6.2 first.** Pure reads over the existing graph artifact; they pay off the V5.10 derived-signal investment immediately — the signals exist in graph nodes today but have no query surface. Either can ship first; they share only presentation scaffolding.
+- **V6.3 next or in parallel.** `adoc impacted-by` reuses V3's `ChangedFilesProvider` git machinery and has no dependency on V6.1/V6.2 or on apply. It completes the read side of the loop: code change → impacted knowledge.
+- **V6.4 is the centerpiece and the long pole.** It depends on nothing in V6.1–V6.3 and can be developed in parallel, but it lands last within V6 so the pilot proof (TB5) can exercise the full loop: `impacted-by` → propose → apply → re-check → `stale`/`contradictions` clean.
+- **V6.5 is parallelizable with all of V6.** It follows the established V5 aggregate pattern on the parser/domain/render path while V6 works the application/infrastructure read-and-write path. Once both land, `create_object` apply covers all fifteen kinds for free — apply dispatches on the same `RESOLVERS`-registered kinds.
+- **V1.7 is independent of both** and touches only the retrieval pipeline. Suggested order V6 → V6.5 → V1.7 only because the editing loop is the bet; nothing technical forces it.
+
+## PRD Traceability
+
+| Milestone | Closes |
+| --- | --- |
+| V6 | §7.7 (edits as semantic transactions, now actually applied), §18.6 (agent patch protocol: apply, freshness, obligations), §21.2 (`adoc stale`, `adoc contradictions`), §21.6 (`adoc impacted-by`), §21.7 (`adoc patch` validates **and applies**, working tree), §14.4 (staleness rules gain a query surface). Resolves V2's open question on create-op placement. Goes deliberately past MVP Could-Have #4 ("patch validation without application") into PRD Phase 3 agent-native territory, because the loop is the product. |
+| V6.5 | §13.7 (`api`), §13.9 (`observation`), §13.10 (`question`), §13.11 (`task`); completes MVP Must-Haves #2 (typed blocks) and #4 (core schema validation) across the full fifteen-kind §13 vocabulary; §15.4 evidence requirements for `api`. |
+| V1.7 | §19.1–§19.2 (retrieval over both objects and prose), §30.7 search requirements, MVP Must-Haves #12 and #19 now covering prose. Discharges the V4 prose-only-project migration hint: `.md` prose becomes genuinely searchable. |
+
+---
+
+## V6: Agent Editing Loop
+
+V6 closes the loop opened by V2. Three new read commands expose the V5.10 derived lifecycle signals and source-path impact, then patch application makes every already-validated op family (`update_fields`, `replace_body`, `create_object`, `supersede`, `revoke`) actually rewrite `.adoc` source via formatting-preserving span splices — atomically, with an automatic post-apply re-check, never an auto-revert. A gated MCP `adoc_patch_apply` tool extends the loop to agents under explicit project opt-in.
+
+### V6.1: `adoc stale` Slice
+
+Goal: give the V5.10 stale and review-overdue signals a first-class query surface.
+
+Scope:
+
+- New CLI command `adoc stale` reading `dist/docs.graph.json` (no compile), with `--format auto|plain|styled|json`.
+- Default listing: every Knowledge Object whose `expires_at` is in the past, plus every `active` policy whose `effective_at + review_interval` is before today. Staleness and overdue-ness are **re-derived at read time** from authored fields using the existing `derive_effective_status` logic in `infrastructure/artifact/graph_json.rs` — an artifact built last week must not report stale-as-of-build-time. The envelope carries `evaluated_at`.
+- `--within <N>d` additionally lists verified objects whose `expires_at` falls within the next N days, as category `expiring_soon` with `days_remaining`.
+- New wire envelope `adoc.stale.v0`: `{ schema_version, evaluated_at, records: [{ id, kind, category: "stale"|"review_overdue"|"expiring_soon", authored_status, effective_status, reason, expires_at?, days_overdue?, days_remaining?, owner?, source_path }], diagnostics }`. Sorted most-overdue first, then by id; deterministic.
+- Exit code 0 whether or not stale records exist — this is a query, not a gate.
+- JSON Schema under `docs/agent/v0/schema/`, contract-tested per ADR-0015. New MCP tool `adoc_stale`. `adoc://agent/v0/usage-contract` update.
+- Logic lives in a new `application/signals.rs` over the loaded graph index, following the `why`/`graph`/`search` read-only session pattern; one use case in `adoc-local`, one thin subcommand in `adoc-cli`.
+
+Acceptance: against the Expanded Pilot, `adoc stale --format json` exits 0 and emits exactly 3 records: `security.audit.retention` (`category: "stale"`, `authored_status: "verified"`), `billing.credits.legacy-export` (`category: "stale"`, `authored_status: "draft"`), and `security.production-db-access` (`category: "review_overdue"`, positive `days_overdue`). `adoc stale --within 36500d` additionally lists the pilot's future-dated verified objects as `expiring_soon`.
+
+Deferred: `--fail-on-stale` CI gating, health scores (PRD §14.5), staleness from linked-source change (that is `impacted-by`'s job), per-kind project-status counts.
+
+### V6.2: `adoc contradictions` Slice
+
+Goal: give unresolved contradictions and contradicted claims a query surface.
+
+Scope:
+
+- New CLI command `adoc contradictions` reading the graph artifact, with `--format auto|plain|styled|json`.
+- Default listing, two record classes from one artifact pass: every `contradiction` object with status `unresolved` (severity, `claims[]`, owner, source path, body summary), plus a `contradicted_claims` section listing every claim whose derived `effective_status` is `contradicted` or whose authored status is `contradicted`, each with the contradiction ids that implicate it. Consumers never have to join the two lists themselves.
+- `--all` includes `resolved` and `dismissed` contradictions.
+- New wire envelope `adoc.contradictions.v0`: `{ schema_version, contradictions: [{ id, severity, status, claims, owner?, source_path, summary }], contradicted_claims: [{ id, authored_status, effective_status, effective_reason?, contradiction_ids }], diagnostics }`. Sorted by severity descending, then id.
+- Exit code 0 regardless of findings. JSON Schema, MCP tool `adoc_contradictions`, and an `adoc://agent/v0/contradiction-guide` update: agents should run this before answering definitively in a domain.
+
+Acceptance: against the Expanded Pilot, `adoc contradictions --format json` exits 0 with exactly 1 contradiction (`auth.session.conflict`, severity `high`) and exactly 3 entries in `contradicted_claims`: `auth.session.memory-storage` and `auth.session.local-storage-allowed` (authored `contradicted`) and `auth.session.csrf-protection` (authored status unchanged, `effective_status: "contradicted"`), each carrying `contradiction_ids: ["auth.session.conflict"]`.
+
+Deferred: automated contradiction detection (Later), resolution workflow commands, contradiction inbox web surface (V7).
+
+### V6.3: `adoc impacted-by` Slice
+
+Goal: answer "this code changed — which knowledge is now suspect?" per PRD §21.6.
+
+Scope:
+
+- New CLI command with two mutually exclusive input shapes: `adoc impacted-by <path>...` (explicit changed-file list) and `adoc impacted-by --ref <git-ref>` (derive the changed set via the existing V3.3 `ChangedFilesProvider` git adapter). No third shape.
+- Impact reasons, both exact per-path (no globs, consistent with V3.3): `impacts_path` (the object's declared `impacts:` contains a changed path) and `evidence_path` (an inline `source_code`/`test` evidence path, or the `path` of a referenced `source` object, matches a changed path).
+- This is **not** a reuse of `compute_impact`, which projects over an `ObjectDiff` (objects that themselves changed). `impacted-by` asks the inverse question over current knowledge, so it adds a sibling pure function `impacted_objects(objects, changed_paths)` in `domain/review/impact.rs`, reusing the already-factored `impact_entry_for`. No recompile, no snapshot worktree — a graph-artifact read like V6.1/V6.2.
+- Proof obligations: reuse `obligations_for_impact` so each impacted verified object carries its impact-review obligation in the envelope.
+- New wire envelope `adoc.impacted.v0`: `{ schema_version, changed_paths, impacted: [{ id, kind, status, owner?, reasons: [{ kind: "impacts_path"|"evidence_path", matched_path, via_source_object? }] }], proof_obligations[], diagnostics }`. Sorted by id; deterministic.
+- `--format auto|plain|styled|json|markdown` — markdown reuses the V3.5 presenter conventions for PR comments.
+- JSON Schema, MCP tool `adoc_impacted_by`, `adoc://agent/v0/review-workflow` update.
+
+Acceptance: against the V3.3 billing-pilot impact fixture, `adoc impacted-by crates/billing/src/refund.rs --format json` exits 0 and reports the verified claim declaring that path under `reasons[].kind: "impacts_path"` with one impact-review obligation. `adoc impacted-by --ref main` over the V3 two-commit fixture produces the same impacted set as `adoc review main`'s `impact[]`.
+
+Deferred: relation-cascade impact (`depends_on` propagation), glob `impacts:` paths, linked-test execution, API-schema change detection.
+
+### V6.4: Patch Apply Slice
+
+Goal: apply validated patches to `.adoc` source via formatting-preserving span splices — atomic, re-checked, never auto-reverted. Closes PRD §7.7 and §21.7 and resolves V2's create-placement open question.
+
+A ground truth that shapes this slice: typed-block close-fence spans are not retained today (`ParsedTypedBlock.span` is the open-fence line only; graph spans are start-only with no byte length). The graph artifact therefore **cannot drive splicing and must not be asked to**. Apply always re-parses current source and splices against fresh parser spans, using byte offsets (`SourcePosition.offset`) exclusively — parser columns are char-based and must never be used to reconstruct positions.
+
+Structured as tracer bullets, mirroring V5.10:
+
+- **TB1 — span foundation + splice engine + `update_fields`/`replace_body`.** Parser extension: retain the close-fence span on `ParsedTypedBlock` so a block's full byte range is recoverable (behavior-preserving for everything existing). New pure domain module `domain/source_edit/` with `SpanEdit { byte_range, replacement }`, `SourceEditPlan` (sorted, non-overlapping; factory rejects overlap), and `splice()` — every byte outside the edited ranges preserved identically, by construction. New `application/apply.rs` orchestration: load graph → existing V2 patch validation, unchanged → recompile the working tree in memory → **source-drift gate** (below) → plan edits → write through a new `pub(crate)` `WorkspaceWriter` port → post-apply re-check → envelope. CLI: `adoc patch --apply <path-or-@-stdin>`; bare `adoc patch` keeps `--check` behavior. `update_fields` rewrites only the targeted field-value spans (new keys insert one `key: value` line after the last field line); `replace_body` replaces only the region between `--` and the closing `::`.
+- **TB2 — relation ops.** `supersede` and `revoke` apply as field-line edits (status value, `supersedes:` value) with the same splice discipline.
+- **TB3 — `create_object` placement semantics.** The validated `PlacementHint { page_id, after }` already exists on `adoc.patch.v0` — no wire change. V6 defines its apply semantics: `page_id` resolves to a file via the page node's `source_path`; `after: <id>` inserts immediately after that block's close fence; `after` absent appends at end of file. Created objects are inserted as a complete typed block with deterministic (sorted) field order and a separating blank line. New rules: `patch.create_missing_placement` (WARNING on `--check`, ERROR on `--apply`) and `patch.placement_not_adoc` (placement page must be an `.adoc` source — `.md` pages cannot host typed blocks). New-file creation is deferred.
+- **TB4 — gated MCP `adoc_patch_apply`.** New optional config block in `agentdoc.config.yaml`: `mcp: { patch_apply: enabled }` — default when absent is disabled, and `adoc init` does not write the key. The tool is **registered always**; when disabled it returns a normal `applied: false` envelope with one fix-oriented diagnostic naming the config key and noting that `adoc_patch_check` remains available. Project-root sandbox (`resolve_write_path`) and `base_hash` preconditions apply identically over MCP. New guidance resource `adoc://agent/v0/patch-apply-guide` (propose → check → apply → re-check → cite the post-check) plus JSON Schema resource. `adoc.project.status.v0` gains an additive readiness boolean `patch_apply_enabled` so agents can check the gate before constructing a patch. Every doc that promises "MCP does not apply patches" is updated in this TB: `docs/agent/v0/usage-contract.md`, `docs/agent/v0/review-workflow.md`, `docs/agent/v0/schema/patch.md`, `docs/agent/v0/schema/review.md` (reworded to scope the promise to review), `docs/mcp-agent-gateway.md`, and the two `CONTEXT.md` entries. The pinned v0 propose-patch prompt stays byte-stable per ADR-0014; an apply-aware v1 prompt is added alongside it.
+- **TB5 — Expanded Pilot full-loop proof.** End-to-end test driving the loop: `adoc impacted-by` flags a claim → a patch proposes a body update → `adoc patch --apply` rewrites exactly the body span (asserted byte-exact against a golden file) → post-check clean → `adoc stale` / `adoc contradictions` outputs unchanged → a second apply of the same patch fails with the existing stale-`base_hash` diagnostic and writes nothing.
+
+Freshness is a two-layer precondition — the load-bearing invariant of this slice:
+
+1. `base_hash` vs graph: the existing V2 check, unchanged. It proves the proposer saw the latest artifact.
+2. Graph vs source (new, apply-time): the in-memory recompile must reproduce the graph's `content_hash` for the target object, else apply refuses with new diagnostic `patch.source_drift` ("source changed since last build; run adoc build and re-propose"). `base_hash` alone cannot catch a stale artifact over moved-on source. The recompile also supplies the fresh spans the planner needs, so it is not extra cost.
+
+Atomicity and post-check: writes are per-file temp file in the same directory, fsync, rename; the on-disk file is re-hashed immediately before rename and apply refuses on mismatch (TOCTOU guard; cross-process locking is an explicit non-goal). After the rename, apply re-runs the compile/check pipeline in memory and embeds all resulting diagnostics. **No artifact files are rewritten** — `dist/docs.graph.json` is stale by design after an apply; the envelope says so (`artifacts_stale: true`) and agents run `adoc build` or `adoc_project_status refresh: "build"`. Never auto-revert, even when post-check reports errors: AgentDoc does not decide to undo; the human and Git do.
+
+New wire envelope `adoc.patch.apply.v0`:
+
+```json
+{
+  "schema_version": "adoc.patch.apply.v0",
+  "applied": true,
+  "target": "billing.credits.consume",
+  "operation": "replace_body",
+  "check": { "...embedded adoc.patch.check.v0..." },
+  "written_files": [
+    { "path": "docs/billing.adoc", "before_file_hash": "sha256:...", "after_file_hash": "sha256:..." }
+  ],
+  "object": { "before_content_hash": "sha256:...", "after_content_hash": "sha256:..." },
+  "post_check": { "ran": true, "error_count": 0, "warning_count": 1, "diagnostics": ["..."] },
+  "artifacts_stale": true,
+  "proof_obligations": ["..."],
+  "trace": { "interface": "cli", "proposer": { "kind": "...", "id": "..." } },
+  "diagnostics": []
+}
+```
+
+Refusals (validation failure, source drift, disabled gate) are the same envelope with `applied: false`, empty `written_files`, and fix-oriented diagnostics — never a protocol error. Exit codes: `0` applied and post-check clean; `1` refused, nothing written; `2` applied but post-check reports new errors — agents must treat `2` as "stop and surface to a human".
+
+Acceptance: a `replace_body` patch against an Expanded Pilot claim exits 0, the source file differs from the original in exactly the body lines (golden-file byte comparison; `git diff` shows only that hunk), and the envelope reports `check.valid: true` with `post_check.error_count: 0`. The same patch re-run exits 1 with the stale-`base_hash` diagnostic and no write. A `create_object` patch without placement exits 1 under `--apply` with `patch.create_missing_placement`. With the config key absent, MCP `adoc_patch_apply` refuses naming `mcp.patch_apply`; with `patch_apply: enabled`, it returns the same `adoc.patch.apply.v0` envelope as the CLI.
+
+Deferred: multi-patch transactions (one patch document, one target, one file write per apply), new-file creation via placement, auto-revert or rollback commands, patch application via `adoc review`, hosted approval state, permission engine (proposer metadata is recorded, not enforced).
+
+Design guidance:
+
+- Splicing math is pure and unit-tested against off-by-one fence cases; parsing stays in infrastructure; orchestration mirrors `application/patch.rs`'s reader-injected style.
+- Apply compiles source at apply time; it never trusts spans from a previously written artifact. `base_hash` protects against semantic staleness; fresh compilation protects against positional staleness.
+- Required property tests: splicing an empty plan is byte-identical; all bytes outside edited ranges unchanged; recompiling the spliced file yields exactly the intended `ObjectChange` and nothing else in `ObjectDiff::compute`; re-applying the same patch fails on `base_hash`, never double-writes; one targeted multibyte-field test guards the char/byte offset boundary.
+- Keep `adoc.patch.v0` at v0 — placement semantics and the two new diagnostics are additive.
+- The post-check is reported, never acted on.
+- Note on config back-compat: `agentdoc.config.yaml` parsing uses `deny_unknown_fields`, so a project that opts into `mcp.patch_apply` becomes unreadable by pre-V6 binaries. That failure is loud and only bites users who opted in; document it, do not bump the config version for it.
+
+Questions to resolve later:
+
+- Should `adoc stale` and `adoc impacted-by` learn `--fail-on` thresholds for CI, and does that belong in those commands or in `adoc review`?
+- Should apply refuse when the target file has uncommitted Git changes, or is `base_hash` + source-drift + fresh compile enough? (V6 says enough; revisit on real corruption reports.)
+- When `create_object` needs a new file, what names it — the placement hint or a config convention?
+- Should `requested_status` on a patch (PRD §7.7) be honored at apply time, or remain a review hint?
+- Does the apply loop need rate limiting or an append-only local audit log before V7's agent activity log?
+
+---
+
+## V6.5: Vocabulary Completion
+
+V6.5 adds the four remaining PRD §13 kinds — `api`, `observation`, `question`, `task` — completing the fifteen-kind vocabulary. Every slice follows the established V5 pattern verbatim: fallible aggregate constructor owning required-field invariants in `domain/knowledge_object/`, value objects in `domain/value_objects/`, `RESOLVERS` registration, `BlockKind` variant, draft support (so `create_object` patches work day one), `FieldChange` variants, distinct HTML rendering, graph emission, retrieval/diff/review coverage.
+
+**Graph artifact: bump to `adoc.graph.v4`, folding in the graph-side half of the ADR-0035 cleanup.** New `kind` strings in the payload demand a loud version per the ADR-0028 precedent, and a bump forces a full rebuild + re-embed anyway, so this is the cheapest moment to execute the planned cleanup: `status` becomes lifecycle-only (absent for `warning`/`constraint`/`agent_instruction`, where it carried Severity/Trust), and `severity`/`trust` become the sole carriers, entering the hash payload as authored fields. All `base_hash` values regenerate with the rebuild; in-flight patches fail loudly via the existing base-hash mismatch, which is the designed behavior. The envelope-side half of ADR-0035 (typed `FieldChange` payloads) stays deferred so `adoc.diff.v0` and `adoc.review.v0` remain at v0 — the new ADR records this split explicitly so the deferral is a decision, not an accident. The bump lands once, in V6.5.1; afterwards `grep adoc.graph.v3` over the repo must come back empty.
+
+### V6.5.1: API Slice
+
+Goal: introduce the `api` Knowledge Object as a typed API contract (PRD §13.7).
+
+Scope:
+
+- Required: `id`, one of `method` (closed HTTP-method value object, mirroring `Severity`'s fallible-parse pattern) or `interface_type` (open string: `grpc`, `graphql`, ...), one of `path` or `symbol`, `body`. Both one-of invariants live in the constructor, mirroring `source`'s path-XOR-url pattern. `path` validates as a non-empty `/`-prefixed template string — no deeper grammar.
+- Statuses: closed `draft | verified | deprecated` (the ADR-0029 procedure pattern). Verified `api` requires `owner`, `verified_at`, and at least one `api_schema` or `source_code` evidence — an API contract is verified by its schema source, not by human assertion.
+- `evidence_ref` to `source` objects accepted symmetrically with claim/decision; `impacts:` allowed (an api naturally declares its OpenAPI/proto file).
+- Method and path ride the hashed `fields` map — no new graph node slots; dedicated slots are for list-typed values only (the `approved_by` precedent).
+- HTML renders an endpoint signature header — method badge plus path in code style — above the prose body.
+- `FieldChange::ApiMethod`, `FieldChange::ApiPath`; a method or path change on a verified api triggers a re-verify obligation.
+- Diagnostics: `schema.api_missing_method_or_interface_type`, `schema.api_missing_path_or_symbol`, `schema.api_invalid_method`, `api.verified_missing_schema_evidence`.
+
+Acceptance: the PRD §13.7 example (`::api billing.consume-credit` with `method: POST`, `path: /api/billing/credits/consume`, `status: verified`, `source: openapi/billing.yaml#/...`, `owner: backend-platform`) exits 0 and emits `kind: "api"` with method and path preserved. The same block with neither `method:` nor `interface_type:` exits non-zero with `schema.api_missing_method_or_interface_type`. A verified api whose only evidence is `reviewed_by:` exits non-zero with `api.verified_missing_schema_evidence`.
+
+Deferred: OpenAPI/proto schema parsing or drift detection, request/response shape modeling, api-schema-change staleness (PRD §14.4).
+
+### V6.5.2: Observation Slice
+
+Goal: introduce the `observation` Knowledge Object for support, analytics, research, and ops findings (PRD §13.9).
+
+Scope:
+
+- Required: `id`, `status`, `body`. Status is the closed single-value enum `observed` — observations record what was seen; they are never `verified` (the policy precedent: authority comes from elsewhere, here from the data itself). The enum can grow later without breaking authoring.
+- Optional: `source` (free string or `evidence_ref`, consistent with ADR-0027 coexistence), `sample_size` (positive-integer value object `SampleSize`), `observed_at` (date).
+- Observations plug into the V5 evidence model rather than inventing a parallel one; derived `evidence_quality` applies unchanged when evidence is present.
+- HTML renders an observation card with sample size and observed date as metadata chips.
+- Diagnostics: `schema.observation_missing_status`, `schema.observation_invalid_status`, `schema.observation_invalid_sample_size`.
+
+Acceptance: the PRD §13.9 example (`status: observed`, `source: support_tickets`, `sample_size: 37`, `observed_at: 2026-04-30`) exits 0. `sample_size: -3` exits non-zero with `schema.observation_invalid_sample_size`. `status: verified` exits non-zero with `schema.observation_invalid_status`.
+
+Deferred: observation-to-claim promotion workflow, aggregation of repeated observations, analytics integrations.
+
+### V6.5.3: Question Slice
+
+Goal: introduce the `question` Knowledge Object for tracked open questions (PRD §13.10).
+
+Scope:
+
+- Required: `id`, `status`, `body`. Statuses: closed `open | answered`. Optional: `owner`.
+- `answered` requires `resolved_by: <object-id>` referencing an existing `claim` or `decision` — an answered question must point at the knowledge that answered it. This is a cross-aggregate rule, so it lives in `infrastructure/validate/objects/` (the V5.6 contradiction-claims precedent): target exists and has claim/decision kind. The reference emits a graph edge so traversal can walk question → answer.
+- HTML renders open questions with a prominent "Open" badge; answered ones link to the resolving object.
+- `FieldChange::QuestionResolvedBy`; diagnostics `schema.question_missing_status`, `schema.question_answered_missing_resolved_by`, `schema.question_resolved_by_not_found`, `schema.question_resolved_by_wrong_kind`.
+
+Acceptance: the PRD §13.10 example (`owner: product-growth`, `status: open`) exits 0. The same question with `status: answered` and no `resolved_by:` exits non-zero with `schema.question_answered_missing_resolved_by`; with `resolved_by:` naming a `glossary` object, exits non-zero with `schema.question_resolved_by_wrong_kind`.
+
+Deferred: question aging/staleness warnings, question inbox surfaces, auto-suggesting answers from retrieval.
+
+### V6.5.4: Task Slice
+
+Goal: introduce the `task` Knowledge Object for documentation action items (PRD §13.11).
+
+Scope:
+
+- Required: `id`, `status`, `owner`, `body` — task is the only kind beyond policy requiring `owner` unconditionally (a task without an owner is a wish). Statuses: closed `open | done`. Optional: `due` (date). Existing relation fields (`depends_on`, ...) work unchanged, matching the PRD example.
+- New clock-dependent lifecycle warning `task.overdue` (WARNING) when an `open` task's `due` is before today — same `today` threading as the policy review rule, same wide-margin fixture-date discipline.
+- HTML renders a task card with owner, due date, and open/done state.
+- `FieldChange::Due`; diagnostics `schema.task_missing_owner`, `schema.task_missing_status`, `schema.task_invalid_status`, `task.overdue`.
+
+Acceptance: the PRD §13.11 example (`owner: support-ops`, `status: open`, `due: 2026-05-20`, `depends_on: ...`) exits 0 against a pre-due fixture clock and produces the `depends_on` edge in graph JSON. The same task without `owner:` exits non-zero with `schema.task_missing_owner`. An open task with a wide-margin past `due` produces exactly one `task.overdue` warning.
+
+Deferred: surfacing overdue tasks in `adoc.stale.v0` (an additive `category: "task_overdue"` — decide after usage), issue-tracker sync, done-requires-evidence rules.
+
+### V6.5.5: Full-Vocabulary Pilot Slice
+
+Goal: prove the fifteen-kind vocabulary end-to-end, mirroring V5.9.
+
+Scope:
+
+- Extend `examples/expanded-pilot/` with at minimum: one verified `api` with `api_schema` evidence and `impacts:`; one `observation` with `sample_size` and `observed_at`; one `open` and one `answered` question (the latter with `resolved_by`); one `open` task with a wide-margin past `due` (firing `task.overdue`) and one `done` task.
+- Update the exact-match diagnostic budget (expected: 0 errors, 6 warnings — the V5.10 five plus `task.overdue`; confirm at slice start) and the per-kind count table in [expanded-pilot.md](expanded-pilot.md).
+- Extend `expanded_pilot.rs` graph and retrieval assertions for the four new kinds; extend the V6.4 TB5 loop test with one apply against a new-kind object (e.g. marking the task `done` via `update_fields`).
+- Update the "Implemented" sections in [ROADMAP.md](ROADMAP.md) and this file.
+
+Acceptance: `cargo test -p adoc-cli --test expanded_pilot` exits 0 with the documented budget; `dist/docs.html` is hand-reviewed — all fifteen kinds render distinctly.
+
+Deferred: nothing kind-related remains; composition items stay in Later.
+
+Design guidance (milestone-wide):
+
+- One kind per slice, full vertical story per slice — the V5 rule unchanged.
+- Closed status enums per kind; no new kind reuses claim's free-string status.
+- New kinds participate in patch check/apply, diff, review, and retrieval automatically by construction; each slice's tests must assert at least diff (`FieldChange`) and retrieval coverage, not just check/build.
+
+Questions to resolve later:
+
+- Do task and question need richer status enums (`in_progress`, `cancelled`, `retired`), or do the lean pairs hold?
+- Should `observation` grow `archived`, and should very old observations warn?
+- Do tasks belong in `adoc stale` output, in a future `adoc tasks`, or nowhere?
+- Does `api` need structured params/response fields before custom schemas (Later) make that generic?
+
+---
+
+## V1.7: Prose Retrieval
+
+V1.7 indexes prose blocks — headings, paragraphs, lists, code blocks — in BM25 and embeddings, symmetrically across `.adoc` and `.md` sources. The graph artifact already carries prose-block nodes with addressable IDs (`<page-id>#block-NNNN`), text payloads, and source spans for both source modes, so this is a retrieval-pipeline milestone, not a compiler one. The docs have named this milestone V1.7 since the V1 cycle; it keeps that number.
+
+Result-shape decision: `adoc search` returns one blended, RRF-ranked list. Knowledge Objects and prose hits compete honestly; Object ID pins stay on top; ranking stays parameter-free (the V1 rule: lifecycle and quality are filters, not score modifiers — prose gets no boost or penalty). Two contract bumps, both loud per the ADR-0028 philosophy:
+
+- `adoc.retrieval.v0` → **`adoc.retrieval.v1`**: every match gains `record_type: "knowledge_object" | "prose"`; KO records are field-identical to v0; prose records carry `{ record_type: "prose", id, page_id, block_kind, text, heading_context, source: { path, line }, search_match }`. A prose hit cannot honestly masquerade as a `RetrievalRecord` — it has no `content_hash`, no relations, and cannot be fed to `adoc why` — so a discriminated v1 beats tolerant reading.
+- `adoc.search.v0` → **`adoc.search.v1`**: entries gain an `entry_kind: "knowledge_object" | "prose"` discriminator; prose entries derive `content_hash` from canonical prose text (prose has no graph content hash to reuse); the `{ id, content_hash, vector }` shape is otherwise unchanged. A second Embedding Composition is itself a contract change.
+
+`adoc why` and `adoc graph` remain Knowledge-Object-only. The v0 retrieval schema stays published.
+
+### V1.7.1: Prose Lexical Slice
+
+Goal: BM25 over prose blocks, blended with Knowledge Object results.
+
+Scope:
+
+- `GraphIndex` retains prose-block nodes (id → node map plus per-page ordered list) instead of only counting them.
+- The lexical index gains a prose document source: tokenize `text` / `code` / `items`, prefixed with the nearest ancestor heading for context. BM25 statistics are shared across both corpora (one index, two record types) so RRF stays parameter-free.
+- Blended ranking with existing exact/prefix Object ID pins unchanged; new flags `--objects-only` and `--prose-only`.
+- Envelope bump to `adoc.retrieval.v1` as above; JSON Schema published; MCP `adoc_search` returns v1; `adoc://agent/v0/answer-contract` updated — prose hits are orientation context, never citable verified knowledge; agents cite Knowledge Objects.
+- Default behavior: prose results **on** for projects with zero Knowledge Objects (this finally gives `.md`-only projects working search instead of the migration hint), **on** for mixed projects unless `--objects-only` — measured against the pilots before ranking ships.
+- Symmetry rule: identical prose in a `.adoc` file and a `.md` file must rank identically.
+
+Acceptance: in the Markdown Pilot, a query matching only `.md` tutorial prose returns a `record_type: "prose"` match with the correct block id, `heading_context`, and source path, exit 0. The same prose moved to an equivalent `.adoc` fixture returns the same rank. `adoc search "<exact-object-id>"` still pins the Knowledge Object first. `--objects-only` reproduces pre-V1.7 result sets for KO-only queries.
+
+Deferred: embeddings (V1.7.2), `adoc why` on prose node IDs, prose snippets in `adoc graph`.
+
+### V1.7.2: Prose Embedding Slice
+
+Goal: prose vectors in the search artifact.
+
+Scope:
+
+- `docs.search.json` bumps to `adoc.search.v1` with one entry per indexed prose block. Prose Embedding Composition fixed as part of the contract: `prose: {text}` plus a page-id marker line, the analogue of the KO composition. `graph_artifact_hash` drift detection unchanged.
+- Cost controls decided up front: skip blocks under a minimum token threshold; skip `CodeBlock` embeddings (code stays lexical-only); embedding cache keyed by **content hash**, not block ID — order-derived `#block-NNNN` IDs renumber when a block is inserted mid-page, and hash-keyed caching makes renumbering free where ID-keyed caching would re-embed the tail of every edited page.
+- `--no-embeddings` and `embeddings.provider: none` skip prose vectors exactly as they skip KO vectors. Build time and artifact size are recorded on the pilots before/after — this is the milestone's watch item.
+
+Acceptance: building the Markdown Pilot with the deterministic provider produces a v1 search artifact containing prose entries; `adoc search --semantic` returns a prose match for a paraphrase query that lexical search misses (fixture-pinned with deterministic vectors); model-mismatch rejection behaves as in V1.4.
+
+Deferred: chunking long blocks into multiple vectors, ANN indexes, hosted embedding providers.
+
+### V1.7.3: Hybrid Evaluation Slice
+
+Goal: prove blended hybrid quality and pin it with fixtures.
+
+Scope:
+
+- RRF fusion across both record types in hybrid mode, parameter-free.
+- Retrieval-set fixtures extended in the billing and Markdown pilots: queries that must return Knowledge Objects first, queries that legitimately return prose first, and `.adoc`/`.md` symmetry as property-style invariants.
+- [v1-retrieval.md](v1-retrieval.md) maintenance docs updated; the V4 retrieval migration hint retired or downgraded now that prose is searchable.
+
+Acceptance: the extended retrieval-set suite passes; the documented symmetry property holds across all pilot pairs; no existing Knowledge Object retrieval fixture regresses.
+
+Deferred: prose-aware `--related-to` traversal, stable prose anchors that survive edits, prose deduplication across near-identical blocks.
+
+Design guidance:
+
+- Prose node IDs are positional and rebuilt per compile; that is acceptable for retrieval-with-span-citation, and stable prose anchors are explicitly out of scope.
+- Prose hits never satisfy answer-citation requirements on their own; the answer contract keeps verified Knowledge Objects as the only citable authority.
+- Keep the blend honest: if pilots show prose drowning out Knowledge Objects, fix it with filters or fixtures, not with score weights.
+
+Questions to resolve later:
+
+- Should `adoc why` learn prose node IDs, or is span citation in search results enough?
+- When do prose volumes force chunking or an ANN index (measured, per the V1 rule)?
+- Should compat-mode `.md` prose carry a lower default trust marker in retrieval records?
+
+---
+
+## Contract and Versioning Inventory
+
+| Envelope / artifact | Change | Milestone |
+| --- | --- | --- |
+| `adoc.stale.v0`, `adoc.contradictions.v0`, `adoc.impacted.v0` | **new** | V6.1–V6.3 |
+| `adoc.patch.apply.v0` | **new** | V6.4 |
+| `adoc.patch.v0` | unchanged wire; placement apply-semantics documented; two new placement diagnostics | V6.4 |
+| `adoc.patch.check.v0` | unchanged; embedded in the apply envelope | V6.4 |
+| `adoc.project.status.v0` | additive `patch_apply_enabled` readiness | V6.4 |
+| MCP tools / resources / prompts | additive: `adoc_stale`, `adoc_contradictions`, `adoc_impacted_by`, `adoc_patch_apply`, `patch-apply-guide`, apply-aware v1 prompt (v0 prompt byte-stable) | V6 |
+| `agentdoc.config.yaml` | additive optional `mcp.patch_apply` (note `deny_unknown_fields` back-compat) | V6.4 |
+| `adoc.graph.v3` → `adoc.graph.v4` | four new kinds + graph-side ADR-0035 status-slot cleanup | V6.5.1 |
+| `adoc.diff.v0` / `adoc.review.v0` | **unchanged** — typed `FieldChange` payloads deferred again, recorded in the v4 ADR | V6.5 |
+| `adoc.search.v0` → `adoc.search.v1` | prose entries, `entry_kind`, prose Embedding Composition | V1.7.2 |
+| `adoc.retrieval.v0` → `adoc.retrieval.v1` | `record_type` discriminator + prose record shape | V1.7.1 |
+
+ADRs to record at slice start (continuing from ADR-0035):
+
+- **ADR-0036** — Patch application as formatting-preserving span splice: working-tree-only, temp+rename atomicity, two-layer freshness (`base_hash` + `patch.source_drift`), no auto-revert, post-check in the envelope, parser close-fence span extension.
+- **ADR-0037** — MCP `adoc_patch_apply` opt-in via project config: registered-but-refusing posture; supersedes-in-part the "MCP does not apply patches" promises of ADR-0013/0014 and the ADR-0012 "never rewrites source" framing, with the V6.4 TB4 doc inventory as the migration checklist.
+- **ADR-0038** — Lifecycle-signal read commands as graph-artifact readers: three envelopes, read-time re-derivation of `effective_status`, `impacted_objects` as a sibling of (not a reuse of) `compute_impact`.
+- **ADR-0039** — `adoc.graph.v4`: additive kind expansion plus the graph-side status-slot cleanup in one bump; explicit re-deferral of the diff/review typed-payload half of ADR-0035.
+- **ADR-0040** — Prose retrieval contracts: `adoc.search.v1`, `adoc.retrieval.v1`, prose Embedding Composition, hash-keyed embedding cache, order-derived prose ID stance.
+
+## Risks and Invariants
+
+Top risks:
+
+1. **Span drift (graph vs source).** Graph spans are start-only and build-stale. Mitigation is structural: apply never splices from artifact spans; it re-parses and additionally requires the recomputed `content_hash` to equal the graph's (`patch.source_drift` refusal). `base_hash` alone only proves the agent saw the latest artifact.
+2. **Concurrent edits (TOCTOU).** Read file bytes once, plan and splice against those exact bytes, re-hash the on-disk file immediately before rename, refuse on mismatch; temp+rename prevents torn writes. Cross-process locking is an explicit non-goal — documented.
+3. **Lossy rewrite breaking byte-identity.** Held by the V6.4 property tests (empty-plan identity, outside-range preservation, `ObjectDiff` exactness, idempotence-fails-on-base-hash).
+4. **Char/byte confusion.** Parser columns are char-based; splicing uses `SourcePosition.offset` bytes only, guarded by a multibyte test.
+5. **Order-derived prose IDs (V1.7).** Insertions renumber downstream block IDs — citation drift is accepted and documented for v1 prose records; the embedding cache is hash-keyed so renumbering costs nothing.
+6. **Post-check errors after apply.** Workspace-level rules (duplicate IDs, broken refs) surface only post-write. `applied: true` with post-check errors must be unmissable (exit code 2); never auto-revert.
+
+Invariants that must hold across all three milestones:
+
+- `content_hash` determinism: canonical-JSON hash payload; derived fields (`effective_status`, `evidence_quality`) stay excluded exactly as ADR-0033/0034/0035 define; in v4, `severity`/`trust` enter the payload as authored carriers.
+- Source-as-canonical: apply mutates `.adoc` source and re-derives; it never edits `docs.graph.json` or any artifact directly; artifacts go stale loudly (`artifacts_stale: true`).
+- Schema-version loud rejection: every new envelope and all three bumps reuse the existing exact-match `SchemaUnsupportedVersion` pattern.
+- Additive bumps: untouched node/edge/record shapes byte-identical across `v3→v4` and `search`/`retrieval` `v0→v1`, verified by golden fixtures.
+- Working-tree-only writes; one file per patch; no Git mutations; project-root sandbox on every write path.
+- Gate posture: `adoc_patch_apply` registered always, refusing with a fix-oriented message when disabled; the CLI apply path is ungated.
+
+## Later / Explicitly Not Now
+
+- **Composition (formerly "V6")**: `@include` with circular detection, nested typed blocks, custom schema registry (PRD §29), automated contradiction detection (PRD §27), SQLite or embedded graph stores. Postponed until the editing loop and full vocabulary are proven in real use; the design guidance and open questions recorded in [ROADMAP.md](ROADMAP.md) under the old V6 section remain valid.
+- **V4.5 Markdown migration** (`adoc migrate`, suggested-claim extraction, `adoc.migrate.report.v0`): still waiting on measured compat-mode friction. PRD MVP must-have #18 — the last unfinished MVP item.
+- **V7 web and governance**: object explorer, review dashboard, agent activity log, SSO/RBAC/audit. Unchanged.
+- **Example sandbox execution**: `checks`/`sandbox` remain declaration-only per V5.3.
+- **Permission engine**: PRD §17 agent permissions stay unenforced. V6 records proposer metadata and gates agent writes behind a single config switch; per-agent, per-scope authorization is a V7-class problem.

--- a/docs/ROADMAP-V6.md
+++ b/docs/ROADMAP-V6.md
@@ -40,7 +40,7 @@ V6 closes the loop opened by V2. Three new read commands expose the V5.10 derive
 
 ### V6.1: `adoc stale` Slice
 
-Goal: give the V5.10 stale and review-overdue signals a first-class query surface.
+Goal: give the V5.10 stale and review-overdue signals a first-class query surface. Implemented (ADR-0038, [V6-DESIGN.md](V6-DESIGN.md) §V6.1).
 
 Scope:
 

--- a/docs/V6-DESIGN.md
+++ b/docs/V6-DESIGN.md
@@ -1,0 +1,101 @@
+# V6 Design
+
+This document is the implementation contract for V6: the Agent Editing Loop. It is the V5-DESIGN equivalent for the [ROADMAP-V6.md](ROADMAP-V6.md) cycle. Per the roadmap, contract sections are recorded **at slice start** — this file grows one section per slice rather than being written all at once. Sections for slices that have not started are stubs.
+
+V6 closes the loop opened by V2: three new read commands expose the V5.10 derived lifecycle signals and source-path impact (V6.1–V6.3), then patch application makes every already-validated op family actually rewrite `.adoc` source via formatting-preserving span splices (V6.4). The architectural choices live in ADR-0038 (lifecycle-signal read commands as graph-artifact readers) and, when V6.4 starts, ADR-0036/0037.
+
+## Goals
+
+- Give the V5.10 derived signals (stale, review-overdue, contradicted) and source-path impact a first-class query surface without recompiling.
+- Keep all three read commands graph-artifact readers: no compile, no snapshot worktree, no source access.
+- Re-derive clock-dependent signals **at read time** from authored fields — an artifact built last week must not report stale-as-of-build-time.
+- Queries are not gates: exit 0 whether or not records exist; non-zero only for operational failures (artifact missing/unreadable/unsupported).
+- Every new envelope is a versioned, JSON-Schema'd, contract-tested wire surface per ADR-0015, with a paired MCP tool.
+
+## Non-Goals (V6.1–V6.3)
+
+- **No CI gating flags.** `--fail-on-stale` thresholds are an open question in the roadmap, not part of these slices.
+- **No health scores** (PRD §14.5).
+- **No automated contradiction detection** — `adoc contradictions` (V6.2) lists manually authored contradictions only.
+- **No staleness from linked-source change** — that is `adoc impacted-by`'s job (V6.3), and it is impact, not staleness.
+- **No writes of any kind.** Apply lands in V6.4 under its own ADRs.
+
+## V6.1: `adoc stale` — Implemented
+
+### Wire contract
+
+`adoc.stale.v0`, emitted by `adoc stale` and the MCP tool `adoc_stale`:
+
+```json
+{
+  "schema_version": "adoc.stale.v0",
+  "evaluated_at": "2026-06-11",
+  "records": [
+    {
+      "id": "security.audit.retention",
+      "kind": "claim",
+      "category": "stale",
+      "authored_status": "verified",
+      "effective_status": "stale",
+      "reason": "expired:2024-01-01",
+      "expires_at": "2024-01-01",
+      "days_overdue": 892,
+      "owner": "security-lead",
+      "source_path": "examples/expanded-pilot/security/policies.adoc"
+    }
+  ],
+  "diagnostics": []
+}
+```
+
+JSON Schema: `docs/agent/v0/schema/adoc.stale.v0.schema.json` (resource `adoc://agent/v0/schema/adoc.stale.v0.schema.json`); prose reference `docs/agent/v0/schema/stale.md` (resource `adoc://agent/v0/schema/stale`). Contract-tested in `crates/adoc-mcp/tests/contract_schemas.rs` with all three categories and the empty-records case.
+
+### Category derivation rules
+
+All derivation happens at read time against `evaluated_at` (the query date, obtained from the local clock at the single `local_today()` entry point in `application/mod.rs`). The persisted `effective_status` projection on graph nodes is **never** consulted.
+
+| Category | Rule | `days_*` | `reason` |
+| --- | --- | --- | --- |
+| `stale` | `expires_at < evaluated_at`, **any** authored status (matching the compile-time `lifecycle.expired` rule's breadth) | `days_overdue = evaluated_at − expires_at` | `expired:<expires_at>` |
+| `review_overdue` | `kind == policy && status == active && effective_at + review_interval < evaluated_at` (the `PolicyReviewDrift` arithmetic, strict `<`) | `days_overdue = evaluated_at − next_review` | `review_due:<next_review>` |
+| `expiring_soon` | only with a horizon (CLI `--within <N>d`, MCP `within_days`): authored `verified` and `evaluated_at <= expires_at <= evaluated_at + N` | `days_remaining = expires_at − evaluated_at` | `expires:<expires_at>` |
+
+`effective_status` on a record is the read-time re-derivation (`derive_effective_status_from_fields`: verified + expired → `"stale"`); when no derivation applies it **echoes the authored status** (a draft expired claim reads `authored_status: "draft", effective_status: "draft"` — listed by category, unchanged by derivation).
+
+Note the deliberate asymmetry: **category-stale is broader than effective-status-stale.** Any object with a past expiry is listed (the lifecycle.expired breadth); only verified objects re-derive `effective_status: "stale"` (the ADR-0033 rule).
+
+### Determinism and sorting
+
+Records sort most-overdue first, then Object ID ascending, then a fixed category ordinal (stale < review_overdue < expiring_soon) as the final tiebreak. The sort key is a signed urgency: `+days_overdue` for overdue categories (≥ 1 by the strict `<` rules), `−days_remaining` for expiring_soon (≤ 0) — so all overdue records always precede all expiring-soon records. One object can yield two records (an expired active policy that is also overdue for review); the category ordinal keeps that deterministic.
+
+### Edge cases (decided)
+
+- `expires_at == evaluated_at` is **not** stale (strict `<`, consistent with `derive_effective_status`) but **is** `expiring_soon` under `--within 0d` with `days_remaining: 0`.
+- Unparseable `expires_at` / `effective_at` / `review_interval` values: the object is skipped silently for that rule — compile already warned (`lifecycle.invalid_expires_at` etc.); a graph-artifact reader cannot improve on that.
+- Policy missing `review_interval`: exempt (the `PolicyReviewDrift` precedent). The review rule is gated to `kind == "policy" && status == "active"`; other kinds carrying those fields are ignored.
+- `--within` horizon overflowing the date range (`checked_add_days` → `None`): treated as unbounded, not an error.
+- ADR-0035 slot overload: `authored_status` echoes the artifact's `status` slot, which carries Severity/Trust for `warning`/`constraint`/`agent_instruction` until the `adoc.graph.v4` cleanup. No special-casing.
+
+### Surfaces
+
+- **CLI:** `adoc stale [--artifact <path>] [--within <N>d] --format auto|plain|styled|json`. The `--within` grammar is `[0-9]+d` (the `review_interval` shape), parsed by the CLI; everything below the CLI takes `within_days: Option<u32>`. Markdown format stays diff/review-only.
+- **MCP:** `adoc_stale { project_root?, artifact?, within_days? }` returning the envelope directly (the `adoc_graph` precedent — no command-envelope wrapper).
+- **Exit codes:** `0` with or without records; `2` on artifact-load failure (missing file, malformed JSON, `SchemaUnsupportedVersion`), with the same envelope shape, empty `records`, and fix-oriented diagnostics. There is no not-found exit (no object-id argument).
+
+### Module layout
+
+- `crates/adoc-core/src/application/signals.rs` — categories, records, envelope, pure `evaluate_stale_for_date` (will also host V6.2 `adoc contradictions`).
+- `crates/adoc-core/src/infrastructure/artifact/graph_json.rs` — `derive_effective_status_from_fields`, the field-string core extracted from the V5.10 `derive_effective_status` so build-time and read-time derivation share one implementation.
+- `crates/adoc-local/src/use_cases.rs` — `StaleUseCase` mirroring the graph use case (artifact resolution via config, path policy, exit codes).
+- `crates/adoc-cli/src/commands/stale.rs` — thin subcommand with plain/styled/json presenters.
+- `crates/adoc-mcp/src/lib.rs` — `adoc_stale` tool; resources registered in `resources.rs`.
+
+### Acceptance (pinned in tests)
+
+Against the Expanded Pilot (`crates/adoc-cli/tests/expanded_pilot.rs::expanded_pilot_stale_query`): exactly 3 records in clock-stable order — `security.production-db-access` (`review_overdue`, due 2020-03-31), `security.audit.retention` (`stale`, verified → stale), `billing.credits.legacy-export` (`stale`, draft, echo) — and `--within 36500d` adds `billing.credits.consume` (expires 2120-01-01) then `auth.mfa.enforced` (expires 2125-01-01) as `expiring_soon`.
+
+## V6.2: `adoc contradictions` — contract recorded at slice start
+
+## V6.3: `adoc impacted-by` — contract recorded at slice start
+
+## V6.4: Patch Apply — contract recorded at slice start (ADR-0036, ADR-0037)

--- a/docs/adr/0038-lifecycle-signal-read-commands.md
+++ b/docs/adr/0038-lifecycle-signal-read-commands.md
@@ -1,0 +1,90 @@
+# ADR-0038: Lifecycle-Signal Read Commands as Graph-Artifact Readers
+
+**Status:** Accepted
+**Date:** 2026-06-11
+**Slice:** V6.1 (`adoc stale`); forward-records the shared design for V6.2 (`adoc contradictions`) and V6.3 (`adoc impacted-by`)
+
+Recorded out of numeric order deliberately: ADR-0036 (patch application as
+formatting-preserving span splice) and ADR-0037 (MCP `adoc_patch_apply`
+opt-in) are reserved for V6.4 per the [ROADMAP-V6.md](../ROADMAP-V6.md) ADR
+inventory.
+
+## Context
+
+V5.10 added derived lifecycle signals — `effective_status: "stale"` on
+verified-expired nodes, `effective_status: "contradicted"` on claims named by
+unresolved contradictions, the `schema.policy_review_overdue` warning — but
+they exist only inside graph nodes and check diagnostics. There is no query
+surface: an agent that wants "what knowledge is suspect right now?" has to
+parse `dist/docs.graph.json` itself, which the agent usage contract forbids
+(ADR-0013).
+
+Two properties make the design non-obvious:
+
+1. **Artifacts are build-stale by nature.** The persisted `effective_status`
+   was derived against the build date. An artifact built last week must not
+   report stale-as-of-build-time when queried today.
+2. **V3's `compute_impact` answers the wrong direction.** It projects over an
+   `ObjectDiff` — objects that themselves changed. "This code path changed —
+   which *current* knowledge is implicated?" is the inverse question over the
+   current graph, not a diff.
+
+## Decision
+
+The V6.1–V6.3 commands (`adoc stale`, `adoc contradictions`,
+`adoc impacted-by`) are **read-only graph-artifact readers** in the
+`why`/`graph`/`search` session mold:
+
+1. **No compile, no source access, no snapshot worktree.** Each command loads
+   `dist/docs.graph.json` through the existing `ArtifactReader` port and the
+   `GraphSession` index. Operational failures (missing artifact, malformed
+   JSON, `SchemaUnsupportedVersion`) surface through the existing diagnostics
+   with exit code 2.
+2. **Clock-dependent signals are re-derived at read time.** The shared
+   derivation core is extracted as
+   `derive_effective_status_from_fields(status, expires_at, today)` in
+   `infrastructure/artifact/graph_json.rs`; the build-time
+   `derive_effective_status` delegates to it, so build and read can never
+   disagree on the rule. The evaluation date enters once, via the hoisted
+   `application::local_today()`, and every envelope carries `evaluated_at`.
+   The persisted `effective_status` projection is never consulted at read
+   time.
+3. **Queries, not gates.** Exit code 0 whether or not records exist. Findings
+   are data in a versioned envelope (`adoc.stale.v0`,
+   `adoc.contradictions.v0`, `adoc.impacted.v0`), JSON-Schema'd and
+   contract-tested per ADR-0015, each with a paired MCP tool.
+4. **One module hosts the signal logic.** `application/signals.rs` owns the
+   pure evaluation functions (`evaluate_stale_for_date` now; the
+   contradictions listing next), keeping the session-loading pattern and the
+   sorting/determinism rules in one place.
+5. **`impacted_objects` will be a sibling of `compute_impact`, not a reuse.**
+   V6.3 adds a pure `impacted_objects(objects, changed_paths)` in
+   `domain/review/impact.rs` answering the inverse-direction question over
+   current knowledge, sharing `impact_entry_for` but not the diff projection.
+
+For `adoc stale` specifically (V6.1, implemented): the `stale` category lists
+**any** object with a past `expires_at` — matching the compile-time
+`lifecycle.expired` rule's breadth — while the record's `effective_status`
+re-derives `"stale"` only for verified objects (the ADR-0033 rule) and
+otherwise echoes the authored status. Records sort most-overdue first, then
+Object ID, then a fixed category ordinal. The full rule table, edge cases, and
+surfaces are pinned in [V6-DESIGN.md](../V6-DESIGN.md).
+
+## Consequences
+
+- Agents get lifecycle truth as of the query date from week-old artifacts;
+  only structural changes (new objects, edited fields) require a rebuild.
+- The same authored fields are interpreted by exactly one derivation
+  implementation in two phases (build emission and read queries); a rule
+  change automatically affects both, with the shared function unit-tested
+  directly.
+- Read commands inherit the artifact contract: anything the graph does not
+  carry (e.g. fields of `.md` prose pages) is invisible to them by design.
+- The ADR-0035 status-slot overload leaks into `authored_status` for
+  `warning`/`constraint`/`agent_instruction` records until the
+  `adoc.graph.v4` cleanup (V6.5.1); documented in the schema reference, not
+  special-cased.
+- Exit-code semantics diverge intentionally from `adoc check`: a project full
+  of stale knowledge still exits 0 from `adoc stale`. CI gating, if demanded,
+  is a future `--fail-on` decision recorded as an open question in the
+  roadmap.

--- a/docs/agent/v0/schema/adoc.stale.v0.schema.json
+++ b/docs/agent/v0/schema/adoc.stale.v0.schema.json
@@ -1,0 +1,70 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adoc://agent/v0/schema/adoc.stale.v0.schema.json",
+  "title": "AgentDoc Stale Query",
+  "description": "Lifecycle-signal listing of stale, review-overdue, and (with a within horizon) expiring-soon Knowledge Objects, re-derived from authored fields at read time against `evaluated_at`. Emitted by `adoc stale` and the `adoc_stale` MCP tool. Records are sorted most-overdue first, then by Object ID. See ROADMAP-V6.md §V6.1 and ADR-0038.",
+  "type": "object",
+  "required": ["schema_version", "evaluated_at", "records", "diagnostics"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "adoc.stale.v0" },
+    "evaluated_at": {
+      "description": "The date staleness was derived against (the query date, never the artifact's build date).",
+      "type": "string",
+      "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+    },
+    "records": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/staleRecord" }
+    },
+    "diagnostics": {
+      "description": "Artifact-load diagnostics. Stale records themselves are data, not diagnostics.",
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  },
+  "$defs": {
+    "staleRecord": {
+      "type": "object",
+      "required": ["id", "kind", "category", "reason", "source_path"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "kind": { "type": "string" },
+        "category": {
+          "description": "stale: `expires_at` is past (any authored status). review_overdue: active policy past `effective_at + review_interval`. expiring_soon: verified object expiring within the requested horizon.",
+          "enum": ["stale", "review_overdue", "expiring_soon"]
+        },
+        "authored_status": {
+          "description": "The status slot as authored. For warning/constraint/agent_instruction this slot carries Severity/Trust until the adoc.graph.v4 cleanup (ADR-0035).",
+          "type": "string"
+        },
+        "effective_status": {
+          "description": "Re-derived at read time; echoes the authored status when no derivation applies.",
+          "type": "string"
+        },
+        "reason": {
+          "description": "Machine-readable cause: `expired:<date>`, `review_due:<date>`, or `expires:<date>`.",
+          "type": "string",
+          "pattern": "^(expired|review_due|expires):\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "expires_at": {
+          "type": "string",
+          "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
+        },
+        "days_overdue": {
+          "description": "Days past expiry / past the review due date. Present on stale and review_overdue records.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "days_remaining": {
+          "description": "Days until expiry. Present on expiring_soon records.",
+          "type": "integer",
+          "minimum": 0
+        },
+        "owner": { "type": "string" },
+        "source_path": { "type": "string" }
+      }
+    }
+  }
+}

--- a/docs/agent/v0/schema/stale.md
+++ b/docs/agent/v0/schema/stale.md
@@ -1,0 +1,17 @@
+# AgentDoc Stale Query Schema
+
+The V6.1 lifecycle-signal query surface is `adoc.stale.v0`.
+
+Stale envelopes are returned by `adoc stale` and the `adoc_stale` MCP tool. The envelope lists Knowledge Objects whose lifecycle signals warrant attention, derived from the graph artifact **at read time** against the `evaluated_at` date — never from the artifact's build-time `effective_status` projection, so a week-old artifact still reports staleness as of the query date.
+
+Three record categories, all from one artifact pass:
+
+- `stale` — the object's `expires_at` is strictly before `evaluated_at`. Listed for **any** authored status (matching the compile-time `lifecycle.expired` rule); the record's `effective_status` re-derives `stale` only for verified objects and otherwise echoes the authored status.
+- `review_overdue` — an `active` policy whose `effective_at + review_interval` is strictly before `evaluated_at`, with `days_overdue` counted from that due date.
+- `expiring_soon` — only with a `within` horizon (CLI `--within <N>d`, MCP `within_days`): a verified object whose `expires_at` falls between `evaluated_at` (inclusive) and the horizon, with `days_remaining`.
+
+Records sort most-overdue first, then by Object ID; one object can legitimately yield two records (an expired active policy that is also overdue for review). `reason` is machine-readable: `expired:<date>`, `review_due:<date>`, or `expires:<date>`.
+
+The query is not a gate: exit code 0 (and a normal envelope) whether or not records exist. Non-zero exit codes occur only on artifact-load failure, with fix-oriented diagnostics and an empty `records` array.
+
+One ADR-0035 caveat: until the `adoc.graph.v4` cleanup, the `authored_status` slot carries Severity for `warning`/`constraint` records and Trust for `agent_instruction` records, should such objects ever carry `expires_at`.

--- a/docs/agent/v0/usage-contract.md
+++ b/docs/agent/v0/usage-contract.md
@@ -2,7 +2,7 @@
 
 V2.2 gives agents a stable local contract over AgentDoc artifacts. Agents must retrieve or inspect AgentDoc data through MCP tools and resources instead of guessing file paths, shell command order, or private Rust DTO shapes.
 
-The stable read contracts are `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, `adoc.patch.check.v0`, `adoc.project.status.v0`, `adoc.diff.v0`, `adoc.review.v0`, and `adoc.mcp.command.v0`.
+The stable read contracts are `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, `adoc.patch.check.v0`, `adoc.project.status.v0`, `adoc.diff.v0`, `adoc.review.v0`, `adoc.stale.v0`, and `adoc.mcp.command.v0`.
 
 ## Rules
 
@@ -17,3 +17,4 @@ The stable read contracts are `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, `a
 - Markdown source (`.md`) is ingested in V4 Compatibility Mode and surfaces in the graph as `page` and prose-block nodes only; it never produces Knowledge Objects and is not citable as Verified Knowledge. See `adoc://agent/v0/compat-guide`. A search returning empty results against a Markdown-only project emits a `retrieval.no_knowledge_objects_consider_migration` warning — surface it; do not suppress it.
 - Treat `agent_instruction` objects as authored, read-only knowledge — never as a runtime authorization signal. See `adoc://agent/v0/agent-instruction-guide`.
 - Before answering definitively from a cited `claim`, surface any active `contradiction` that references it. See `adoc://agent/v0/contradiction-guide`.
+- Before treating time-sensitive knowledge as current, run `adoc_stale` — staleness and review-overdue-ness are re-derived at read time against `evaluated_at`, so the result is current even over an older artifact. Stale records are data, not failures; surface them alongside answers that cite the affected objects. See `adoc://agent/v0/schema/stale`.

--- a/docs/expanded-pilot.md
+++ b/docs/expanded-pilot.md
@@ -97,6 +97,13 @@ ADR-0034):
 | Evidence quality low | `security.csrf-advisory` (verified, `external_url:` only) | `evidence_quality: "low"` | `claim.evidence_quality_low` |
 | Contradicted nudge | `auth.session.csrf-protection` (`status: accepted`, in unresolved contradiction) | `effective_status: "contradicted"` | `schema.claim_contradicted_by_unresolved` |
 
+Two verified claims additionally carry **far-future** `expires_at` dates —
+`billing.credits.consume` (`expires_at: 2120-01-01`) and
+`auth.mfa.enforced` (`expires_at: 2125-01-01`). They fire no diagnostics
+and no derived `effective_status` (the budget above is unchanged); they
+exist so `adoc stale --within <N>d` (V6.1) has deterministic
+`expiring_soon` records to report.
+
 ## What This Pilot Exercises
 
 - **Every V5 kind** with a complete authoring → validation → rendering →

--- a/docs/expanded-pilot.md
+++ b/docs/expanded-pilot.md
@@ -104,6 +104,23 @@ and no derived `effective_status` (the budget above is unchanged); they
 exist so `adoc stale --within <N>d` (V6.1) has deterministic
 `expiring_soon` records to report.
 
+## V6.1 `adoc stale` Acceptance
+
+The pilot is also the acceptance fixture for the V6.1 stale query
+(`crates/adoc-cli/tests/expanded_pilot.rs::expanded_pilot_stale_query`).
+Against a built pilot artifact, `adoc stale --format json` exits 0 with
+exactly 3 records, most-overdue first:
+
+| # | Object | Category | Reason |
+| :- | :----- | :------- | :----- |
+| 1 | `security.production-db-access` | `review_overdue` | `review_due:2020-03-31` |
+| 2 | `security.audit.retention` | `stale` (verified → effective `stale`) | `expired:2024-01-01` |
+| 3 | `billing.credits.legacy-export` | `stale` (draft, status echoed) | `expired:2026-01-15` |
+
+`adoc stale --within 36500d` additionally lists `billing.credits.consume`
+then `auth.mfa.enforced` as `expiring_soon`. All dates are wide-margin fixed
+dates, so the records and their order are clock-stable.
+
 ## What This Pilot Exercises
 
 - **Every V5 kind** with a complete authoring → validation → rendering →

--- a/examples/expanded-pilot/auth/claims.adoc
+++ b/examples/expanded-pilot/auth/claims.adoc
@@ -21,6 +21,7 @@ Session tokens may be stored in localStorage so that sessions survive a page rel
 status: verified
 owner: platform-security
 verified_at: 2026-05-06
+expires_at: 2125-01-01
 source: auth service production config 2026-05-05
 test: cargo test auth_mfa_enforced
 reviewed_by: security-review

--- a/examples/expanded-pilot/billing/claims.adoc
+++ b/examples/expanded-pilot/billing/claims.adoc
@@ -7,6 +7,7 @@ reusable [[billing.consume-use-case]] source objects.
 status: verified
 owner: backend-platform
 verified_at: 2026-05-01
+expires_at: 2120-01-01
 test: cargo test credits
 evidence_ref: billing.consume-use-case
 related_to: billing.credits


### PR DESCRIPTION
## Summary

First slice of the V6 Agent Editing Loop cycle ([ROADMAP-V6.md](docs/ROADMAP-V6.md) §V6.1; includes the V6 roadmap doc commit since `docs/roadmap-v6` was never pushed).

- New read-only `adoc stale` CLI command and `adoc_stale` MCP tool over `dist/docs.graph.json` (no compile): lists `stale` (past `expires_at`, any status), `review_overdue` (active policy past `effective_at + review_interval`), and — with `--within <N>d` / `within_days` — `expiring_soon` (verified, expiry inside the horizon), as a new contract-tested `adoc.stale.v0` envelope sorted most-overdue first.
- Staleness is **re-derived at read time** against `evaluated_at`: the shared core `derive_effective_status_from_fields` is extracted from the V5.10 build-time derivation so build and read can never disagree; the persisted `effective_status` projection is never consulted. Exit 0 with or without records (query, not a gate); exit 2 only on artifact-load failure.
- Docs: new `docs/V6-DESIGN.md` (V6.1 contract section), ADR-0038 (lifecycle-signal read commands as graph-artifact readers), JSON Schema + `stale.md` agent resources, usage-contract and CONTEXT.md vocabulary updates. Expanded Pilot gains two far-future `expires_at` fields for the `expiring_soon` acceptance (diagnostic budget unchanged at 0 errors / 5 warnings).

## Test Plan

- [x] `cargo test --workspace` — all 50 targets green; `cargo fmt --check` + `cargo clippy --workspace --all-targets` clean
- [x] 9 unit tests in `application/signals.rs` (fixed dates: categories, re-derivation without persisted projection, boundary day, horizon overflow, double-record policy, sort determinism, serde omission)
- [x] `expanded_pilot_stale_query` integration test pins the 3-record acceptance output, `--within 36500d` (5 records), plain output, markdown rejection, and missing-artifact exit 2
- [x] Contract tests validate `adoc.stale.v0` envelopes (all three categories + empty) against the published JSON Schema
- [x] Manual smoke against the Expanded Pilot matches the roadmap acceptance byte-for-byte