### PR TITLE
feat(v6): lifecycle-signal read queries — adoc stale (V6.1) and adoc contradictions (V6.2)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -372,6 +372,10 @@ _Avoid_: health score, validation error, trusting the artifact's build-time `eff
 The V6.1 read command `adoc stale` / MCP tool `adoc_stale` (implemented): a graph-artifact reader emitting `adoc.stale.v0` — `evaluated_at` plus records categorized `stale | review_overdue | expiring_soon`, sorted most-overdue first then Object ID. The `stale` category lists any object with a past expiry (the `lifecycle.expired` breadth); the record's `effective_status` re-derives `stale` only for verified objects and otherwise echoes the authored status. Exit 0 with or without records; logic in `application/signals.rs`. See `docs/V6-DESIGN.md` §V6.1.
 _Avoid_: recompiling source to answer staleness, exit codes that gate on findings, `--fail-on` thresholds before measured demand
 
+**Contradictions Query**:
+The V6.2 read command `adoc contradictions` / MCP tool `adoc_contradictions` (implemented): a graph-artifact reader emitting `adoc.contradictions.v0` — every `unresolved` contradiction (`--all` adds resolved/dismissed) joined with every contradicted claim and its implicating contradiction ids, so consumers never join the lists. Implication is recomputed at read time via the `unresolved_contradiction_claim_index` shared with the build-time projection. **Clock-free by design**: no `evaluated_at`, byte-identical output for the same artifact on any day; the envelope reports the contradiction axis only (the expiry axis is the **Stale Query**'s job). Sorted severity-descending then Object ID. See `docs/V6-DESIGN.md` §V6.2.
+_Avoid_: trusting the artifact's persisted `effective_status`, threading a clock into the contradictions path, `--all` changing `contradicted_claims`, consumers re-joining contradictions to claims
+
 ## Relationships
 
 - **AgentDoc Source** contains prose and typed blocks that compile into **Knowledge Objects**.

--- a/crates/adoc-cli/src/cli.rs
+++ b/crates/adoc-cli/src/cli.rs
@@ -16,6 +16,7 @@ Examples:
   adoc diff main
   adoc search \"refund policy\"
   adoc stale --within 30d
+  adoc contradictions --all
 ";
 const INIT_LONG_HELP: &str = "\
 Examples:
@@ -82,6 +83,19 @@ Examples:
   adoc stale --within 30d
   adoc stale --within 30d --format json
   adoc stale --artifact dist/docs.graph.json
+";
+const CONTRADICTIONS_LONG_HELP: &str = "\
+Lists every unresolved contradiction plus every contradicted claim — implicated
+by an unresolved contradiction or authored as contradicted — with the
+contradiction ids that implicate it, so consumers never join the two lists.
+The output is a pure function of the graph artifact (no clock). The command is
+a query, not a gate: it exits 0 whether or not findings exist.
+
+Examples:
+  adoc contradictions
+  adoc contradictions --all
+  adoc contradictions --format json
+  adoc contradictions --artifact dist/docs.graph.json
 ";
 
 /// Parse the `--within <N>d` horizon grammar (same `[0-9]+d` shape as the
@@ -281,6 +295,20 @@ pub(crate) enum Commands {
         /// e.g. `--within 30d`.
         #[arg(long, value_name = "Nd", value_parser = parse_within_days)]
         within: Option<u32>,
+    },
+    #[command(
+        about = "List unresolved contradictions and contradicted claims from graph artifacts.",
+        after_long_help = CONTRADICTIONS_LONG_HELP
+    )]
+    Contradictions {
+        #[arg(
+            long,
+            help = "Graph JSON artifact path (default: config outputs.graph, then dist/docs.graph.json)"
+        )]
+        artifact: Option<PathBuf>,
+        /// Include resolved and dismissed contradictions in the listing.
+        #[arg(long)]
+        all: bool,
     },
     #[command(
         about = "Validate one AgentDoc patch document against graph artifacts.",

--- a/crates/adoc-cli/src/commands/contradictions.rs
+++ b/crates/adoc-cli/src/commands/contradictions.rs
@@ -1,0 +1,182 @@
+use std::fmt::Write as FmtWrite;
+use std::io;
+use std::path::PathBuf;
+
+use adoc_core::{ContradictedClaimRecord, ContradictionRecord, ContradictionsEnvelope};
+use adoc_local::{
+    ContradictionsInput as LocalContradictionsInput, ContradictionsUseCase, LocalContext,
+    UnrestrictedPathPolicy,
+};
+
+use crate::error::CliError;
+use crate::presentation::style::key::cyan_key;
+use crate::presentation::style::kv::faint_label;
+use crate::presentation::{ResolvedFormat, json as json_presentation};
+
+use super::{current_dir, eprint_diagnostics, report};
+
+pub(crate) struct ContradictionsCommandInput {
+    pub(crate) artifact: Option<PathBuf>,
+    pub(crate) all: bool,
+}
+
+pub(crate) fn contradictions(input: ContradictionsCommandInput, resolved: ResolvedFormat) -> i32 {
+    let config_start = match current_dir() {
+        Ok(path) => path,
+        Err(error) => return report(error),
+    };
+    let context = LocalContext::new(config_start, UnrestrictedPathPolicy);
+    let outcome = match ContradictionsUseCase::new(context).run(LocalContradictionsInput {
+        artifact: input.artifact,
+        all: input.all,
+    }) {
+        Ok(outcome) => outcome,
+        Err(error) => return report(error.into()),
+    };
+    let exit_code = outcome.exit_code;
+    if exit_code != 0 {
+        return emit_contradictions_error(outcome.envelope, resolved, exit_code);
+    }
+    if resolved != ResolvedFormat::Json && !outcome.envelope.diagnostics.is_empty() {
+        eprint_diagnostics(&outcome.envelope.diagnostics);
+    }
+    match resolved {
+        ResolvedFormat::Json => write_contradictions_json(&outcome.envelope, exit_code),
+        ResolvedFormat::Plain => write_contradictions_text(&outcome.envelope, false),
+        ResolvedFormat::Styled => write_contradictions_text(&outcome.envelope, true),
+        ResolvedFormat::Markdown => {
+            unreachable!(
+                "main.rs rejects markdown format for `adoc contradictions` before dispatch"
+            )
+        }
+    }
+}
+
+fn emit_contradictions_error(
+    envelope: ContradictionsEnvelope,
+    resolved: ResolvedFormat,
+    exit_code: i32,
+) -> i32 {
+    if resolved == ResolvedFormat::Json {
+        return write_contradictions_json(&envelope, exit_code);
+    }
+    eprint_diagnostics(&envelope.diagnostics);
+    exit_code
+}
+
+fn write_contradictions_json(envelope: &ContradictionsEnvelope, exit_code: i32) -> i32 {
+    json_presentation::write_json(envelope, &mut io::stdout()).map_or_else(
+        |source| report(CliError::RetrievalIo { source }),
+        |()| exit_code,
+    )
+}
+
+fn write_contradictions_text(envelope: &ContradictionsEnvelope, styled: bool) -> i32 {
+    let mut output = String::new();
+    render_contradictions_text(&mut output, envelope, styled);
+    print!("{output}");
+    0
+}
+
+fn render_contradictions_text(
+    output: &mut String,
+    envelope: &ContradictionsEnvelope,
+    styled: bool,
+) {
+    let header = format!("{} contradiction(s)", envelope.contradictions.len());
+    if styled {
+        writeln!(output, "{} {header}", faint_label("Contradictions:"))
+            .expect("writing to String cannot fail");
+    } else {
+        writeln!(output, "Contradictions: {header}").expect("writing to String cannot fail");
+    }
+    if envelope.contradictions.is_empty() {
+        writeln!(output, "(none)").expect("writing to String cannot fail");
+    }
+    for record in &envelope.contradictions {
+        render_contradiction(output, record, styled);
+    }
+
+    let claims_header = format!(
+        "{} contradicted claim(s)",
+        envelope.contradicted_claims.len()
+    );
+    if styled {
+        writeln!(
+            output,
+            "{} {claims_header}",
+            faint_label("Contradicted claims:")
+        )
+        .expect("writing to String cannot fail");
+    } else {
+        writeln!(output, "Contradicted claims: {claims_header}")
+            .expect("writing to String cannot fail");
+    }
+    if envelope.contradicted_claims.is_empty() {
+        writeln!(output, "(none)").expect("writing to String cannot fail");
+    }
+    for record in &envelope.contradicted_claims {
+        render_contradicted_claim(output, record, styled);
+    }
+}
+
+fn render_contradiction(output: &mut String, record: &ContradictionRecord, styled: bool) {
+    let owner = record
+        .owner
+        .as_ref()
+        .map(|owner| format!(", owner: {owner}"))
+        .unwrap_or_default();
+    if styled {
+        writeln!(
+            output,
+            "- {} ({} {}, {} {}{owner}, {})",
+            record.id,
+            cyan_key("severity"),
+            record.severity,
+            cyan_key("status"),
+            record.status,
+            record.source_path,
+        )
+        .expect("writing to String cannot fail");
+    } else {
+        writeln!(
+            output,
+            "- {} ({}, {}{owner}, {})",
+            record.id, record.severity, record.status, record.source_path,
+        )
+        .expect("writing to String cannot fail");
+    }
+    writeln!(output, "  claims: {}", record.claims.join(", "))
+        .expect("writing to String cannot fail");
+    if !record.summary.is_empty() {
+        writeln!(output, "  {}", record.summary).expect("writing to String cannot fail");
+    }
+}
+
+fn render_contradicted_claim(output: &mut String, record: &ContradictedClaimRecord, styled: bool) {
+    let status = match (&record.authored_status, &record.effective_status) {
+        (Some(authored), Some(effective)) if authored != effective => {
+            format!("{authored} -> {effective}")
+        }
+        (Some(authored), _) => authored.clone(),
+        (None, Some(effective)) => effective.clone(),
+        (None, None) => String::new(),
+    };
+    let via = if record.contradiction_ids.is_empty() {
+        "authored only".to_string()
+    } else {
+        format!("via {}", record.contradiction_ids.join(", "))
+    };
+    if styled {
+        writeln!(
+            output,
+            "- {} ({} {status}, {via})",
+            record.id,
+            cyan_key("status"),
+        )
+        .expect("writing to String cannot fail");
+    } else {
+        writeln!(output, "- {} ({status}, {via})", record.id)
+            .expect("writing to String cannot fail");
+    }
+}

--- a/crates/adoc-cli/src/commands/mod.rs
+++ b/crates/adoc-cli/src/commands/mod.rs
@@ -1,5 +1,6 @@
 mod build;
 mod check;
+mod contradictions;
 mod diff;
 mod graph;
 mod init;
@@ -21,6 +22,7 @@ use crate::presentation::{
 
 pub(crate) use build::build;
 pub(crate) use check::check;
+pub(crate) use contradictions::{ContradictionsCommandInput, contradictions};
 pub(crate) use diff::{DiffCommandInput, diff};
 pub(crate) use graph::{GraphCommandInput, graph};
 pub(crate) use init::init;

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -9,8 +9,9 @@ use clap::{Parser, error::ErrorKind};
 
 use crate::cli::{Cli, Commands};
 use crate::commands::{
-    DiffCommandInput, GraphCommandInput, PatchCommandInput, ReviewCommandInput, SearchCommandInput,
-    StaleCommandInput, build, check, diff, graph, init, patch, review, search_command, stale, why,
+    ContradictionsCommandInput, DiffCommandInput, GraphCommandInput, PatchCommandInput,
+    ReviewCommandInput, SearchCommandInput, StaleCommandInput, build, check, contradictions, diff,
+    graph, init, patch, review, search_command, stale, why,
 };
 use crate::presentation::{ResolvedFormat, terminal};
 
@@ -67,6 +68,9 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
                     },
                     resolved,
                 ),
+                Commands::Contradictions { artifact, all } => {
+                    contradictions(ContradictionsCommandInput { artifact, all }, resolved)
+                }
                 Commands::Patch { check, artifact } => patch(
                     PatchCommandInput {
                         patch_path: check,

--- a/crates/adoc-cli/tests/expanded_pilot.rs
+++ b/crates/adoc-cli/tests/expanded_pilot.rs
@@ -815,3 +815,225 @@ fn expanded_pilot_stale_query() {
         "failure envelope must carry fix-oriented diagnostics"
     );
 }
+
+/// V6.2 acceptance: exactly 1 unresolved contradiction and exactly 3
+/// contradicted claims, each carrying the implicating contradiction ids so
+/// consumers never join the two lists themselves. The envelope is a pure
+/// function of the artifact: no `evaluated_at`. Exit 0 with findings, exit 2
+/// only on artifact-load failure; `--format markdown` stays diff/review-only.
+#[test]
+fn expanded_pilot_contradictions_query() {
+    let repo_root = repo_root();
+    let workspace = TestWorkspace::new("expanded-pilot-contradictions");
+    let dist = workspace.root.join("dist");
+    let build = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&repo_root)
+        .env("ADOC_TEST_EMBEDDING_PROVIDER", "deterministic")
+        .args([
+            "build",
+            PILOT_PATH,
+            "--out",
+            dist.to_str().expect("dist path is utf-8"),
+        ])
+        .output()
+        .expect("adoc build runs");
+    assert!(
+        build.status.success(),
+        "contradictions prerequisite build must succeed\nstderr:\n{}",
+        String::from_utf8_lossy(&build.stderr)
+    );
+    let graph = dist.join("docs.graph.json");
+    let graph_arg = graph.to_str().expect("graph path is utf-8");
+
+    // --- default listing: exactly 1 contradiction, exactly 3 claims ---
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "contradictions",
+            "--artifact",
+            graph_arg,
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("adoc contradictions runs");
+    assert!(
+        output.status.success(),
+        "adoc contradictions is a query and must exit 0 even with findings\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let envelope: Value =
+        serde_json::from_slice(&output.stdout).expect("contradictions stdout is JSON");
+    assert_eq!(envelope["schema_version"], "adoc.contradictions.v0");
+    assert!(
+        envelope.get("evaluated_at").is_none(),
+        "the contradictions envelope is clock-free — no evaluated_at"
+    );
+
+    let contradictions = envelope["contradictions"]
+        .as_array()
+        .expect("contradictions array");
+    assert_eq!(
+        contradictions.len(),
+        1,
+        "expected exactly 1 contradiction: {contradictions:#?}"
+    );
+    let conflict = &contradictions[0];
+    assert_eq!(conflict["id"], "auth.session.conflict");
+    assert_eq!(conflict["severity"], "high");
+    assert_eq!(conflict["status"], "unresolved");
+    assert_eq!(
+        conflict["claims"],
+        serde_json::json!([
+            "auth.session.csrf-protection",
+            "auth.session.local-storage-allowed",
+            "auth.session.memory-storage",
+        ]),
+        "claims echo the parse-time sorted list"
+    );
+    assert!(
+        conflict["source_path"]
+            .as_str()
+            .expect("source_path")
+            .contains("security/contradictions.adoc")
+    );
+    assert_eq!(
+        conflict["summary"], "Claim auth.session.memory-storage requires memory-only storage while",
+        "summary is the first body line"
+    );
+
+    let claims = envelope["contradicted_claims"]
+        .as_array()
+        .expect("contradicted_claims array");
+    assert_eq!(
+        claims.len(),
+        3,
+        "expected exactly 3 contradicted claims: {claims:#?}"
+    );
+
+    assert_eq!(claims[0]["id"], "auth.session.csrf-protection");
+    assert_eq!(
+        claims[0]["authored_status"], "accepted",
+        "csrf-protection's authored status is untouched"
+    );
+    assert_eq!(
+        claims[0]["effective_status"], "contradicted",
+        "implication by an unresolved contradiction derives contradicted"
+    );
+    assert_eq!(
+        claims[0]["effective_reason"],
+        "contradiction:auth.session.conflict"
+    );
+
+    assert_eq!(claims[1]["id"], "auth.session.local-storage-allowed");
+    assert_eq!(claims[1]["authored_status"], "contradicted");
+    assert_eq!(claims[2]["id"], "auth.session.memory-storage");
+    assert_eq!(claims[2]["authored_status"], "contradicted");
+
+    for claim in claims {
+        assert_eq!(
+            claim["contradiction_ids"],
+            serde_json::json!(["auth.session.conflict"]),
+            "every contradicted claim carries its implicating contradiction ids"
+        );
+    }
+
+    // --- --all is identical on this pilot (no resolved/dismissed records) ---
+    let all = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "contradictions",
+            "--artifact",
+            graph_arg,
+            "--all",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("adoc contradictions --all runs");
+    assert!(
+        all.status.success(),
+        "adoc contradictions --all must exit 0"
+    );
+    let all_env: Value = serde_json::from_slice(&all.stdout).expect("--all stdout is JSON");
+    assert_eq!(
+        all_env, envelope,
+        "--all must be identical when every contradiction is unresolved"
+    );
+
+    // --- plain output smoke ---
+    let plain = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "contradictions",
+            "--artifact",
+            graph_arg,
+            "--format",
+            "plain",
+        ])
+        .output()
+        .expect("adoc contradictions --format plain runs");
+    assert!(plain.status.success(), "plain contradictions must exit 0");
+    let plain_stdout = String::from_utf8_lossy(&plain.stdout);
+    assert!(
+        plain_stdout.contains("Contradictions: 1 contradiction(s)"),
+        "plain output must lead with the contradiction count header:\n{plain_stdout}"
+    );
+    assert!(
+        plain_stdout.contains("Contradicted claims: 3 contradicted claim(s)"),
+        "plain output must include the contradicted-claims section:\n{plain_stdout}"
+    );
+    assert!(
+        plain_stdout.contains("accepted -> contradicted"),
+        "plain output must show the authored -> effective transition:\n{plain_stdout}"
+    );
+
+    // --- markdown stays diff/review-only ---
+    let markdown = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "contradictions",
+            "--artifact",
+            graph_arg,
+            "--format",
+            "markdown",
+        ])
+        .output()
+        .expect("adoc contradictions --format markdown runs");
+    assert_eq!(
+        markdown.status.code(),
+        Some(2),
+        "markdown format must be rejected for adoc contradictions"
+    );
+    assert!(
+        String::from_utf8_lossy(&markdown.stderr).contains("cli.format"),
+        "markdown rejection must name the cli.format diagnostic"
+    );
+
+    // --- artifact-load failure exits 2 with an empty-lists envelope ---
+    let missing = dist.join("does-not-exist.graph.json");
+    let missing_arg = missing.to_str().expect("missing path is utf-8");
+    let failed = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .args([
+            "contradictions",
+            "--artifact",
+            missing_arg,
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("adoc contradictions with missing artifact runs");
+    assert_eq!(
+        failed.status.code(),
+        Some(2),
+        "artifact-load failure must exit 2"
+    );
+    let failed_env: Value =
+        serde_json::from_slice(&failed.stdout).expect("failure envelope is JSON");
+    assert_eq!(failed_env["schema_version"], "adoc.contradictions.v0");
+    assert_eq!(failed_env["contradictions"], serde_json::json!([]));
+    assert_eq!(failed_env["contradicted_claims"], serde_json::json!([]));
+    assert!(
+        !failed_env["diagnostics"]
+            .as_array()
+            .expect("diagnostics array")
+            .is_empty(),
+        "failure envelope must carry fix-oriented diagnostics"
+    );
+}

--- a/crates/adoc-cli/tests/help_cli.rs
+++ b/crates/adoc-cli/tests/help_cli.rs
@@ -26,6 +26,7 @@ fn long_top_level_help_lists_command_descriptions_and_examples() {
     assert!(stdout.contains("Validate one AgentDoc patch document against graph artifacts"));
     assert!(stdout.contains("Search compiled Knowledge Objects"));
     assert!(stdout.contains("List stale, review-overdue, and expiring Knowledge Objects"));
+    assert!(stdout.contains("List unresolved contradictions and contradicted claims"));
     assert!(stdout.contains("Examples:"));
     assert!(stdout.contains("adoc init"));
     assert!(stdout.contains("adoc check docs"));
@@ -35,6 +36,7 @@ fn long_top_level_help_lists_command_descriptions_and_examples() {
     assert!(stdout.contains("adoc patch --check patch.json"));
     assert!(stdout.contains("adoc search \"refund policy\""));
     assert!(stdout.contains("adoc stale --within 30d"));
+    assert!(stdout.contains("adoc contradictions --all"));
 }
 
 #[test]

--- a/crates/adoc-core/src/application/signals.rs
+++ b/crates/adoc-core/src/application/signals.rs
@@ -1,10 +1,13 @@
-//! V6.1 lifecycle-signal read queries over a loaded graph artifact.
+//! Lifecycle-signal read queries over a loaded graph artifact (V6.1/V6.2).
 //!
-//! `adoc stale` (and, later, `adoc contradictions`) are read-only queries over
-//! `dist/docs.graph.json`. Staleness and overdue-ness are **re-derived at read
-//! time** from authored fields — an artifact built last week must not report
+//! `adoc stale` and `adoc contradictions` are read-only queries over
+//! `dist/docs.graph.json`. Signals are **re-derived at read time** from
+//! authored fields — an artifact built last week must not report
 //! stale-as-of-build-time — so this module never trusts the persisted
-//! `effective_status` projection. See ADR-0038 and docs/V6-DESIGN.md.
+//! `effective_status` projection. The stale query is clock-dependent and
+//! carries `evaluated_at`; the contradictions query is a pure function of the
+//! artifact bytes and deliberately carries no evaluation date. See ADR-0038
+//! and docs/V6-DESIGN.md.
 
 use chrono::NaiveDate;
 use serde::Serialize;
@@ -12,7 +15,10 @@ use serde::Serialize;
 use crate::domain::diagnostic::Diagnostic;
 use crate::domain::graph::GraphKnowledgeObjectNode;
 use crate::domain::value_objects::review_interval::ReviewInterval;
-use crate::infrastructure::artifact::graph_json::derive_effective_status_from_fields;
+use crate::domain::value_objects::severity::Severity;
+use crate::infrastructure::artifact::graph_json::{
+    derive_effective_status_from_fields, unresolved_contradiction_claim_index,
+};
 
 use super::graph::GraphSession;
 use super::local_today;
@@ -255,6 +261,168 @@ fn rederived_effective_status(node: &GraphKnowledgeObjectNode, today: NaiveDate)
 /// every call site, so the result is ≥ 1 for overdue and ≥ 0 for remaining).
 fn days_between(earlier: NaiveDate, later: NaiveDate) -> u32 {
     u32::try_from((later - earlier).num_days()).unwrap_or(u32::MAX)
+}
+
+pub const CONTRADICTIONS_SCHEMA_VERSION: &str = "adoc.contradictions.v0";
+
+/// Maximum `summary` length in characters (not bytes — multibyte-safe).
+const SUMMARY_MAX_CHARS: usize = 120;
+
+/// One contradiction object in the `adoc.contradictions.v0` listing.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ContradictionRecord {
+    pub id: String,
+    pub severity: String,
+    /// Echo of the authored status: `unresolved` by default; `resolved` /
+    /// `dismissed` appear only under `--all`.
+    pub status: String,
+    pub claims: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub owner: Option<String>,
+    pub source_path: String,
+    /// First non-empty body line, char-truncated to 120 with `…`.
+    pub summary: String,
+}
+
+/// One contradicted claim in the `adoc.contradictions.v0` listing: a claim
+/// implicated by at least one unresolved contradiction, or one whose authored
+/// status is `contradicted`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ContradictedClaimRecord {
+    pub id: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub authored_status: Option<String>,
+    /// Contradiction-axis derivation only: `"contradicted"` when implicated by
+    /// an unresolved contradiction, otherwise an echo of the authored status.
+    /// The expiry axis is `adoc stale`'s job — the two commands answer
+    /// different questions and this one is deliberately clock-free.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_status: Option<String>,
+    /// `"contradiction:<id>"` where `<id>` is the lexicographically smallest
+    /// implicating contradiction — identical to the build-time projection.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub effective_reason: Option<String>,
+    /// All implicating unresolved contradiction ids, sorted ascending. Empty
+    /// only for a claim whose authored status is `contradicted` while no
+    /// unresolved contradiction references it.
+    pub contradiction_ids: Vec<String>,
+}
+
+/// The `adoc.contradictions.v0` wire envelope. A pure function of the artifact
+/// bytes: no `evaluated_at`, byte-identical on any day.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct ContradictionsEnvelope {
+    pub schema_version: &'static str,
+    pub contradictions: Vec<ContradictionRecord>,
+    pub contradicted_claims: Vec<ContradictedClaimRecord>,
+    pub diagnostics: Vec<Diagnostic>,
+}
+
+impl ContradictionsEnvelope {
+    pub fn new(
+        contradictions: Vec<ContradictionRecord>,
+        contradicted_claims: Vec<ContradictedClaimRecord>,
+        diagnostics: Vec<Diagnostic>,
+    ) -> Self {
+        Self {
+            schema_version: CONTRADICTIONS_SCHEMA_VERSION,
+            contradictions,
+            contradicted_claims,
+            diagnostics,
+        }
+    }
+}
+
+/// Evaluate the contradictions query: unresolved contradictions (all statuses
+/// with `include_all`) plus every contradicted claim, joined for the consumer.
+pub(crate) fn evaluate_contradictions(
+    session: &GraphSession,
+    include_all: bool,
+    diagnostics: Vec<Diagnostic>,
+) -> ContradictionsEnvelope {
+    let implicated = unresolved_contradiction_claim_index(session.objects());
+
+    let mut contradictions: Vec<ContradictionRecord> = session
+        .objects()
+        .filter(|node| node.kind == "contradiction")
+        .filter(|node| include_all || node.status.as_deref() == Some("unresolved"))
+        .map(|node| ContradictionRecord {
+            id: node.id.clone(),
+            severity: node
+                .severity
+                .clone()
+                .or_else(|| node.fields.get("severity").cloned())
+                .unwrap_or_default(),
+            status: node.status.clone().unwrap_or_default(),
+            claims: node.contradiction_claims.clone(),
+            owner: node.fields.get("owner").cloned(),
+            source_path: node.source_span.path.clone(),
+            summary: body_summary(&node.body),
+        })
+        .collect();
+
+    // Severity descending (critical first; unparseable last), then id.
+    contradictions.sort_by(|a, b| {
+        let a_severity = Severity::try_new(&a.severity).ok();
+        let b_severity = Severity::try_new(&b.severity).ok();
+        b_severity.cmp(&a_severity).then_with(|| a.id.cmp(&b.id))
+    });
+
+    let mut contradicted_claims: Vec<ContradictedClaimRecord> = session
+        .objects()
+        .filter(|node| node.kind == "claim")
+        .filter_map(|node| {
+            let contradiction_ids = implicated.get(&node.id).cloned().unwrap_or_default();
+            let authored_contradicted = node.status.as_deref() == Some("contradicted");
+            if contradiction_ids.is_empty() && !authored_contradicted {
+                return None;
+            }
+            let (effective_status, effective_reason) = if contradiction_ids.is_empty() {
+                // Orphaned authored status: echo, no derivation.
+                (node.status.clone(), None)
+            } else {
+                (
+                    Some("contradicted".to_string()),
+                    Some(format!("contradiction:{}", contradiction_ids[0])),
+                )
+            };
+            Some(ContradictedClaimRecord {
+                id: node.id.clone(),
+                authored_status: node.status.clone(),
+                effective_status,
+                effective_reason,
+                contradiction_ids,
+            })
+        })
+        .collect();
+
+    contradicted_claims.sort_by(|a, b| a.id.cmp(&b.id));
+
+    ContradictionsEnvelope::new(contradictions, contradicted_claims, diagnostics)
+}
+
+/// Empty envelope for the artifact-load-failure path.
+pub(crate) fn empty_contradictions_envelope(
+    diagnostics: Vec<Diagnostic>,
+) -> ContradictionsEnvelope {
+    ContradictionsEnvelope::new(Vec::new(), Vec::new(), diagnostics)
+}
+
+/// First non-empty (ASCII-trimmed) body line, truncated to
+/// [`SUMMARY_MAX_CHARS`] characters with a trailing `…` when cut.
+fn body_summary(body: &str) -> String {
+    let first_line = body
+        .lines()
+        .map(str::trim)
+        .find(|line| !line.is_empty())
+        .unwrap_or("");
+    if first_line.chars().count() <= SUMMARY_MAX_CHARS {
+        first_line.to_string()
+    } else {
+        let mut truncated: String = first_line.chars().take(SUMMARY_MAX_CHARS - 1).collect();
+        truncated.push('…');
+        truncated
+    }
 }
 
 #[cfg(test)]
@@ -625,5 +793,378 @@ mod tests {
         assert!(!object.contains_key("owner"));
         assert_eq!(value["category"], "stale");
         assert_eq!(value["days_overdue"], 137);
+    }
+
+    fn contradiction_node(id: &str, severity: &str, status: &str, claims: &[&str]) -> GraphNode {
+        contradiction_node_with_body(
+            id,
+            severity,
+            status,
+            claims,
+            "Claims disagree about session storage.",
+        )
+    }
+
+    fn contradiction_node_with_body(
+        id: &str,
+        severity: &str,
+        status: &str,
+        claims: &[&str],
+        body: &str,
+    ) -> GraphNode {
+        let mut node = ko_node(
+            id,
+            "contradiction",
+            Some(status),
+            &[("severity", severity), ("owner", "platform-security")],
+        );
+        let GraphNode::KnowledgeObject(ko) = &mut node else {
+            unreachable!("ko_node builds a knowledge object");
+        };
+        ko.contradiction_claims = claims.iter().map(|claim| (*claim).to_string()).collect();
+        ko.body = body.to_string();
+        node
+    }
+
+    /// Default listing is unresolved-only; `--all` adds resolved/dismissed with
+    /// echoed statuses. Claims referenced only by a non-unresolved
+    /// contradiction never enter `contradicted_claims`, under either mode.
+    #[test]
+    fn contradictions_default_lists_unresolved_only_and_all_includes_terminal_statuses() {
+        let session = session_with(vec![
+            contradiction_node(
+                "conflict.open",
+                "high",
+                "unresolved",
+                &["claim.a", "claim.b"],
+            ),
+            contradiction_node(
+                "conflict.closed",
+                "critical",
+                "resolved",
+                &["claim.c", "claim.d"],
+            ),
+            contradiction_node(
+                "conflict.noise",
+                "low",
+                "dismissed",
+                &["claim.c", "claim.d"],
+            ),
+            ko_node("claim.a", "claim", Some("verified"), &[]),
+            ko_node("claim.b", "claim", Some("contradicted"), &[]),
+            ko_node("claim.c", "claim", Some("verified"), &[]),
+            ko_node("claim.d", "claim", Some("verified"), &[]),
+        ]);
+
+        let default_envelope = evaluate_contradictions(&session, false, Vec::new());
+        let ids: Vec<&str> = default_envelope
+            .contradictions
+            .iter()
+            .map(|record| record.id.as_str())
+            .collect();
+        assert_eq!(ids, vec!["conflict.open"]);
+        assert_eq!(default_envelope.contradictions[0].status, "unresolved");
+        assert_eq!(default_envelope.contradictions[0].severity, "high");
+        assert_eq!(
+            default_envelope.contradictions[0].claims,
+            vec!["claim.a", "claim.b"]
+        );
+        assert_eq!(
+            default_envelope.contradictions[0].owner.as_deref(),
+            Some("platform-security")
+        );
+        assert_eq!(
+            default_envelope.contradictions[0].source_path,
+            "docs/team.adoc"
+        );
+
+        let all_envelope = evaluate_contradictions(&session, true, Vec::new());
+        let all_ids: Vec<(&str, &str)> = all_envelope
+            .contradictions
+            .iter()
+            .map(|record| (record.id.as_str(), record.status.as_str()))
+            .collect();
+        assert_eq!(
+            all_ids,
+            vec![
+                ("conflict.closed", "resolved"), // critical sorts first
+                ("conflict.open", "unresolved"),
+                ("conflict.noise", "dismissed"),
+            ]
+        );
+
+        // claim.c / claim.d are referenced only by resolved/dismissed
+        // contradictions — never contradicted, under either mode.
+        for envelope in [&default_envelope, &all_envelope] {
+            let claim_ids: Vec<&str> = envelope
+                .contradicted_claims
+                .iter()
+                .map(|record| record.id.as_str())
+                .collect();
+            assert_eq!(claim_ids, vec!["claim.a", "claim.b"]);
+        }
+    }
+
+    /// Contradictions sort severity-descending (critical first), id ascending
+    /// as tiebreak; unparseable severity sorts last and is echoed raw.
+    #[test]
+    fn contradictions_sort_by_severity_descending_then_id() {
+        let session = session_with(vec![
+            contradiction_node("conflict.medium", "medium", "unresolved", &["c.a", "c.b"]),
+            contradiction_node("conflict.low", "low", "unresolved", &["c.a", "c.b"]),
+            contradiction_node("conflict.garbage", "panic", "unresolved", &["c.a", "c.b"]),
+            contradiction_node(
+                "conflict.critical-z",
+                "critical",
+                "unresolved",
+                &["c.a", "c.b"],
+            ),
+            contradiction_node(
+                "conflict.critical-a",
+                "critical",
+                "unresolved",
+                &["c.a", "c.b"],
+            ),
+            contradiction_node("conflict.high", "high", "unresolved", &["c.a", "c.b"]),
+        ]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        let ids: Vec<&str> = envelope
+            .contradictions
+            .iter()
+            .map(|record| record.id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "conflict.critical-a",
+                "conflict.critical-z",
+                "conflict.high",
+                "conflict.medium",
+                "conflict.low",
+                "conflict.garbage",
+            ]
+        );
+        assert_eq!(envelope.contradictions[5].severity, "panic");
+    }
+
+    /// The ADR-0035 top-level severity dual-emit wins over the fields map when
+    /// both are present.
+    #[test]
+    fn contradiction_severity_prefers_top_level_dual_emit() {
+        let mut node = contradiction_node("conflict.dual", "low", "unresolved", &["c.a", "c.b"]);
+        let GraphNode::KnowledgeObject(ko) = &mut node else {
+            unreachable!();
+        };
+        ko.severity = Some("critical".to_string());
+
+        let session = session_with(vec![node]);
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        assert_eq!(envelope.contradictions[0].severity, "critical");
+    }
+
+    /// A claim implicated by an unresolved contradiction derives
+    /// `effective_status: "contradicted"` with the build-format reason, even
+    /// when its authored status is untouched.
+    #[test]
+    fn implicated_claim_derives_contradicted_with_reason() {
+        let session = session_with(vec![
+            contradiction_node(
+                "conflict.one",
+                "high",
+                "unresolved",
+                &["claim.csrf", "claim.mem"],
+            ),
+            ko_node("claim.csrf", "claim", Some("accepted"), &[]),
+            ko_node("claim.mem", "claim", Some("contradicted"), &[]),
+        ]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        assert_eq!(envelope.contradicted_claims.len(), 2);
+        let csrf = &envelope.contradicted_claims[0];
+        assert_eq!(csrf.id, "claim.csrf");
+        assert_eq!(csrf.authored_status.as_deref(), Some("accepted"));
+        assert_eq!(csrf.effective_status.as_deref(), Some("contradicted"));
+        assert_eq!(
+            csrf.effective_reason.as_deref(),
+            Some("contradiction:conflict.one")
+        );
+        assert_eq!(csrf.contradiction_ids, vec!["conflict.one"]);
+    }
+
+    /// Two unresolved contradictions on one claim: `contradiction_ids` sorted
+    /// ascending, reason from the lexicographically smallest.
+    #[test]
+    fn multiple_contradictions_on_one_claim_sort_ids_and_use_smallest_for_reason() {
+        let session = session_with(vec![
+            contradiction_node(
+                "conflict.zeta",
+                "high",
+                "unresolved",
+                &["claim.x", "claim.y"],
+            ),
+            contradiction_node(
+                "conflict.alpha",
+                "low",
+                "unresolved",
+                &["claim.x", "claim.z"],
+            ),
+            ko_node("claim.x", "claim", Some("verified"), &[]),
+            ko_node("claim.y", "claim", Some("verified"), &[]),
+            ko_node("claim.z", "claim", Some("verified"), &[]),
+        ]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        let x = envelope
+            .contradicted_claims
+            .iter()
+            .find(|record| record.id == "claim.x")
+            .expect("claim.x is implicated twice");
+        assert_eq!(x.contradiction_ids, vec!["conflict.alpha", "conflict.zeta"]);
+        assert_eq!(
+            x.effective_reason.as_deref(),
+            Some("contradiction:conflict.alpha")
+        );
+    }
+
+    /// A claim with authored status `contradicted` but no implicating
+    /// unresolved contradiction is still listed — empty ids, echoed status,
+    /// no derivation reason.
+    #[test]
+    fn orphaned_authored_contradicted_claim_is_listed_with_empty_ids() {
+        let session = session_with(vec![ko_node(
+            "claim.orphan",
+            "claim",
+            Some("contradicted"),
+            &[],
+        )]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        assert_eq!(envelope.contradicted_claims.len(), 1);
+        let orphan = &envelope.contradicted_claims[0];
+        assert_eq!(orphan.authored_status.as_deref(), Some("contradicted"));
+        assert_eq!(orphan.effective_status.as_deref(), Some("contradicted"));
+        assert_eq!(orphan.effective_reason, None);
+        assert!(orphan.contradiction_ids.is_empty());
+    }
+
+    /// The contradictions query is clock-free: an expired verified claim
+    /// implicated by an unresolved contradiction reports `contradicted` on
+    /// this axis (the expiry axis is `adoc stale`'s job; the build artifact's
+    /// single effective_status slot keeps stale precedence).
+    #[test]
+    fn expired_verified_implicated_claim_still_reports_contradicted() {
+        let session = session_with(vec![
+            contradiction_node(
+                "conflict.one",
+                "high",
+                "unresolved",
+                &["claim.expired", "claim.b"],
+            ),
+            ko_node(
+                "claim.expired",
+                "claim",
+                Some("verified"),
+                &[("expires_at", "2000-01-01")],
+            ),
+            ko_node("claim.b", "claim", Some("verified"), &[]),
+        ]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        let expired = envelope
+            .contradicted_claims
+            .iter()
+            .find(|record| record.id == "claim.expired")
+            .expect("expired claim is listed");
+        assert_eq!(expired.effective_status.as_deref(), Some("contradicted"));
+    }
+
+    /// Ids in `claims:` that name a non-claim object or nothing at all produce
+    /// no `contradicted_claims` record (compile already diagnosed them).
+    #[test]
+    fn non_claim_and_dangling_claim_references_produce_no_records() {
+        let session = session_with(vec![
+            contradiction_node(
+                "conflict.one",
+                "high",
+                "unresolved",
+                &["decision.not-a-claim", "claim.gone"],
+            ),
+            ko_node("decision.not-a-claim", "decision", Some("accepted"), &[]),
+        ]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+
+        assert_eq!(envelope.contradictions.len(), 1);
+        assert!(
+            envelope.contradicted_claims.is_empty(),
+            "non-claim and dangling references must not yield records: {:#?}",
+            envelope.contradicted_claims
+        );
+    }
+
+    /// The envelope is artifact-pure: schema version constant, NO evaluated_at
+    /// key, optional record fields omitted rather than null.
+    #[test]
+    fn contradictions_envelope_serializes_without_evaluated_at() {
+        let session = session_with(vec![
+            contradiction_node(
+                "conflict.one",
+                "high",
+                "unresolved",
+                &["claim.a", "claim.b"],
+            ),
+            ko_node("claim.a", "claim", None, &[]),
+        ]);
+
+        let envelope = evaluate_contradictions(&session, false, Vec::new());
+        let value = serde_json::to_value(&envelope).expect("envelope serializes");
+        let object = value.as_object().expect("envelope is an object");
+
+        assert_eq!(value["schema_version"], "adoc.contradictions.v0");
+        assert!(
+            !object.contains_key("evaluated_at"),
+            "contradictions is clock-free — no evaluated_at"
+        );
+        assert_eq!(value["diagnostics"], serde_json::json!([]));
+
+        let claim = value["contradicted_claims"][0]
+            .as_object()
+            .expect("claim record is an object");
+        assert!(!claim.contains_key("authored_status"));
+        assert_eq!(claim["effective_status"], "contradicted");
+
+        let empty = empty_contradictions_envelope(Vec::new());
+        let empty_value = serde_json::to_value(&empty).expect("empty envelope serializes");
+        assert_eq!(empty_value["contradictions"], serde_json::json!([]));
+        assert_eq!(empty_value["contradicted_claims"], serde_json::json!([]));
+    }
+
+    /// Summary is the first non-empty line, char-truncated to 120 with `…`.
+    #[test]
+    fn body_summary_takes_first_non_empty_line_and_truncates_chars() {
+        assert_eq!(body_summary("First line.\nSecond line."), "First line.");
+        assert_eq!(body_summary("\n  \nActual start.\nMore."), "Actual start.");
+        assert_eq!(body_summary(""), "");
+
+        let long = "x".repeat(121);
+        let summary = body_summary(&long);
+        assert_eq!(summary.chars().count(), 120);
+        assert!(summary.ends_with('…'));
+
+        let exactly = "y".repeat(120);
+        assert_eq!(body_summary(&exactly), exactly);
+
+        // Multibyte: truncation must count chars, not bytes.
+        let multibyte = "é".repeat(130);
+        let multibyte_summary = body_summary(&multibyte);
+        assert_eq!(multibyte_summary.chars().count(), 120);
+        assert_eq!(multibyte_summary, format!("{}…", "é".repeat(119)));
     }
 }

--- a/crates/adoc-core/src/domain/value_objects/severity.rs
+++ b/crates/adoc-core/src/domain/value_objects/severity.rs
@@ -13,9 +13,10 @@ use crate::domain::values::trim_ascii_edges;
 /// A severity level with constructor-asserted validity.
 ///
 /// Once constructed the value is total — every variant maps to exactly one
-/// canonical lowercase string and back.
+/// canonical lowercase string and back. Ordering follows escalation:
+/// `Low < Medium < High < Critical` (declaration order).
 #[non_exhaustive]
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub(crate) enum Severity {
     Low,
     Medium,
@@ -101,6 +102,13 @@ mod tests {
             Severity::try_new("HIGH"),
             Err(SeverityError::Invalid("HIGH".to_string()))
         );
+    }
+
+    #[test]
+    fn severity_orders_by_escalation() {
+        assert!(Severity::Low < Severity::Medium);
+        assert!(Severity::Medium < Severity::High);
+        assert!(Severity::High < Severity::Critical);
     }
 
     #[test]

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -492,6 +492,41 @@ pub(crate) fn derive_effective_status_from_fields(
     }
 }
 
+/// Reverse index over `contradiction_claims`: claim id → the sorted ids of
+/// every **unresolved** contradiction node that references it.
+///
+/// Shared core of the build-time `effective_status: "contradicted"` post-pass
+/// and the V6.2 `adoc contradictions` read-time evaluation in
+/// `application/signals.rs`. Values are sorted ascending so element `[0]` is
+/// the lexicographically smallest implicating contradiction id.
+pub(crate) fn unresolved_contradiction_claim_index<'a>(
+    objects: impl Iterator<Item = &'a crate::domain::graph::GraphKnowledgeObjectNode>,
+) -> BTreeMap<String, Vec<String>> {
+    let mut index: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for ko in objects {
+        if ko.kind != "contradiction" {
+            continue;
+        }
+        if ko.status.as_deref() != Some("unresolved") {
+            continue;
+        }
+        for claim_id in &ko.contradiction_claims {
+            index
+                .entry(claim_id.clone())
+                .or_default()
+                .push(ko.id.clone());
+        }
+    }
+
+    for ids in index.values_mut() {
+        ids.sort();
+        ids.dedup();
+    }
+
+    index
+}
+
 /// Cross-object post-pass: propagate `effective_status: "contradicted"` to claim
 /// nodes referenced by an **unresolved** contradiction node.
 ///
@@ -509,35 +544,13 @@ pub(crate) fn derive_effective_status_from_fields(
 /// claim. This ensures the output is byte-stable regardless of iteration order.
 pub(crate) fn apply_contradiction_effective_status(nodes: &mut [crate::domain::graph::GraphNode]) {
     use crate::domain::graph::GraphNode;
-    use std::collections::HashMap;
 
-    // Build a map: claim_id -> lexicographically smallest contradiction_id
-    // among all unresolved contradictions that reference this claim.
-    let mut contradicted: HashMap<String, String> = HashMap::new();
-
-    for node in nodes.iter() {
+    let contradicted = unresolved_contradiction_claim_index(nodes.iter().filter_map(|node| {
         let GraphNode::KnowledgeObject(ko) = node else {
-            continue;
+            return None;
         };
-        if ko.kind != "contradiction" {
-            continue;
-        }
-        if ko.status.as_deref() != Some("unresolved") {
-            continue;
-        }
-        let cid = ko.id.clone();
-        for claim_id in &ko.contradiction_claims {
-            contradicted
-                .entry(claim_id.clone())
-                .and_modify(|existing| {
-                    // Keep the lexicographically smallest contradiction id.
-                    if cid < *existing {
-                        *existing = cid.clone();
-                    }
-                })
-                .or_insert_with(|| cid.clone());
-        }
-    }
+        Some(ko)
+    }));
 
     if contradicted.is_empty() {
         return;
@@ -555,9 +568,9 @@ pub(crate) fn apply_contradiction_effective_status(nodes: &mut [crate::domain::g
             // Stale (or any pre-set status) wins — do not overwrite.
             continue;
         }
-        if let Some(cid) = contradicted.get(&ko.id) {
+        if let Some(ids) = contradicted.get(&ko.id) {
             ko.effective_status = Some("contradicted".to_string());
-            ko.effective_reason = Some(format!("contradiction:{cid}"));
+            ko.effective_reason = Some(format!("contradiction:{}", ids[0]));
         }
     }
 }

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -25,7 +25,10 @@ pub use application::review::{
     ReviewSession, diff_objects, proof_obligations, review_with_patch,
 };
 pub use application::review_envelope::{ObjectDiffEnvelope, ReviewEnvelope};
-pub use application::signals::{STALE_SCHEMA_VERSION, StaleCategory, StaleEnvelope, StaleRecord};
+pub use application::signals::{
+    CONTRADICTIONS_SCHEMA_VERSION, ContradictedClaimRecord, ContradictionRecord,
+    ContradictionsEnvelope, STALE_SCHEMA_VERSION, StaleCategory, StaleEnvelope, StaleRecord,
+};
 pub use domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 pub use domain::graph::{
     GraphDirection, GraphRelationKind, GraphTraversalEdge, GraphTraversalNode, GraphTraversalQuery,
@@ -139,6 +142,22 @@ pub fn evaluate_stale(
     diagnostics: Vec<Diagnostic>,
 ) -> StaleEnvelope {
     application::signals::evaluate_stale_today(session, within_days, diagnostics)
+}
+
+/// Evaluate the V6.2 `adoc contradictions` query: unresolved contradictions
+/// (all statuses with `include_all`) plus contradicted claims with their
+/// implicating contradiction ids, re-derived at read time. Clock-free.
+pub fn evaluate_contradictions(
+    session: &GraphSession,
+    include_all: bool,
+    diagnostics: Vec<Diagnostic>,
+) -> ContradictionsEnvelope {
+    application::signals::evaluate_contradictions(session, include_all, diagnostics)
+}
+
+/// Empty `adoc.contradictions.v0` envelope for artifact-load-failure paths.
+pub fn empty_contradictions_envelope(diagnostics: Vec<Diagnostic>) -> ContradictionsEnvelope {
+    application::signals::empty_contradictions_envelope(diagnostics)
 }
 
 /// Empty `adoc.stale.v0` envelope for artifact-load-failure paths;

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -146,7 +146,8 @@ pub fn evaluate_stale(
 
 /// Evaluate the V6.2 `adoc contradictions` query: unresolved contradictions
 /// (all statuses with `include_all`) plus contradicted claims with their
-/// implicating contradiction ids, re-derived at read time. Clock-free.
+/// implicating contradiction ids, re-derived at read time with no clock
+/// dependence — a pure function of the artifact.
 pub fn evaluate_contradictions(
     session: &GraphSession,
     include_all: bool,

--- a/crates/adoc-local/src/lib.rs
+++ b/crates/adoc-local/src/lib.rs
@@ -12,12 +12,12 @@ pub use error::LocalError;
 pub use path_policy::{PathPolicy, ProjectRootPathPolicy, UnrestrictedPathPolicy};
 pub use use_cases::{
     BuildInput, BuildOutcome, BuildOutputs, BuildUseCase, CheckInput, CheckOutcome, CheckUseCase,
-    DiffInput, DiffOutcome, DiffUseCase, GraphInput, GraphOutcome, GraphUseCase, InitInput,
-    InitOutcome, InitUseCase, PatchCheckInput, PatchCheckOutcome, PatchCheckUseCase,
-    ProjectArtifactLoadStatus, ProjectArtifactStatus, ProjectStatusArtifacts, ProjectStatusConfig,
-    ProjectStatusInput, ProjectStatusOutcome, ProjectStatusPaths, ProjectStatusReadiness,
-    ProjectStatusRefresh, ProjectStatusRefreshReport, ProjectStatusUseCase,
-    ResolvedRetrievalRecord, ReviewInput, ReviewOutcome, ReviewPatchSource, ReviewUseCase,
-    SearchInput, SearchOutcome, SearchUseCase, StaleInput, StaleOutcome, StaleUseCase, WhyInput,
-    WhyOutcome, WhyUseCase,
+    ContradictionsInput, ContradictionsOutcome, ContradictionsUseCase, DiffInput, DiffOutcome,
+    DiffUseCase, GraphInput, GraphOutcome, GraphUseCase, InitInput, InitOutcome, InitUseCase,
+    PatchCheckInput, PatchCheckOutcome, PatchCheckUseCase, ProjectArtifactLoadStatus,
+    ProjectArtifactStatus, ProjectStatusArtifacts, ProjectStatusConfig, ProjectStatusInput,
+    ProjectStatusOutcome, ProjectStatusPaths, ProjectStatusReadiness, ProjectStatusRefresh,
+    ProjectStatusRefreshReport, ProjectStatusUseCase, ResolvedRetrievalRecord, ReviewInput,
+    ReviewOutcome, ReviewPatchSource, ReviewUseCase, SearchInput, SearchOutcome, SearchUseCase,
+    StaleInput, StaleOutcome, StaleUseCase, WhyInput, WhyOutcome, WhyUseCase,
 };

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -7,16 +7,17 @@ use std::time::{Duration, Instant};
 
 use adoc_core::{
     ArtifactInspection, ArtifactLoadStatus, BuildArtifacts, BuildEmbeddingMode,
-    BuildInput as CoreBuildInput, CompileInput, CompileResult, Diagnostic, DiagnosticCode,
-    EmbeddingProviderSelection, GitRef, GraphArtifactInspectionInput, GraphDirection,
-    GraphInput as CoreGraphInput, GraphRelationKind, GraphTraversalEnvelope, GraphTraversalQuery,
-    GraphTraversalResult, ObjectDiffEnvelope, PatchCheckResult, PatchInput, RetrievalEnvelope,
-    RetrievalInput, RetrievalLoadResult, RetrievalRecord, ReviewEnvelope, ReviewError,
-    ReviewInput as CoreReviewInput, SearchArtifactInspectionInput, SearchFilters, SearchMode,
-    SearchQuery, Severity, SnapshotSelector, StaleEnvelope,
+    BuildInput as CoreBuildInput, CompileInput, CompileResult, ContradictionsEnvelope, Diagnostic,
+    DiagnosticCode, EmbeddingProviderSelection, GitRef, GraphArtifactInspectionInput,
+    GraphDirection, GraphInput as CoreGraphInput, GraphRelationKind, GraphTraversalEnvelope,
+    GraphTraversalQuery, GraphTraversalResult, ObjectDiffEnvelope, PatchCheckResult, PatchInput,
+    RetrievalEnvelope, RetrievalInput, RetrievalLoadResult, RetrievalRecord, ReviewEnvelope,
+    ReviewError, ReviewInput as CoreReviewInput, SearchArtifactInspectionInput, SearchFilters,
+    SearchMode, SearchQuery, Severity, SnapshotSelector, StaleEnvelope,
     build_workspace_with_embedding_provider, check_patch as core_check_patch, compile_workspace,
-    diff_objects, embed_query_with_embedding_provider, empty_stale_envelope, evaluate_stale,
-    git_review_available, inspect_graph_artifact, inspect_search_artifact, load_graph_session,
+    diff_objects, embed_query_with_embedding_provider, empty_contradictions_envelope,
+    empty_stale_envelope, evaluate_contradictions, evaluate_stale, git_review_available,
+    inspect_graph_artifact, inspect_search_artifact, load_graph_session,
     load_retrieval_session_with_embedding_provider, load_review_from_git,
     load_review_with_changed_files_from_git, parse_patch_from_path, parse_patch_from_value,
     review_with_patch, search as core_search, traverse_graph, why_object,
@@ -128,6 +129,20 @@ pub struct StaleInput {
 #[derive(Debug, Clone, Serialize)]
 pub struct StaleOutcome {
     pub envelope: StaleEnvelope,
+    pub exit_code: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct ContradictionsInput {
+    pub artifact: Option<PathBuf>,
+    /// `--all`: include `resolved` and `dismissed` contradictions in the
+    /// listing (never affects `contradicted_claims`).
+    pub all: bool,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct ContradictionsOutcome {
+    pub envelope: ContradictionsEnvelope,
     pub exit_code: i32,
 }
 
@@ -399,6 +414,27 @@ where
 
     pub fn run(&self, input: StaleInput) -> Result<StaleOutcome, LocalError> {
         stale_with_context(&self.context, input)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ContradictionsUseCase<P>
+where
+    P: PathPolicy,
+{
+    context: LocalContext<P>,
+}
+
+impl<P> ContradictionsUseCase<P>
+where
+    P: PathPolicy,
+{
+    pub fn new(context: LocalContext<P>) -> Self {
+        Self { context }
+    }
+
+    pub fn run(&self, input: ContradictionsInput) -> Result<ContradictionsOutcome, LocalError> {
+        contradictions_with_context(&self.context, input)
     }
 }
 
@@ -727,7 +763,7 @@ where
         .session
         .filter(|_| !diagnostics_have_errors(&diagnostics));
     let Some(session) = session else {
-        let exit_code = stale_exit_code_for_diagnostics(&diagnostics);
+        let exit_code = signal_query_exit_code(&diagnostics);
         return Ok(StaleOutcome {
             envelope: empty_stale_envelope(diagnostics),
             exit_code,
@@ -735,8 +771,46 @@ where
     };
 
     let envelope = evaluate_stale(&session, input.within_days, diagnostics);
-    let exit_code = stale_exit_code_for_diagnostics(&envelope.diagnostics);
+    let exit_code = signal_query_exit_code(&envelope.diagnostics);
     Ok(StaleOutcome {
+        envelope,
+        exit_code,
+    })
+}
+
+fn contradictions_with_context<P>(
+    context: &LocalContext<P>,
+    input: ContradictionsInput,
+) -> Result<ContradictionsOutcome, LocalError>
+where
+    P: PathPolicy,
+{
+    let artifact = input
+        .artifact
+        .as_deref()
+        .map(|path| context.path_policy().resolve_read_path(path))
+        .transpose()?;
+    let config = discover_project_config_if(artifact.is_none(), context.config_start())?;
+    let graph_artifact = resolve_graph_artifact_path_with_config(artifact, config.as_ref());
+    let graph_artifact = context.path_policy().resolve_read_path(&graph_artifact)?;
+    let load_result = load_graph_session(CoreGraphInput {
+        graph_artifact_path: graph_artifact,
+    });
+    let diagnostics = load_result.diagnostics;
+    let session = load_result
+        .session
+        .filter(|_| !diagnostics_have_errors(&diagnostics));
+    let Some(session) = session else {
+        let exit_code = signal_query_exit_code(&diagnostics);
+        return Ok(ContradictionsOutcome {
+            envelope: empty_contradictions_envelope(diagnostics),
+            exit_code,
+        });
+    };
+
+    let envelope = evaluate_contradictions(&session, input.all, diagnostics);
+    let exit_code = signal_query_exit_code(&envelope.diagnostics);
+    Ok(ContradictionsOutcome {
         envelope,
         exit_code,
     })
@@ -1593,13 +1667,13 @@ fn graph_diagnostic_exit_code(diagnostic: &Diagnostic) -> Option<i32> {
     }
 }
 
-/// `adoc stale` is a query, not a gate: records never affect the exit code;
-/// only artifact-load errors do.
-fn stale_exit_code_for_diagnostics(diagnostics: &[Diagnostic]) -> i32 {
-    exit_code_for_diagnostics(diagnostics, stale_diagnostic_exit_code)
+/// Lifecycle-signal queries (`adoc stale`, `adoc contradictions`) are queries,
+/// not gates: records never affect the exit code; only artifact-load errors do.
+fn signal_query_exit_code(diagnostics: &[Diagnostic]) -> i32 {
+    exit_code_for_diagnostics(diagnostics, signal_query_diagnostic_exit_code)
 }
 
-fn stale_diagnostic_exit_code(diagnostic: &Diagnostic) -> Option<i32> {
+fn signal_query_diagnostic_exit_code(diagnostic: &Diagnostic) -> Option<i32> {
     match diagnostic.severity {
         Severity::Error => Some(2),
         _ => None,

--- a/crates/adoc-mcp/src/lib.rs
+++ b/crates/adoc-mcp/src/lib.rs
@@ -8,11 +8,11 @@ use adoc_core::{
     GraphDirection, GraphRelationKind, PatchJsonInput, RetrievalEnvelope, check_patch_json,
 };
 use adoc_local::{
-    BuildInput, BuildUseCase, CheckInput, CheckUseCase, DiffInput, DiffUseCase, GraphInput,
-    GraphUseCase, InitInput, InitUseCase, LocalContext, PatchCheckInput, PatchCheckUseCase,
-    PathPolicy, ProjectConfig, ProjectRootPathPolicy, ProjectStatusInput, ProjectStatusRefresh,
-    ProjectStatusUseCase, ReviewInput, ReviewPatchSource, ReviewUseCase, SearchInput,
-    SearchUseCase, StaleInput, StaleUseCase, WhyInput, WhyUseCase,
+    BuildInput, BuildUseCase, CheckInput, CheckUseCase, ContradictionsInput, ContradictionsUseCase,
+    DiffInput, DiffUseCase, GraphInput, GraphUseCase, InitInput, InitUseCase, LocalContext,
+    PatchCheckInput, PatchCheckUseCase, PathPolicy, ProjectConfig, ProjectRootPathPolicy,
+    ProjectStatusInput, ProjectStatusRefresh, ProjectStatusUseCase, ReviewInput, ReviewPatchSource,
+    ReviewUseCase, SearchInput, SearchUseCase, StaleInput, StaleUseCase, WhyInput, WhyUseCase,
 };
 use rmcp::{
     ServerHandler,
@@ -122,6 +122,18 @@ impl AgentDocMcpServer {
         let outcome = StaleUseCase::new(context).run(StaleInput {
             artifact: params.artifact,
             within_days: params.within_days,
+        })?;
+        serde_json::to_value(outcome.envelope).map_err(Into::into)
+    }
+
+    pub fn run_contradictions(
+        &self,
+        params: ContradictionsParams,
+    ) -> McpAdapterResult<serde_json::Value> {
+        let context = self.context(params.project_root)?;
+        let outcome = ContradictionsUseCase::new(context).run(ContradictionsInput {
+            artifact: params.artifact,
+            all: params.all,
         })?;
         serde_json::to_value(outcome.envelope).map_err(Into::into)
     }
@@ -327,6 +339,19 @@ impl AgentDocMcpServer {
     }
 
     #[tool(
+        name = "adoc_contradictions",
+        description = "List unresolved contradictions and the claims they implicate (with all=true: resolved and dismissed too), joined from the graph artifact. Read-only query: findings are data, not failures."
+    )]
+    pub fn adoc_contradictions(
+        &self,
+        Parameters(params): Parameters<ContradictionsParams>,
+    ) -> Result<CallToolResult, ErrorData> {
+        self.run_contradictions(params)
+            .map(CallToolResult::structured)
+            .map_err(adapter_error)
+    }
+
+    #[tool(
         name = "adoc_search",
         description = "Search compiled AgentDoc graph and search artifacts."
     )]
@@ -495,6 +520,17 @@ pub struct StaleParams {
     /// Additionally list verified objects whose `expires_at` falls within the
     /// next N days as `expiring_soon` records.
     pub within_days: Option<u32>,
+}
+
+#[derive(Debug, Clone, Default, Deserialize, JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct ContradictionsParams {
+    pub project_root: Option<PathBuf>,
+    pub artifact: Option<PathBuf>,
+    /// Include `resolved` and `dismissed` contradictions in the listing
+    /// (never affects `contradicted_claims`).
+    #[serde(default)]
+    pub all: bool,
 }
 
 #[derive(Debug, Clone, Deserialize, JsonSchema)]

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -167,6 +167,14 @@ const RESOURCES: &[AgentResource] = &[
         contents: include_str!("../../../docs/agent/v0/schema/stale.md"),
     },
     AgentResource {
+        uri: "adoc://agent/v0/schema/contradictions",
+        name: "schema-contradictions",
+        title: "Contradictions Query Schema Reference",
+        description: "Markdown reference for adoc.contradictions.v0.",
+        mime_type: MARKDOWN,
+        contents: include_str!("../../../docs/agent/v0/schema/contradictions.md"),
+    },
+    AgentResource {
         uri: "adoc://agent/v0/schema/retrieval-envelope.json",
         name: "schema-retrieval-envelope-json",
         title: "Retrieval Envelope JSON Schema",
@@ -237,6 +245,14 @@ const RESOURCES: &[AgentResource] = &[
         description: "JSON Schema for adoc.stale.v0.",
         mime_type: JSON_SCHEMA,
         contents: include_str!("../../../docs/agent/v0/schema/adoc.stale.v0.schema.json"),
+    },
+    AgentResource {
+        uri: "adoc://agent/v0/schema/adoc.contradictions.v0.schema.json",
+        name: "schema-adoc-contradictions-v0-json",
+        title: "Contradictions Query JSON Schema",
+        description: "JSON Schema for adoc.contradictions.v0.",
+        mime_type: JSON_SCHEMA,
+        contents: include_str!("../../../docs/agent/v0/schema/adoc.contradictions.v0.schema.json"),
     },
 ];
 

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -8,8 +8,8 @@ use adoc_core::{
     review_with_patch,
 };
 use adoc_mcp::{
-    AdocPatchCheckParams, AdocReviewParams, AgentDocMcpServer, BuildParams, GraphParams,
-    InitParams, PatchInput, ProjectStatusParams, SearchParams, StaleParams,
+    AdocPatchCheckParams, AdocReviewParams, AgentDocMcpServer, BuildParams, ContradictionsParams,
+    GraphParams, InitParams, PatchInput, ProjectStatusParams, SearchParams, StaleParams,
 };
 use serde_json::json;
 
@@ -202,6 +202,19 @@ fn validates_representative_serialized_agent_envelopes_against_contract_schemas(
         .expect("stale succeeds");
     assert_valid("adoc.stale.v0.schema.json", &stale);
     assert_eq!(stale["records"], serde_json::json!([]));
+
+    // Likewise the empty-lists contradictions envelope: the fixture project
+    // has no contradiction objects at all.
+    let contradictions = server
+        .run_contradictions(ContradictionsParams {
+            project_root: None,
+            artifact: None,
+            all: false,
+        })
+        .expect("contradictions succeeds");
+    assert_valid("adoc.contradictions.v0.schema.json", &contradictions);
+    assert_eq!(contradictions["contradictions"], serde_json::json!([]));
+    assert_eq!(contradictions["contradicted_claims"], serde_json::json!([]));
 }
 
 /// V6.1: `adoc_stale` envelopes with all three record categories validate
@@ -304,6 +317,150 @@ fn validates_adoc_stale_v0_envelope_against_schema() {
     assert!(categories.contains(&"stale"));
     assert!(categories.contains(&"review_overdue"));
     assert!(categories.contains(&"expiring_soon"));
+}
+
+/// V6.2: `adoc_contradictions` envelopes — populated default listing, the
+/// `all: true` superset, and an orphaned authored-`contradicted` claim with an
+/// empty `contradiction_ids` — validate against
+/// `adoc.contradictions.v0.schema.json`.
+#[test]
+fn validates_adoc_contradictions_v0_envelope_against_schema() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(
+        &root.join("docs/index.adoc"),
+        concat!(
+            "# Conflicts @doc(team.conflicts)\n",
+            "\n",
+            "::claim team.storage-memory\n",
+            "status: contradicted\n",
+            "owner: team-docs\n",
+            "--\n",
+            "Tokens must be stored in memory only.\n",
+            "::\n",
+            "\n",
+            "::claim team.storage-local\n",
+            "status: accepted\n",
+            "owner: team-docs\n",
+            "--\n",
+            "Tokens may be stored in localStorage.\n",
+            "::\n",
+            "\n",
+            "::claim team.orphaned\n",
+            "status: contradicted\n",
+            "owner: team-docs\n",
+            "--\n",
+            "Authored contradicted with no unresolved contradiction left.\n",
+            "::\n",
+            "\n",
+            "::claim team.settled-a\n",
+            "status: accepted\n",
+            "--\n",
+            "First settled claim.\n",
+            "::\n",
+            "\n",
+            "::claim team.settled-b\n",
+            "status: accepted\n",
+            "--\n",
+            "Second settled claim.\n",
+            "::\n",
+            "\n",
+            "::contradiction team.conflict-open\n",
+            "severity: high\n",
+            "status: unresolved\n",
+            "claims: [team.storage-memory, team.storage-local]\n",
+            "--\n",
+            "Memory-only storage conflicts with the localStorage allowance.\n",
+            "::\n",
+            "\n",
+            "::contradiction team.conflict-closed\n",
+            "severity: critical\n",
+            "status: resolved\n",
+            "claims: [team.settled-a, team.settled-b]\n",
+            "--\n",
+            "Resolved conflict kept for history.\n",
+            "::\n",
+        ),
+    );
+    write(
+        &root.join("agentdoc.config.yaml"),
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: deterministic\n",
+    );
+    let server = AgentDocMcpServer::new(root.to_path_buf());
+    server
+        .run_build(BuildParams {
+            project_root: None,
+            path: None,
+            out: None,
+            no_embeddings: false,
+        })
+        .expect("build succeeds");
+
+    let envelope = server
+        .run_contradictions(ContradictionsParams {
+            project_root: None,
+            artifact: None,
+            all: false,
+        })
+        .expect("contradictions succeeds");
+    assert_valid("adoc.contradictions.v0.schema.json", &envelope);
+    assert!(
+        envelope.get("evaluated_at").is_none(),
+        "the contradictions envelope is clock-free"
+    );
+    let contradictions = envelope["contradictions"]
+        .as_array()
+        .expect("contradictions array");
+    assert_eq!(
+        contradictions.len(),
+        1,
+        "default listing is unresolved-only: {contradictions:#?}"
+    );
+    assert_eq!(contradictions[0]["id"], "team.conflict-open");
+    let claims = envelope["contradicted_claims"]
+        .as_array()
+        .expect("contradicted_claims array");
+    assert_eq!(
+        claims.len(),
+        3,
+        "two implicated + one orphaned authored contradicted: {claims:#?}"
+    );
+    let orphan = claims
+        .iter()
+        .find(|claim| claim["id"] == "team.orphaned")
+        .expect("orphaned claim listed");
+    assert_eq!(
+        orphan["contradiction_ids"],
+        serde_json::json!([]),
+        "orphaned authored status carries an empty contradiction_ids"
+    );
+    assert!(orphan.get("effective_reason").is_none());
+
+    let all_envelope = server
+        .run_contradictions(ContradictionsParams {
+            project_root: None,
+            artifact: None,
+            all: true,
+        })
+        .expect("contradictions --all succeeds");
+    assert_valid("adoc.contradictions.v0.schema.json", &all_envelope);
+    let all_contradictions = all_envelope["contradictions"]
+        .as_array()
+        .expect("contradictions array");
+    assert_eq!(
+        all_contradictions.len(),
+        2,
+        "all: true adds the resolved record: {all_contradictions:#?}"
+    );
+    assert_eq!(
+        all_contradictions[0]["id"], "team.conflict-closed",
+        "critical sorts before high"
+    );
+    assert_eq!(all_contradictions[0]["status"], "resolved");
+    assert_eq!(
+        all_envelope["contradicted_claims"], envelope["contradicted_claims"],
+        "--all never changes contradicted_claims"
+    );
 }
 
 #[test]

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -278,6 +278,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/schema/diff",
         "adoc://agent/v0/schema/review",
         "adoc://agent/v0/schema/stale",
+        "adoc://agent/v0/schema/contradictions",
         "adoc://agent/v0/schema/retrieval-envelope.json",
         "adoc://agent/v0/schema/graph-traversal-envelope.json",
         "adoc://agent/v0/schema/patch-input.json",
@@ -287,6 +288,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/schema/adoc.diff.v0.schema.json",
         "adoc://agent/v0/schema/adoc.review.v0.schema.json",
         "adoc://agent/v0/schema/adoc.stale.v0.schema.json",
+        "adoc://agent/v0/schema/adoc.contradictions.v0.schema.json",
     ];
 
     let resources = server.list_agent_resources();

--- a/docs/ROADMAP-V6.md
+++ b/docs/ROADMAP-V6.md
@@ -58,7 +58,7 @@ Deferred: `--fail-on-stale` CI gating, health scores (PRD §14.5), staleness fro
 
 ### V6.2: `adoc contradictions` Slice
 
-Goal: give unresolved contradictions and contradicted claims a query surface.
+Goal: give unresolved contradictions and contradicted claims a query surface. Implemented (ADR-0038, [V6-DESIGN.md](V6-DESIGN.md) §V6.2).
 
 Scope:
 

--- a/docs/V6-DESIGN.md
+++ b/docs/V6-DESIGN.md
@@ -84,7 +84,7 @@ Records sort most-overdue first, then Object ID ascending, then a fixed category
 
 ### Module layout
 
-- `crates/adoc-core/src/application/signals.rs` — categories, records, envelope, pure `evaluate_stale_for_date` (will also host V6.2 `adoc contradictions`).
+- `crates/adoc-core/src/application/signals.rs` — categories, records, envelope, pure `evaluate_stale_for_date` (also hosts V6.2 `adoc contradictions`).
 - `crates/adoc-core/src/infrastructure/artifact/graph_json.rs` — `derive_effective_status_from_fields`, the field-string core extracted from the V5.10 `derive_effective_status` so build-time and read-time derivation share one implementation.
 - `crates/adoc-local/src/use_cases.rs` — `StaleUseCase` mirroring the graph use case (artifact resolution via config, path policy, exit codes).
 - `crates/adoc-cli/src/commands/stale.rs` — thin subcommand with plain/styled/json presenters.
@@ -94,7 +94,81 @@ Records sort most-overdue first, then Object ID ascending, then a fixed category
 
 Against the Expanded Pilot (`crates/adoc-cli/tests/expanded_pilot.rs::expanded_pilot_stale_query`): exactly 3 records in clock-stable order — `security.production-db-access` (`review_overdue`, due 2020-03-31), `security.audit.retention` (`stale`, verified → stale), `billing.credits.legacy-export` (`stale`, draft, echo) — and `--within 36500d` adds `billing.credits.consume` (expires 2120-01-01) then `auth.mfa.enforced` (expires 2125-01-01) as `expiring_soon`.
 
-## V6.2: `adoc contradictions` — contract recorded at slice start
+## V6.2: `adoc contradictions` — Implemented
+
+### Wire contract
+
+`adoc.contradictions.v0`, emitted by `adoc contradictions` and the MCP tool `adoc_contradictions`:
+
+```json
+{
+  "schema_version": "adoc.contradictions.v0",
+  "contradictions": [
+    {
+      "id": "auth.session.conflict",
+      "severity": "high",
+      "status": "unresolved",
+      "claims": [
+        "auth.session.csrf-protection",
+        "auth.session.local-storage-allowed",
+        "auth.session.memory-storage"
+      ],
+      "source_path": "examples/expanded-pilot/security/contradictions.adoc",
+      "summary": "Claim auth.session.memory-storage requires memory-only storage while"
+    }
+  ],
+  "contradicted_claims": [
+    {
+      "id": "auth.session.csrf-protection",
+      "authored_status": "accepted",
+      "effective_status": "contradicted",
+      "effective_reason": "contradiction:auth.session.conflict",
+      "contradiction_ids": ["auth.session.conflict"]
+    }
+  ],
+  "diagnostics": []
+}
+```
+
+JSON Schema: `docs/agent/v0/schema/adoc.contradictions.v0.schema.json` (resource `adoc://agent/v0/schema/adoc.contradictions.v0.schema.json`); prose reference `docs/agent/v0/schema/contradictions.md` (resource `adoc://agent/v0/schema/contradictions`). Contract-tested in `crates/adoc-mcp/tests/contract_schemas.rs` with the populated default listing, the `--all` superset, the orphaned authored-`contradicted` case, and the empty-lists case.
+
+### Derivation and membership rules
+
+Two record classes from one artifact pass, joined for the consumer:
+
+- **`contradictions`** — every `contradiction` node with status `unresolved`; `--all` (MCP `all: true`) removes the status filter and echoes `resolved`/`dismissed` statuses. Each record carries severity, the parse-time sorted+deduplicated `claims` list, optional `owner`, `source_path`, and `summary` (first non-empty body line, char-truncated to 120 with `…`).
+- **`contradicted_claims`** — every `claim` node implicated by at least one unresolved contradiction **or** whose authored status is `contradicted`. Implication is re-derived at read time from the artifact's contradiction nodes via the shared `unresolved_contradiction_claim_index` (the same reverse index the build-time `effective_status` propagation uses) — the persisted projection is never consulted (ADR-0038). `contradiction_ids` lists all implicating unresolved contradiction ids sorted ascending; `effective_reason` is `contradiction:<id>` with the lexicographically smallest (identical to the build-time rule).
+
+**Clock-free by design.** Unlike `adoc stale`, nothing here is clock-dependent: the envelope carries no `evaluated_at` and the output is a pure function of the artifact bytes — same artifact, byte-identical output on any day. Consequently `effective_status` reports the **contradiction axis only**: `contradicted` when implicated, otherwise an echo of the authored status. A claim that is both expired and contradicted reads `stale` from `adoc stale` and `contradicted` from `adoc contradictions`; the build artifact's single `effective_status` slot keeps its stale-wins precedence. The two commands answer different axes.
+
+### Determinism and sorting
+
+`contradictions` sort severity-descending (`critical > high > medium > low`, via the `Severity` value object's derived `Ord`), then Object ID ascending; a missing or unparseable severity sorts last and is echoed raw. `contradicted_claims` sort by Object ID ascending.
+
+### Edge cases (decided)
+
+- **Orphaned authored status:** a claim authored `contradicted` with no implicating unresolved contradiction is listed with `contradiction_ids: []`, `effective_status` echoing `contradicted`, and no `effective_reason`.
+- **`--all` never changes `contradicted_claims`:** only unresolved contradictions implicate claims (the build-time rule). Claims referenced solely by `resolved`/`dismissed` contradictions are not listed.
+- **Dangling or non-claim references** in a contradiction's `claims[]` produce no `contradicted_claims` record — compile already diagnosed them (`schema.contradiction_claim_not_found` / `_not_a_claim`).
+- **Severity carrier:** records read the ADR-0035 top-level `severity` dual-emit first and fall back to `fields.severity` for pre-dual-emit `adoc.graph.v3` artifacts.
+
+### Surfaces
+
+- **CLI:** `adoc contradictions [--artifact <path>] [--all] --format auto|plain|styled|json`. Markdown format stays diff/review-only.
+- **MCP:** `adoc_contradictions { project_root?, artifact?, all? }` returning the envelope directly (the `adoc_stale` precedent).
+- **Exit codes:** `0` with or without findings; `2` on artifact-load failure with the same envelope shape, empty lists, and fix-oriented diagnostics.
+
+### Module layout
+
+- `crates/adoc-core/src/application/signals.rs` — records, envelope, pure `evaluate_contradictions`, `body_summary` (shared module with V6.1 per ADR-0038).
+- `crates/adoc-core/src/infrastructure/artifact/graph_json.rs` — `unresolved_contradiction_claim_index`, the reverse index shared by the build-time `apply_contradiction_effective_status` pass and the read-time query.
+- `crates/adoc-local/src/use_cases.rs` — `ContradictionsUseCase`; the stale exit-code helper is generalized to `signal_query_exit_code`.
+- `crates/adoc-cli/src/commands/contradictions.rs` — thin subcommand with plain/styled/json presenters.
+- `crates/adoc-mcp/src/lib.rs` — `adoc_contradictions` tool; resources registered in `resources.rs`.
+
+### Acceptance (pinned in tests)
+
+Against the Expanded Pilot (`crates/adoc-cli/tests/expanded_pilot.rs::expanded_pilot_contradictions_query`): exactly 1 contradiction (`auth.session.conflict`, severity `high`, status `unresolved`) and exactly 3 `contradicted_claims` in id order — `auth.session.csrf-protection` (authored `accepted`, effective `contradicted`), `auth.session.local-storage-allowed` and `auth.session.memory-storage` (authored `contradicted`) — each with `contradiction_ids: ["auth.session.conflict"]`. `--all` output is identical on this pilot.
 
 ## V6.3: `adoc impacted-by` — contract recorded at slice start
 

--- a/docs/adr/0038-lifecycle-signal-read-commands.md
+++ b/docs/adr/0038-lifecycle-signal-read-commands.md
@@ -40,15 +40,18 @@ The V6.1–V6.3 commands (`adoc stale`, `adoc contradictions`,
    `GraphSession` index. Operational failures (missing artifact, malformed
    JSON, `SchemaUnsupportedVersion`) surface through the existing diagnostics
    with exit code 2.
-2. **Clock-dependent signals are re-derived at read time.** The shared
-   derivation core is extracted as
-   `derive_effective_status_from_fields(status, expires_at, today)` in
-   `infrastructure/artifact/graph_json.rs`; the build-time
-   `derive_effective_status` delegates to it, so build and read can never
-   disagree on the rule. The evaluation date enters once, via the hoisted
-   `application::local_today()`, and every envelope carries `evaluated_at`.
-   The persisted `effective_status` projection is never consulted at read
-   time.
+2. **Signals are re-derived at read time from shared derivation cores.** The
+   expiry core is extracted as
+   `derive_effective_status_from_fields(status, expires_at, today)` and the
+   contradiction reverse index as `unresolved_contradiction_claim_index`,
+   both in `infrastructure/artifact/graph_json.rs`; the build-time
+   `derive_effective_status` / `apply_contradiction_effective_status`
+   delegate to them, so build and read can never disagree on a rule. For
+   clock-dependent signals the evaluation date enters once, via the hoisted
+   `application::local_today()`, and the envelope carries `evaluated_at`;
+   a clock-free envelope (`adoc.contradictions.v0`) deliberately omits
+   `evaluated_at` — it is a pure function of the artifact bytes. The
+   persisted `effective_status` projection is never consulted at read time.
 3. **Queries, not gates.** Exit code 0 whether or not records exist. Findings
    are data in a versioned envelope (`adoc.stale.v0`,
    `adoc.contradictions.v0`, `adoc.impacted.v0`), JSON-Schema'd and
@@ -69,6 +72,16 @@ re-derives `"stale"` only for verified objects (the ADR-0033 rule) and
 otherwise echoes the authored status. Records sort most-overdue first, then
 Object ID, then a fixed category ordinal. The full rule table, edge cases, and
 surfaces are pinned in [V6-DESIGN.md](../V6-DESIGN.md).
+
+For `adoc contradictions` specifically (V6.2, implemented): membership in
+`contradicted_claims` is implication by ≥ 1 unresolved contradiction **or**
+authored status `contradicted`, recomputed from the artifact's contradiction
+nodes via the shared reverse index. The envelope reports the contradiction
+axis only — a claim both expired and contradicted reads `stale` from
+`adoc stale` and `contradicted` here, while the build artifact's single
+`effective_status` slot keeps its stale-wins precedence. Sorting is severity
+descending then Object ID; `--all` widens only the contradictions listing,
+never `contradicted_claims`. Pinned in [V6-DESIGN.md](../V6-DESIGN.md) §V6.2.
 
 ## Consequences
 

--- a/docs/agent/v0/contradiction-guide.md
+++ b/docs/agent/v0/contradiction-guide.md
@@ -19,9 +19,13 @@ A `contradiction` is authored by a human who has identified a conflict between t
 | `claims` | `[object.id, ...]` | at least two distinct `claim` IDs |
 | `body` | prose | explanation of the conflict |
 
+## Query surface
+
+`adoc contradictions` / the `adoc_contradictions` MCP tool (V6.2) list every `unresolved` contradiction plus every contradicted claim with the contradiction ids that implicate it, joined in one `adoc.contradictions.v0` envelope — run it **before answering definitively in a domain** instead of scanning the graph yourself. The output is a pure function of the graph artifact (no clock); `all: true` adds `resolved` and `dismissed` records. See `adoc://agent/v0/schema/contradictions`.
+
 ## How to use a contradiction in answers
 
-- **Surface active contradictions.** Before answering definitively about a claim, check whether any `unresolved` contradiction references that claim. If one exists, surface it to the user.
+- **Surface active contradictions.** Before answering definitively about a claim, check whether any `unresolved` contradiction references that claim — `adoc_contradictions` answers this in one call. If one exists, surface it to the user.
 - **Cite by Object ID.** Reference the contradiction and both conflicting claims by their Object IDs.
 - **Do not invent resolutions.** If the contradiction is `unresolved`, report the conflict as unresolved. Do not guess which claim is correct.
 - **Resolved/dismissed contradictions.** A `resolved` contradiction means the conflict has been addressed (e.g. one claim was updated). A `dismissed` contradiction means the conflict was judged non-applicable. Both are terminal states; you may note them as context but they do not require active surfacing.

--- a/docs/agent/v0/schema/adoc.contradictions.v0.schema.json
+++ b/docs/agent/v0/schema/adoc.contradictions.v0.schema.json
@@ -1,0 +1,74 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adoc://agent/v0/schema/adoc.contradictions.v0.schema.json",
+  "title": "AgentDoc Contradictions Query",
+  "description": "Listing of unresolved contradictions (all statuses with --all) plus every contradicted claim with the contradiction ids that implicate it, so consumers never join the two lists. Emitted by `adoc contradictions` and the `adoc_contradictions` MCP tool. A pure function of the graph artifact: no evaluation date, byte-identical output for the same artifact on any day. Contradictions are sorted severity-descending then by Object ID; contradicted claims by Object ID. See ROADMAP-V6.md §V6.2 and ADR-0038.",
+  "type": "object",
+  "required": ["schema_version", "contradictions", "contradicted_claims", "diagnostics"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": { "const": "adoc.contradictions.v0" },
+    "contradictions": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/contradictionRecord" }
+    },
+    "contradicted_claims": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/contradictedClaim" }
+    },
+    "diagnostics": {
+      "description": "Artifact-load diagnostics. Contradiction findings themselves are data, not diagnostics.",
+      "type": "array",
+      "items": { "type": "object" }
+    }
+  },
+  "$defs": {
+    "contradictionRecord": {
+      "type": "object",
+      "required": ["id", "severity", "status", "claims", "source_path", "summary"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "severity": { "enum": ["low", "medium", "high", "critical"] },
+        "status": {
+          "description": "Echo of the authored status. The default listing contains only `unresolved`; `resolved` and `dismissed` appear only with --all.",
+          "enum": ["unresolved", "resolved", "dismissed"]
+        },
+        "claims": {
+          "description": "The claim Object IDs this contradiction links, sorted and deduplicated at parse time.",
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "owner": { "type": "string" },
+        "source_path": { "type": "string" },
+        "summary": {
+          "description": "First non-empty body line, truncated to 120 characters with a trailing ellipsis when cut.",
+          "type": "string"
+        }
+      }
+    },
+    "contradictedClaim": {
+      "type": "object",
+      "required": ["id", "contradiction_ids"],
+      "additionalProperties": false,
+      "properties": {
+        "id": { "type": "string" },
+        "authored_status": { "type": "string" },
+        "effective_status": {
+          "description": "Contradiction-axis derivation only: `contradicted` when implicated by an unresolved contradiction, otherwise an echo of the authored status. The expiry axis is `adoc stale`'s job.",
+          "type": "string"
+        },
+        "effective_reason": {
+          "description": "`contradiction:<id>` where `<id>` is the lexicographically smallest implicating contradiction — identical to the build-time projection. Absent when no unresolved contradiction implicates the claim.",
+          "type": "string",
+          "pattern": "^contradiction:.+$"
+        },
+        "contradiction_ids": {
+          "description": "All implicating unresolved contradiction ids, sorted ascending. Empty only for a claim whose authored status is `contradicted` while no unresolved contradiction references it.",
+          "type": "array",
+          "items": { "type": "string" }
+        }
+      }
+    }
+  }
+}

--- a/docs/agent/v0/schema/contradictions.md
+++ b/docs/agent/v0/schema/contradictions.md
@@ -1,0 +1,14 @@
+# AgentDoc Contradictions Query Schema
+
+The V6.2 contradiction query surface is `adoc.contradictions.v0`.
+
+Contradiction envelopes are returned by `adoc contradictions` and the `adoc_contradictions` MCP tool. The envelope joins two record classes from one graph-artifact pass, so consumers never have to join them:
+
+- `contradictions` — every `contradiction` Knowledge Object with status `unresolved` (with `--all` / `all: true`: `resolved` and `dismissed` too), carrying severity, the sorted claim list, optional owner, source path, and a one-line body `summary` (first non-empty line, truncated to 120 characters).
+- `contradicted_claims` — every claim implicated by at least one unresolved contradiction **or** whose authored status is `contradicted`, each with `contradiction_ids`: all implicating unresolved contradiction ids, sorted ascending. A claim authored `contradicted` with no implicating contradiction is still listed, with an empty `contradiction_ids`.
+
+Implication is re-derived at read time from the artifact's contradiction nodes — never from the persisted `effective_status` projection (ADR-0038). `effective_status` reports the **contradiction axis only**: `contradicted` when implicated, otherwise an echo of the authored status, with `effective_reason: contradiction:<id>` naming the lexicographically smallest implicating contradiction (the same rule as the build-time projection). A claim that is both expired and contradicted reads `stale` from `adoc stale` and `contradicted` here — the two commands answer different axes; the build artifact's single `effective_status` slot keeps stale precedence.
+
+The envelope is a pure function of the artifact bytes: it carries no evaluation date and is byte-identical for the same artifact on any day. Contradictions sort severity-descending (`critical` first), then by Object ID; contradicted claims sort by Object ID. `--all` never changes `contradicted_claims` — only unresolved contradictions implicate claims.
+
+The query is not a gate: exit code 0 (and a normal envelope) whether or not findings exist. Non-zero exit codes occur only on artifact-load failure, with fix-oriented diagnostics and empty lists.

--- a/docs/agent/v0/usage-contract.md
+++ b/docs/agent/v0/usage-contract.md
@@ -2,7 +2,7 @@
 
 V2.2 gives agents a stable local contract over AgentDoc artifacts. Agents must retrieve or inspect AgentDoc data through MCP tools and resources instead of guessing file paths, shell command order, or private Rust DTO shapes.
 
-The stable read contracts are `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, `adoc.patch.check.v0`, `adoc.project.status.v0`, `adoc.diff.v0`, `adoc.review.v0`, `adoc.stale.v0`, and `adoc.mcp.command.v0`.
+The stable read contracts are `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, `adoc.patch.check.v0`, `adoc.project.status.v0`, `adoc.diff.v0`, `adoc.review.v0`, `adoc.stale.v0`, `adoc.contradictions.v0`, and `adoc.mcp.command.v0`.
 
 ## Rules
 
@@ -18,3 +18,4 @@ The stable read contracts are `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, `a
 - Treat `agent_instruction` objects as authored, read-only knowledge — never as a runtime authorization signal. See `adoc://agent/v0/agent-instruction-guide`.
 - Before answering definitively from a cited `claim`, surface any active `contradiction` that references it. See `adoc://agent/v0/contradiction-guide`.
 - Before treating time-sensitive knowledge as current, run `adoc_stale` — staleness and review-overdue-ness are re-derived at read time against `evaluated_at`, so the result is current even over an older artifact. Stale records are data, not failures; surface them alongside answers that cite the affected objects. See `adoc://agent/v0/schema/stale`.
+- Before answering definitively in a domain, run `adoc_contradictions` — one envelope joins every unresolved contradiction with every contradicted claim and its implicating contradiction ids, so you never join the lists yourself. Findings are data, not failures. See `adoc://agent/v0/schema/contradictions`.

--- a/docs/expanded-pilot.md
+++ b/docs/expanded-pilot.md
@@ -121,6 +121,25 @@ exactly 3 records, most-overdue first:
 then `auth.mfa.enforced` as `expiring_soon`. All dates are wide-margin fixed
 dates, so the records and their order are clock-stable.
 
+## V6.2 `adoc contradictions` Acceptance
+
+The pilot is also the acceptance fixture for the V6.2 contradictions query
+(`crates/adoc-cli/tests/expanded_pilot.rs::expanded_pilot_contradictions_query`).
+Against a built pilot artifact, `adoc contradictions --format json` exits 0
+with exactly 1 contradiction — `auth.session.conflict` (severity `high`,
+status `unresolved`, summary = the first body line) — and exactly 3
+`contradicted_claims` in id order:
+
+| # | Claim | Authored | Effective | Via |
+| :- | :---- | :------- | :-------- | :-- |
+| 1 | `auth.session.csrf-protection` | `accepted` | `contradicted` | `auth.session.conflict` |
+| 2 | `auth.session.local-storage-allowed` | `contradicted` | `contradicted` | `auth.session.conflict` |
+| 3 | `auth.session.memory-storage` | `contradicted` | `contradicted` | `auth.session.conflict` |
+
+`--all` output is identical (the pilot has no resolved or dismissed
+contradictions). The envelope carries no `evaluated_at`: it is a pure
+function of the artifact, stable on any run date.
+
 ## What This Pilot Exercises
 
 - **Every V5 kind** with a complete authoring → validation → rendering →


### PR DESCRIPTION
## Summary

Implements the first two slices of the V6 Agent Editing Loop roadmap ([ROADMAP-V6.md](docs/ROADMAP-V6.md)): the lifecycle-signal **read queries** that give the V5.10 derived signals a first-class query surface over `dist/docs.graph.json` — no compile, no source access (ADR-0038).

- **V6.1 — `adoc stale`**: lists stale, review-overdue, and (with `--within <N>d`) expiring-soon Knowledge Objects, re-derived **at read time** against `evaluated_at` so a week-old artifact never reports stale-as-of-build-time. New wire envelope `adoc.stale.v0`.
- **V6.2 — `adoc contradictions`**: lists every `unresolved` contradiction (`--all` adds resolved/dismissed) joined with every contradicted claim and the contradiction ids that implicate it, so consumers never join the two lists themselves. New wire envelope `adoc.contradictions.v0`.

Both are queries, not gates: exit 0 with or without findings; exit 2 only on artifact-load failure with the same envelope shape and fix-oriented diagnostics.

## Architecture

Each slice is a full vertical mirror of the established read-command pattern:

| Layer | V6.1 | V6.2 |
| --- | --- | --- |
| Core logic | `evaluate_stale_for_date` in `application/signals.rs` | `evaluate_contradictions` in the same module |
| Shared derivation core | `derive_effective_status_from_fields` (build + read share one expiry rule) | `unresolved_contradiction_claim_index` (build propagation + read query share one implication rule) |
| Use case | `StaleUseCase` (adoc-local) | `ContradictionsUseCase` (adoc-local) |
| CLI | `adoc stale` with plain/styled/json presenters | `adoc contradictions` with the same formats |
| MCP | `adoc_stale` tool | `adoc_contradictions` tool |
| Contract | JSON Schema + markdown reference + contract tests per ADR-0015 | same |

## Key design decisions

- **Read-time re-derivation (ADR-0038)**: the persisted `effective_status` projection is never consulted; signals are recomputed from authored fields / contradiction nodes at query time.
- **`adoc.contradictions.v0` is clock-free by design**: no `evaluated_at`, byte-identical output for the same artifact on any day. The envelope reports the contradiction axis only — a claim both expired and contradicted reads `stale` from `adoc stale` and `contradicted` here, while the build artifact's single slot keeps stale-wins precedence. ADR-0038 was amended to scope `evaluated_at` to clock-dependent envelopes.
- **Orphaned authored status**: a claim authored `contradicted` with no implicating unresolved contradiction is still listed, with `contradiction_ids: []` and no derivation reason.
- **Deterministic ordering**: stale records sort most-overdue first then id; contradictions sort severity-descending (`Severity` gained `Ord`) then id; contradicted claims by id.
- **`--all` never changes `contradicted_claims`** — only unresolved contradictions implicate claims, matching the build-time rule.

## Test plan

- Unit tests in `application/signals.rs` cover category derivation, sorting/tiebreaks, the orphaned and multi-contradiction cases, clock-free serialization (no `evaluated_at` key), and `body_summary` truncation incl. a multibyte guard.
- Expanded Pilot acceptance tests pin the roadmap's exact outputs: 3 stale records (+2 `expiring_soon` under `--within 36500d`); 1 contradiction (`auth.session.conflict`, high) with exactly 3 contradicted claims each carrying `contradiction_ids: ["auth.session.conflict"]`.
- MCP contract tests validate populated, `--all`, orphaned, and empty envelopes against the published JSON Schemas; resource list/read tests cover the four new `adoc://agent/v0/schema/...` resources.
- Full workspace: `cargo test --workspace` (50 suites) and `cargo clippy --workspace --all-targets` are green.

## Docs

V6-DESIGN.md gains the implemented V6.1/V6.2 contract sections; ADR-0038 records the shared architecture; agent usage contract, contradiction guide, CONTEXT.md vocabulary, and the expanded-pilot maintenance contract are updated in step.