### PR TITLE
docs(v7.1): docs-truth hygiene — true up published surface, add registry guard tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ AgentDoc is pre-release compiler and retrieval infrastructure. The source-to-art
 - path-derived page identity when no annotation exists
 - headings, paragraphs, unordered lists, ordered lists, and fenced code blocks
 - rich inline rendering for inline code, emphasis, strong text, and links
-- typed Knowledge Objects: `claim`, `decision`, `warning`, and `glossary`
+- typed Knowledge Objects across the full kind vocabulary (the canonical list is under "Supported object kinds" below)
 - verified claims with `owner`, `verified_at`, and V0 evidence fields
 - object references written as `[[object.id]]`
 - relation fields `depends_on`, `supersedes`, and `related_to`
@@ -143,7 +143,7 @@ Explicit paths still work and override config defaults where provided:
 
 ### Try The Billing Pilot
 
-The realistic V0 pilot under [examples/billing-pilot](examples/billing-pilot) exercises the full core object set: `claim`, `decision`, `warning`, and `glossary`. It contains 30+ Knowledge Objects, 8+ verified claims, object references, relations, source spans, and a golden retrieval set.
+The realistic V0 pilot under [examples/billing-pilot](examples/billing-pilot) exercises the four V0 core kinds: `claim`, `decision`, `warning`, and `glossary`. It contains 30+ Knowledge Objects, 8+ verified claims, object references, relations, source spans, and a golden retrieval set.
 
 ```bash
 rm -rf /tmp/adoc-billing-pilot
@@ -178,9 +178,25 @@ cargo build -p adoc-mcp --release
 
 Configure your MCP client to launch `target/release/adoc-mcp` over stdio with
 the AgentDoc project as the process working directory. The gateway exposes
-`adoc_init`, `adoc_check`, `adoc_build`, `adoc_why`, `adoc_graph`,
-`adoc_search`, `adoc_patch_check`, and `adoc_project_status`, plus versioned
-Agent Guidance Resources and Agent Workflow Prompts.
+these tools, plus versioned Agent Guidance Resources and Agent Workflow
+Prompts:
+
+<!-- adoc:mcp-tools -->
+- `adoc_init`
+- `adoc_check`
+- `adoc_build`
+- `adoc_why`
+- `adoc_graph`
+- `adoc_stale`
+- `adoc_contradictions`
+- `adoc_impacted_by`
+- `adoc_search`
+- `adoc_patch_check`
+- `adoc_patch_apply`
+- `adoc_diff`
+- `adoc_review`
+- `adoc_project_status`
+<!-- /adoc:mcp-tools -->
 
 Agents should begin by reading `adoc://agent/v0/usage-contract`, getting the
 `adoc_answer_with_citations` prompt, and calling `adoc_project_status` before
@@ -213,6 +229,12 @@ adoc check [path]
 adoc build [path] [--out <directory>] [--no-embeddings]
 adoc why <object-id> [--artifact <path>] [--format auto|plain|styled|json]
 adoc graph <object-id> [--artifact <path>] [--relation depends_on|supersedes|related_to] [--direction outgoing|incoming|both] [--format auto|plain|styled|json]
+adoc stale [--artifact <path>] [--within <Nd>] [--format auto|plain|styled|json]
+adoc contradictions [--artifact <path>] [--all] [--format auto|plain|styled|json]
+adoc impacted-by [path]... [--ref <git-ref>] [--artifact <path>] [--format auto|plain|styled|json|markdown]
+adoc patch (--check <patch-json> | --apply <patch-json|@->) [--artifact <path>] [--format auto|plain|styled|json]
+adoc diff <base-ref> [--format auto|plain|styled|json|markdown]
+adoc review <base-ref> [--patch <patch-json>] [--format auto|plain|styled|json|markdown]
 adoc search <query> [--artifact <path>] [--search-artifact <path>] [--lexical | --semantic] [--kind <value>] [--status <value>] [--owner <value>] [--source-path <value>] [--related-to <object-id>] [--relation depends_on|supersedes|related_to] [--direction outgoing|incoming|both] [--top <n>] [--format auto|plain|styled|json]
 ```
 
@@ -273,6 +295,42 @@ as global config.
 - includes the root node at distance `0` and preserves original edge direction in output
 - supports `--relation depends_on|supersedes|related_to` and `--direction outgoing|incoming|both`
 - supports `--format auto|plain|styled|json`
+
+`adoc stale`:
+
+- reads a compiled graph artifact; it does not compile source
+- lists stale, review-overdue, and expiring Knowledge Objects, re-deriving lifecycle signals as of the query date
+- accepts `--within <Nd>` to widen the expiring-soon horizon
+- exits `0` whether or not records exist and emits the `adoc.stale.v0` envelope
+
+`adoc contradictions`:
+
+- reads a compiled graph artifact; it does not compile source
+- lists unresolved contradictions and contradicted claims; `--all` widens the contradictions listing to resolved ones
+- exits `0` whether or not records exist and emits the `adoc.contradictions.v0` envelope
+
+`adoc impacted-by`:
+
+- reads a compiled graph artifact; it does not compile source
+- lists verified Knowledge Objects implicated by changed source paths, passed explicitly or derived from `--ref <git-ref>`
+- emits the `adoc.impacted.v0` envelope and supports `--format markdown` for PR-comment output
+
+`adoc patch`:
+
+- validates one `adoc.patch.v0` document against the compiled graph artifact's `content_hash` preconditions
+- `--check <patch-json>` is read-only and emits the `adoc.patch.check.v0` envelope
+- `--apply <patch-json>` (or `@-` to read from stdin) validates, then rewrites the affected source spans and emits the `adoc.patch.apply.v0` envelope
+
+`adoc diff`:
+
+- diffs Knowledge Objects between `<base-ref>` and the working tree, emitting the `adoc.diff.v0` envelope
+- supports `--format markdown` for PR-comment output
+
+`adoc review`:
+
+- reviews Knowledge Object changes since `<base-ref>` with source-path impact and required reviewers, emitting the `adoc.review.v0` envelope
+- `--patch <patch-json>` embeds an `adoc.patch.check.v0` result in the review
+- supports `--format markdown` for PR-comment output
 
 `adoc search`:
 
@@ -347,10 +405,19 @@ The customer-visible balance available for future invoices.
 
 Supported object kinds:
 
+<!-- adoc:kinds -->
 - `claim`
 - `decision`
-- `warning`
 - `glossary`
+- `warning`
+- `constraint`
+- `policy`
+- `procedure`
+- `example`
+- `agent_instruction`
+- `contradiction`
+- `source`
+<!-- /adoc:kinds -->
 
 Supported relation fields:
 

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -853,6 +853,17 @@ impl BlockKind {
     }
 }
 
+/// Kind name strings for every supported typed block, in `BlockKind::ALL`
+/// order. Public so the published-docs guard (ADR-0041) can assert doc kind
+/// lists against the shipped vocabulary without widening `BlockKind` itself.
+pub fn block_kind_names() -> Vec<&'static str> {
+    BlockKind::ALL
+        .iter()
+        .copied()
+        .map(BlockKind::as_str)
+        .collect()
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum KnowledgeObject {
     Claim(Claim),

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -39,6 +39,7 @@ pub use domain::graph::{
     GraphDirection, GraphRelationKind, GraphTraversalEdge, GraphTraversalNode, GraphTraversalQuery,
     GraphTraversalResult,
 };
+pub use domain::knowledge_object::block_kind_names;
 pub use domain::obligation::ProofObligation;
 pub use domain::patch::{AffectedRelation, PatchDiff, PatchDocument, PatchOperation};
 pub use domain::ports::snapshot_workspace::{GitRef, SnapshotError, SnapshotSelector};

--- a/crates/adoc-mcp/src/lib.rs
+++ b/crates/adoc-mcp/src/lib.rs
@@ -312,7 +312,7 @@ impl AgentDocMcpServer {
     }
 }
 
-#[tool_router(router = tool_router)]
+#[tool_router(router = tool_router, vis = "pub")]
 impl AgentDocMcpServer {
     #[tool(
         name = "adoc_init",

--- a/crates/adoc-mcp/tests/docs_manifest_guard.rs
+++ b/crates/adoc-mcp/tests/docs_manifest_guard.rs
@@ -1,0 +1,117 @@
+//! Docs-truth guard (ADR-0041): the tool and kind lists published in
+//! `README.md` and `docs/mcp-agent-gateway.md` are asserted against the code
+//! registry — set-equality on names, so a failure says which name drifted.
+//! The parse targets pinned HTML comment anchors, never free prose.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::PathBuf;
+
+use adoc_mcp::AgentDocMcpServer;
+
+fn read_repo_doc(relative: &str) -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(relative);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+/// Extracts the codespan names from the bulleted list between
+/// `<!-- {anchor} -->` and `<!-- /{anchor} -->`, failing loudly when an
+/// anchor is missing or a line inside is not a `- `name`` bullet.
+fn anchored_list(doc: &str, doc_name: &str, anchor: &str) -> BTreeSet<String> {
+    let open = format!("<!-- {anchor} -->");
+    let close = format!("<!-- /{anchor} -->");
+    let start = doc.find(&open).unwrap_or_else(|| {
+        panic!(
+            "{doc_name} is missing the `{open}` anchor required by the docs-truth guard (ADR-0041)"
+        )
+    }) + open.len();
+    let end = doc[start..].find(&close).unwrap_or_else(|| {
+        panic!("{doc_name} is missing the closing `{close}` anchor required by the docs-truth guard (ADR-0041)")
+    }) + start;
+
+    let mut names = BTreeSet::new();
+    for line in doc[start..end].lines().map(str::trim) {
+        if line.is_empty() {
+            continue;
+        }
+        let name = line
+            .strip_prefix("- `")
+            .and_then(|rest| rest.strip_suffix('`'))
+            .unwrap_or_else(|| {
+                panic!(
+                    "{doc_name}: the `{anchor}` anchored list must contain only \
+                     `- `name`` bullets, found: {line:?}"
+                )
+            });
+        names.insert(name.to_string());
+    }
+    assert!(
+        !names.is_empty(),
+        "{doc_name}: the `{anchor}` anchored list is empty"
+    );
+    names
+}
+
+fn registered_tool_names() -> BTreeSet<String> {
+    AgentDocMcpServer::tool_router()
+        .list_all()
+        .into_iter()
+        .map(|tool| tool.name.to_string())
+        .collect()
+}
+
+fn assert_matches_registry(
+    doc_name: &str,
+    what: &str,
+    published: &BTreeSet<String>,
+    registered: &BTreeSet<String>,
+) {
+    let missing: Vec<_> = registered.difference(published).cloned().collect();
+    let extra: Vec<_> = published.difference(registered).cloned().collect();
+    assert!(
+        missing.is_empty() && extra.is_empty(),
+        "{doc_name} {what} list drifted from the code registry — \
+         missing from doc: [{}], not in registry: [{}]",
+        missing.join(", "),
+        extra.join(", ")
+    );
+}
+
+#[test]
+fn readme_mcp_tool_list_matches_registry() {
+    let published = anchored_list(&read_repo_doc("README.md"), "README.md", "adoc:mcp-tools");
+    assert_matches_registry(
+        "README.md",
+        "MCP tool",
+        &published,
+        &registered_tool_names(),
+    );
+}
+
+#[test]
+fn gateway_doc_mcp_tool_list_matches_registry() {
+    let published = anchored_list(
+        &read_repo_doc("docs/mcp-agent-gateway.md"),
+        "docs/mcp-agent-gateway.md",
+        "adoc:mcp-tools",
+    );
+    assert_matches_registry(
+        "docs/mcp-agent-gateway.md",
+        "MCP tool",
+        &published,
+        &registered_tool_names(),
+    );
+}
+
+#[test]
+fn readme_kind_list_matches_block_kinds() {
+    let published = anchored_list(&read_repo_doc("README.md"), "README.md", "adoc:kinds");
+    let shipped: BTreeSet<String> = adoc_core::block_kind_names()
+        .into_iter()
+        .map(str::to_string)
+        .collect();
+    assert_matches_registry("README.md", "object kind", &published, &shipped);
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,7 @@
 
 This roadmap converts the broad PRD into small tracer-bullet milestones. A milestone is not complete just because one subsystem exists; it is complete when a user can start with `.adoc` source, run the `adoc` CLI, receive useful diagnostics, and get both human HTML and graph JSON outputs.
 
-The initial product is a local CLI for native AgentDoc authoring in Git repositories. The compiler, graph artifact, local retrieval loop, hybrid search, graph traversal, retrieval evaluation harness, local workflow, agent patch validation, and local MCP gateway are now implemented. The next product bet is team CI and review: AgentDoc should turn object-level changes, proof obligations, and ownership into useful pull-request feedback.
+The initial product is a local CLI for native AgentDoc authoring in Git repositories. The compiler, graph artifact, local retrieval loop, hybrid search, graph traversal, retrieval evaluation harness, local workflow, agent patch validation, local MCP gateway, team CI diff/review, Markdown compatibility mode, the V5 Expanded Knowledge Model, lifecycle automation, and the V6 agent editing loop (lifecycle read commands plus gated patch apply) are now implemented. The next product bet is the V7 cycle ([ROADMAP-V7.md](ROADMAP-V7.md)): complete the fifteen-kind vocabulary, make prose retrievable, keep published docs true by guard test, and run the pilot that discharges the MVP acceptance bar.
 
 V0 implementation stack: Rust for the `adoc` CLI, parser, validator, compiler, HTML renderer, and graph JSON emitter. The Rust project starts as a Cargo workspace with `crates/adoc-cli` for command-line behavior and `crates/adoc-core` for reusable compiler behavior. Future editor, web, and agent integrations should consume the compiled artifacts or core library rather than own the source grammar.
 
@@ -43,14 +43,17 @@ Implemented:
 - V5 Expanded Knowledge Model: seven new typed kinds (`constraint`, `procedure`, `example`, `policy`, `agent_instruction`, `contradiction`, `source`), the shared `Severity` value object, the typed `EvidenceKind` evidence model (`evidence_ref` to `source` objects with edge + projection, symmetric `claim`/`decision` evidence), the additive `adoc.graph.v2` → `adoc.graph.v3` bump, the `agent_instruction` runtime-not-enforced banner and `adoc://agent/v0/agent-instruction-guide` / `contradiction-guide` resources, and the Expanded Pilot end-to-end harness ([expanded-pilot.md](expanded-pilot.md)). Closes PRD MVP must-have #4 for the seven object types, plus PRD §13.3–§13.15, §14.3 (proof obligations for the new kinds), and §15 (typed evidence model). The implementation contract is [V5-DESIGN.md](V5-DESIGN.md); the decisions are ADR-0024 through ADR-0032.
 - V5.10 Lifecycle Automation: four additive derived signals layered on the V5 Expanded Object Set without new wire-envelope versions or source-authoring changes. (1) `schema.policy_review_overdue` (WARNING) when an active policy's `effective_at + review_interval` is before today — ADR-0033. (2) Derived `effective_status: "stale"` / `effective_reason: "expired:<date>"` on any `verified` object whose `expires_at` is in the past — displayed as an HTML badge and emitted in graph nodes and retrieval records. (3) Derived `evidence_quality: "high"|"medium"|"low"` on objects with evidence, computed from the `EvidenceTier` mapping in ADR-0034; plus `claim.evidence_quality_low` (WARNING) when a verified claim's only inline evidence is Low-tier. (4) Derived `effective_status: "contradicted"` on a claim referenced by an unresolved contradiction, plus `schema.claim_contradicted_by_unresolved` (WARNING) when that claim's authored status is not already `contradicted` — stale takes precedence when both apply. All derived fields are additive and excluded from `content_hash`. The Expanded Pilot now exercises all four signals with clock-stable wide-margin fixture dates; the exact-match budget is 0 errors, 5 warnings. The implementation contract is [V5-DESIGN.md](V5-DESIGN.md) §V5.10.
 
+- V6.1–V6.3 lifecycle-signal read commands ([ROADMAP-V6.md](ROADMAP-V6.md), ADR-0038): `adoc stale`, `adoc contradictions`, and `adoc impacted-by` as read-only graph-artifact readers that re-derive lifecycle signals as of the query date, with versioned envelopes (`adoc.stale.v0`, `adoc.contradictions.v0`, `adoc.impacted.v0`), paired MCP tools (`adoc_stale`, `adoc_contradictions`, `adoc_impacted_by`), and `--format markdown` PR-comment output for `impacted-by`.
+- V6.4 patch apply ([ROADMAP-V6.md](ROADMAP-V6.md), ADR-0036, ADR-0037): `adoc patch --apply` rewrites `.adoc` source via formatting-preserving span splices — atomic per-file temp-write and rename, apply-time source-drift gate (`patch.source_drift`), post-apply re-check, never auto-revert — emitting `adoc.patch.apply.v0`; `create_object` placement semantics; the MCP `adoc_patch_apply` tool gated behind `mcp: { patch_apply: enabled }` with the `adoc://agent/v0/patch-apply-guide` resource and the additive `patch_apply_enabled` readiness flag in `adoc.project.status.v0`; the Expanded Pilot full-loop test (impacted-by → propose → check → apply → post-check).
+
 Next:
 
-- V6 composition and advanced graphs: `@include`, nested typed blocks, custom schema registry, automated contradiction detection. Sequenced after V5 and V5.10 because V6 assumes the V5 Expanded Object Set plus the V5.10 lifecycle contract are stable.
+- The V7 cycle ([ROADMAP-V7.md](ROADMAP-V7.md)): V6.5 vocabulary completion (`api`, `observation`, `question`, `task` — the full fifteen-kind PRD §13 set), V1.7 prose retrieval, V7.1 docs-truth hygiene, and the V7.2 pilot readiness gate.
 
 Later:
 
 - V4.5 Markdown migration (`adoc migrate`, suggested-claim extraction, import report, `adoc.migrate.report.v0` envelope, MCP integration). Sequenced after V4 once compatibility-mode usage surfaces measured friction. PRD MVP must-have #18.
-- V1.7 prose retrieval. Extends BM25 and embedding pipelines to index prose blocks symmetrically across `.adoc` and `.md` sources. Independent of V4 / V5 sequencing; can ship before or after.
+- Composition and advanced graphs (formerly "V6"): `@include`, nested typed blocks, custom schema registry, automated contradiction detection. Postponed until the editing loop and full vocabulary are proven in real use; un-gating is measured by the V7.2 pilot report ([ROADMAP-V7.md](ROADMAP-V7.md) Later section).
 - V7 web surfaces and governance: read-only object explorer, review dashboard, ownership and approval workflows, agent activity log, SSO/RBAC/audit/compliance, hosted storage.
 
 ## V0: Native CLI Compiler
@@ -361,7 +364,7 @@ Acceptance:
 - Read/query tools return existing `adoc.retrieval.v0`, `adoc.graph.traversal.v0`, and `adoc.patch.check.v0` envelopes where applicable.
 - Build/init writes are constrained by a project-root sandbox.
 - Patch validation accepts either a patch file path or inline `adoc.patch.v0` JSON.
-- MCP does not apply patches, approve knowledge, rewrite source from patches, or introduce hosted review state.
+- MCP does not approve knowledge or introduce hosted review state. (Patch application over MCP shipped later in V6.4 as `adoc_patch_apply`, gated behind the explicit `mcp: { patch_apply: enabled }` config opt-in; in this slice MCP was read-and-validate only.)
 
 ## V2.2: Agent Usage Contract and MCP Guidance
 
@@ -853,11 +856,11 @@ The currently resolved and implemented local cut is:
 - Build output directory: created automatically when missing.
 - Source extension: `.adoc`.
 - Authoring workflow: native AgentDoc Source first.
-- Commands: `adoc init`, `adoc check`, `adoc build`, `adoc why`, `adoc graph`, `adoc search`.
-- MCP tools: `adoc_init`, `adoc_check`, `adoc_build`, `adoc_why`, `adoc_graph`, `adoc_search`, `adoc_patch_check`, `adoc_project_status`.
+- Commands: `adoc init`, `adoc check`, `adoc build`, `adoc why`, `adoc graph`, `adoc stale`, `adoc contradictions`, `adoc impacted-by`, `adoc patch`, `adoc diff`, `adoc review`, `adoc search`.
+- MCP tools: the registered set in `crates/adoc-mcp/src/lib.rs` — the canonical published list lives in [README.md](../README.md) and [mcp-agent-gateway.md](mcp-agent-gateway.md), guard-tested against the registry (ADR-0041).
 - Modes: strict mode only.
 - Config: minimal `agentdoc.config.yaml` for local docs path, outputs, and `embeddings.provider: local|deterministic|none`.
-- Initial objects: `claim`, `decision`, `warning`, `glossary`.
+- Objects: the eleven-kind vocabulary — the canonical published list lives in [README.md](../README.md), guard-tested against `BlockKind::ALL` (ADR-0041).
 - Verified support: verified claims only.
 - V0 evidence: `source`, `test`, `reviewed_by`.
 - Relations: `depends_on`, `supersedes`, `related_to`.

--- a/docs/adr/0041-docs-truth-guards.md
+++ b/docs/adr/0041-docs-truth-guards.md
@@ -1,0 +1,72 @@
+# ADR-0041: Docs-Truth Guards for Published Tool and Kind Lists
+
+**Status:** Accepted
+**Date:** 2026-07-02
+**Slice:** V7.1.1
+
+Recorded out of numeric order deliberately: ADR-0039 (`adoc.graph.v4`) and
+ADR-0040 (prose retrieval contracts) are reserved for V6.5.1 and V1.7.1 per
+the [ROADMAP-V6.md](../ROADMAP-V6.md) ADR inventory, restated in
+[ROADMAP-V7.md](../ROADMAP-V7.md) — the ADR-0038 out-of-order precedent.
+
+## Context
+
+The published docs drifted from the shipped surface. `README.md` advertises
+8 of the 14 MCP tools the registry in `crates/adoc-mcp/src/lib.rs` declares,
+and lists the V0 four object kinds when eleven ship;
+`docs/mcp-agent-gateway.md` omits `adoc_stale`, `adoc_contradictions`,
+`adoc_impacted_by`, `adoc_diff`, and `adoc_review` — the last two missing
+since V3; `docs/ROADMAP.md` "Current Status" stopped at V5.10. Every one of
+these lists was hand-maintained, and a published number that no test can
+fail is a future lie: the same drift will recur when V6.5 adds four kinds
+and any future slice adds a tool.
+
+Two mechanical sources of truth already exist in code: the `#[tool]`
+manifest (enumerable at test time via the generated
+`AgentDocMcpServer::tool_router()` and `ToolRouter::list_all()`), and
+`BlockKind::ALL` in `crates/adoc-core`. What was missing is a contract
+binding the published prose to them.
+
+## Decision
+
+1. **Published tool and kind lists are asserted against the code registry
+   by a guard test**, `crates/adoc-mcp/tests/docs_manifest_guard.rs` — a
+   sibling of `manifest_guard.rs`, not an extension of it. The package
+   manifest and the published-docs manifest are unrelated concerns, and a
+   red test must name which one broke.
+2. **Set-equality on names, not counts.** The guard compares the parsed doc
+   list with the registered set in both directions, so a failure names
+   *which* tool or kind is missing or extra, not just that a number is off.
+3. **The parse targets a pinned doc shape, not free prose.** Each doc wraps
+   its canonical list in HTML comment anchors —
+   `<!-- adoc:mcp-tools -->` … `<!-- /adoc:mcp-tools -->` and
+   `<!-- adoc:kinds -->` … `<!-- /adoc:kinds -->` — around a bulleted list
+   of backtick codespans and nothing else. The guard reads only between
+   anchors and fails loudly when an anchor is missing. Surrounding prose,
+   tables, and code-block examples stay free-form and never drift the
+   parse.
+4. **The guarded surfaces are the ones that demonstrably drifted**: the
+   `adoc:mcp-tools` list in `README.md` and `docs/mcp-agent-gateway.md`
+   (against the `#[tool]` registry) and the `adoc:kinds` list in
+   `README.md` (against `BlockKind::ALL`, exposed to the test crate via a
+   public `block_kind_names()` accessor in `adoc-core` rather than by
+   widening the domain enum's visibility). The CLI command list and the
+   `docs/agent/v0/` guides are deliberately not covered — extend on the
+   next drift, per the roadmap's open question.
+5. **Hand-maintenance is retired.** From this slice on, adding a tool or a
+   kind without updating the anchored lists is a red test naming the files
+   to touch. Auto-generating the README section from the manifest stays
+   deferred; the guard is cheaper and sufficient unless it proves annoying.
+
+## Consequences
+
+- V6.5 landing its four new kinds turns `README.md` stale loudly instead of
+  silently — the guard failure lists the missing kind names.
+- The anchors are load-bearing: editors may reformat prose freely but must
+  keep the anchored lists as bulleted codespans; deleting an anchor is a
+  test failure, not silent un-guarding.
+- The guard needs the generated `tool_router()` to be public
+  (`vis = "pub"` on the `#[tool_router]` attribute) and a one-line public
+  accessor in `adoc-core` — the only code the docs-truth slice ships.
+- Counts quoted in prose (e.g. "14 tools") remain unguarded; the anchored
+  lists are the canonical claim, so prose should reference, not enumerate.

--- a/docs/mcp-agent-gateway.md
+++ b/docs/mcp-agent-gateway.md
@@ -12,6 +12,28 @@ refuses unless the project opts in with `mcp: { patch_apply: enabled }` in
 `agentdoc.config.yaml` (V6.4, ADR-0037); every other tool never writes
 AgentDoc Source.
 
+## Tool Surface
+
+The gateway registers these tools (this list is guard-tested against the
+`crates/adoc-mcp` registry, ADR-0041):
+
+<!-- adoc:mcp-tools -->
+- `adoc_init`
+- `adoc_check`
+- `adoc_build`
+- `adoc_why`
+- `adoc_graph`
+- `adoc_stale`
+- `adoc_contradictions`
+- `adoc_impacted_by`
+- `adoc_search`
+- `adoc_patch_check`
+- `adoc_patch_apply`
+- `adoc_diff`
+- `adoc_review`
+- `adoc_project_status`
+<!-- /adoc:mcp-tools -->
+
 ## Build The Server
 
 From this repository:
@@ -69,15 +91,22 @@ inventing tool order:
 3. Call `adoc_project_status` with no arguments for a read-only Project Status Report.
 4. If artifacts are missing or stale, call `adoc_project_status` with `refresh: "check"` for diagnostics or `refresh: "build"` to write configured artifacts.
 5. Use `adoc_search`, `adoc_why`, and `adoc_graph` for evidence.
-6. Use `adoc_patch_check` for inline `adoc.patch.v0` proposals.
-7. When the project has opted in (`readiness.patch_apply_enabled: true`), use
+6. Use `adoc_stale`, `adoc_contradictions`, and `adoc_impacted_by` to check
+   which knowledge is suspect right now — stale or review-overdue objects,
+   unresolved contradictions, and objects implicated by changed source paths.
+7. Use `adoc_diff` and `adoc_review` to inspect Knowledge Object changes
+   against a git ref, with source-path impact and required reviewers.
+8. Use `adoc_patch_check` for inline `adoc.patch.v0` proposals.
+9. When the project has opted in (`readiness.patch_apply_enabled: true`), use
    `adoc_patch_apply` to apply a validated patch; follow
    `adoc://agent/v0/patch-apply-guide`.
 
 The Project Status Report has schema version `adoc.project.status.v0`. Retrieval
 tools return `adoc.retrieval.v0` and graph traversal returns
-`adoc.graph.traversal.v0`. Patch validation returns `adoc.patch.check.v0`;
-patch application returns `adoc.patch.apply.v0`.
+`adoc.graph.traversal.v0`. The lifecycle read tools return `adoc.stale.v0`,
+`adoc.contradictions.v0`, and `adoc.impacted.v0`. Diff and review return
+`adoc.diff.v0` and `adoc.review.v0`. Patch validation returns
+`adoc.patch.check.v0`; patch application returns `adoc.patch.apply.v0`.
 
 ## JSON-RPC Smoke Flow
 


### PR DESCRIPTION
## Summary

Implements **V7.1.1 Docs-Truth Slice**, the first slice of the V7 cycle per [ROADMAP-V7.md](docs/ROADMAP-V7.md) ("V7.1 first — it is cheap, self-contained, and unblocking"). Every published promise about the shipped surface becomes true, and a guard test keeps it true without a human remembering.

## The debt this pays

- `README.md` advertised **8 of 14** MCP tools and **4 of 11** object kinds.
- `docs/ROADMAP.md` "Current Status" stopped at V5.10; "Next" still pointed at V6 composition; the V2.1 "MCP does not apply patches" line survived the V6.4 sweep.
- `docs/mcp-agent-gateway.md` omitted `adoc_stale`, `adoc_contradictions`, `adoc_impacted_by`, `adoc_diff`, `adoc_review`.

## Changes

- **ADR-0041** (`docs/adr/0041-docs-truth-guards.md`): published tool/kind lists are asserted against the code registry — set-equality on **names, not counts**; the parse targets pinned HTML comment anchors (`<!-- adoc:mcp-tools -->`, `<!-- adoc:kinds -->`); hand-maintenance retired.
- **README.md**: full 14-tool and 11-kind anchored lists; CLI section now documents `stale`, `contradictions`, `impacted-by`, `patch --apply`, `diff`, `review`; the billing-pilot "full core object set" claim re-scoped to the four V0 kinds.
- **docs/ROADMAP.md**: Current Status extended through V6.4; "Next" repointed at ROADMAP-V7.md; the surviving apply-promise line scoped to its slice; Current Implemented Cut trued up.
- **docs/mcp-agent-gateway.md**: anchored canonical tool list; workflow and envelope coverage for the five missing tools.
- **New guard test** `crates/adoc-mcp/tests/docs_manifest_guard.rs` (sibling of `manifest_guard.rs`, which stays single-purpose): reads only between anchors, fails loudly on a missing anchor, and a failure names *which* tool or kind drifted. When V6.5 adds kinds, the README goes stale loudly instead of silently.
- **Two thin enablers**: `vis = "pub"` on the generated `tool_router()` (lets the test enumerate the `#[tool]` manifest via `list_all()`), and a `block_kind_names()` accessor in adoc-core (keeps `BlockKind` `pub(crate)`).

## Test plan

- [x] `cargo test -p adoc-mcp --test docs_manifest_guard --locked` exits 0 (slice acceptance command)
- [x] Mutation check: deleting `adoc_diff` from README fails with `missing from doc: [adoc_diff]`
- [x] Grep sweep: no stale tool/kind enumerations or apply-promise survivors in README / ROADMAP / gateway doc
- [x] `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` all green

## Deferred (per spec)

`docs/agent/v0/tool-guide.md` coverage, README auto-generation, CLI-command-list guard, docs linter — extend on the next drift.