### PR TITLE
feat: V6.5.1 — adoc.graph.v4 status-slot cleanup and the api Knowledge Object

### DIFF
--- a/README.md
+++ b/README.md
@@ -417,6 +417,7 @@ Supported object kinds:
 - `agent_instruction`
 - `contradiction`
 - `source`
+- `api`
 <!-- /adoc:kinds -->
 
 Supported relation fields:

--- a/crates/adoc-cli/src/presentation/plain.rs
+++ b/crates/adoc-cli/src/presentation/plain.rs
@@ -49,12 +49,16 @@ pub(crate) fn render_record(
 ) {
     writeln!(output, "Object: {}", record.id).expect("writing to String cannot fail");
     writeln!(output, "Kind: {}", record.kind).expect("writing to String cannot fail");
+    // ADR-0039: status is lifecycle-only; severity/trust have their own
+    // record fields (this also fixes constraints mislabelled "Status:").
     if let Some(status) = &record.status {
-        if record.kind == "warning" {
-            writeln!(output, "Severity: {status}").expect("writing to String cannot fail");
-        } else {
-            writeln!(output, "Status: {status}").expect("writing to String cannot fail");
-        }
+        writeln!(output, "Status: {status}").expect("writing to String cannot fail");
+    }
+    if let Some(severity) = &record.severity {
+        writeln!(output, "Severity: {severity}").expect("writing to String cannot fail");
+    }
+    if let Some(trust) = &record.trust {
+        writeln!(output, "Trust: {trust}").expect("writing to String cannot fail");
     }
     if let Some(owner) = &record.owner {
         writeln!(output, "Owner: {owner}").expect("writing to String cannot fail");
@@ -264,8 +268,9 @@ mod tests {
 
     #[test]
     fn plain_presenter_uses_severity_label_for_warnings() {
+        // ADR-0039: severity is a dedicated record field, not the status slot.
         let mut record = make_record("team.warn", "warning");
-        record.status = Some("high".to_string());
+        record.severity = Some("high".to_string());
         let view = view_for(record);
         let text = render(&view);
 

--- a/crates/adoc-cli/src/presentation/styled.rs
+++ b/crates/adoc-cli/src/presentation/styled.rs
@@ -59,17 +59,22 @@ fn render_styled_record(output: &mut String, presentation_record: &PresentationR
     writeln!(output, "{} {}", faint_label("Kind:"), record.kind)
         .expect("writing to String cannot fail");
 
+    // ADR-0039: status is lifecycle-only; severity/trust have their own
+    // record fields. Severity strings feed the same chip palette.
     if let Some(status) = &record.status {
-        let palette = status_color(Some(status.as_str()));
-        let chip = status_chip(palette, status.as_str());
-        if record.kind == "warning" {
-            // Warnings use "Severity:" label but still get a chip.
-            writeln!(output, "{} {chip}", faint_label("Severity:"))
-                .expect("writing to String cannot fail");
-        } else {
-            writeln!(output, "{} {chip}", faint_label("Status:"))
-                .expect("writing to String cannot fail");
-        }
+        let chip = status_chip(status_color(Some(status.as_str())), status.as_str());
+        writeln!(output, "{} {chip}", faint_label("Status:"))
+            .expect("writing to String cannot fail");
+    }
+    if let Some(severity) = &record.severity {
+        let chip = status_chip(status_color(Some(severity.as_str())), severity.as_str());
+        writeln!(output, "{} {chip}", faint_label("Severity:"))
+            .expect("writing to String cannot fail");
+    }
+    if let Some(trust) = &record.trust {
+        let chip = status_chip(status_color(Some(trust.as_str())), trust.as_str());
+        writeln!(output, "{} {chip}", faint_label("Trust:"))
+            .expect("writing to String cannot fail");
     }
 
     if let Some(owner) = &record.owner {
@@ -408,8 +413,9 @@ mod tests {
 
     #[test]
     fn styled_uses_severity_label_for_warnings() {
+        // ADR-0039: severity is a dedicated record field, not the status slot.
         let mut record = make_record("team.warn", "warning");
-        record.status = Some("high".to_string());
+        record.severity = Some("high".to_string());
         let view = view_for(record);
         let text = strip_ansi(&render(&view));
 

--- a/crates/adoc-cli/tests/agent_instruction_cli.rs
+++ b/crates/adoc-cli/tests/agent_instruction_cli.rs
@@ -182,12 +182,12 @@ fn build_emits_agent_instruction_into_graph_and_renders_banner() {
     );
 
     // Graph: the agent_instruction node carries kind, trust, scope, and both
-    // action sets (schema stays adoc.graph.v3 — additive).
+    // action sets (schema stays adoc.graph.v4 — additive).
     let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let node = graph["nodes"]
         .as_array()
@@ -197,9 +197,9 @@ fn build_emits_agent_instruction_into_graph_and_renders_banner() {
         .expect("graph contains an agent_instruction node");
 
     assert_eq!(node["id"], "auth.docs-answering-policy");
-    // `trust` rides the node `status` slot via the discriminant projection;
-    // the dedicated `trust` field is the ADR-0035 dual-emit.
-    assert_eq!(node["status"], "team");
+    // ADR-0039: agent_instruction has no lifecycle status; `trust` is the
+    // sole, authored, hashed carrier.
+    assert_eq!(node["status"], Value::Null);
     assert_eq!(node["trust"], "team");
     assert_eq!(node["fields"]["scope"], "docs/auth/*");
     assert!(

--- a/crates/adoc-cli/tests/api_cli.rs
+++ b/crates/adoc-cli/tests/api_cli.rs
@@ -1,0 +1,218 @@
+//! V6.5.1 `api` Knowledge Object CLI acceptance (PRD §13.7, ADR-0039).
+
+mod support;
+
+use std::fs;
+
+use serde_json::Value;
+
+use support::{TestWorkspace, adoc_command, stderr, stdout};
+
+/// The PRD §13.7 example, verbatim.
+const PRD_EXAMPLE_API: &str = "\
+# Billing API @doc(team.billing-api)
+
+Billing service API contracts.
+
+::api billing.consume-credit
+method: POST
+path: /api/billing/credits/consume
+status: verified
+source: openapi/billing.yaml#/paths/~1credits~1consume
+owner: backend-platform
+verified_at: 2026-04-30
+--
+Consumes one or more credits for a completed generation job.
+::
+";
+
+const MISSING_METHOD_API: &str = "\
+# Billing API @doc(team.billing-api)
+
+Billing service API contracts.
+
+::api billing.consume-credit
+path: /api/billing/credits/consume
+--
+Consumes one or more credits for a completed generation job.
+::
+";
+
+const VERIFIED_REVIEWED_BY_ONLY_API: &str = "\
+# Billing API @doc(team.billing-api)
+
+Billing service API contracts.
+
+::api billing.consume-credit
+method: POST
+path: /api/billing/credits/consume
+status: verified
+owner: backend-platform
+verified_at: 2026-04-30
+reviewed_by: api-guild
+--
+Consumes one or more credits for a completed generation job.
+::
+";
+
+const IMPACTS_API: &str = "\
+# Billing API @doc(team.billing-api)
+
+Billing service API contracts.
+
+::api billing.consume-credit
+method: POST
+path: /api/billing/credits/consume
+status: verified
+source: openapi/billing.yaml#/paths/~1credits~1consume
+owner: backend-platform
+verified_at: 2026-04-30
+impacts: [openapi/billing.yaml]
+--
+Consumes one or more credits for a completed generation job.
+::
+";
+
+#[test]
+fn build_accepts_prd_example_and_emits_api_into_graph_v4() {
+    let workspace = TestWorkspace::new("api-build");
+    workspace.write("api.adoc", PRD_EXAMPLE_API);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "api.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected the PRD §13.7 example to build\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+
+    // Graph: kind api with method and path preserved in the hashed fields map.
+    let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
+        .expect("graph artifact is written");
+    let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
+
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+
+    let api = graph["nodes"]
+        .as_array()
+        .expect("nodes is an array")
+        .iter()
+        .find(|node| node["kind"] == "api")
+        .expect("graph contains an api node");
+
+    assert_eq!(api["id"], "billing.consume-credit");
+    assert_eq!(api["status"], "verified");
+    assert_eq!(api["fields"]["method"], "POST");
+    assert_eq!(api["fields"]["path"], "/api/billing/credits/consume");
+    // ADR-0039: api is born lifecycle-only — no severity/trust carriers.
+    assert!(api.get("severity").is_none());
+    assert!(api.get("trust").is_none());
+
+    // HTML: endpoint signature above the body — method badge + code-style path.
+    let html = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
+        .expect("html artifact is written");
+    assert!(
+        html.contains("<span class=\"api__method\">POST</span>"),
+        "html must contain the method badge\n{html}"
+    );
+    assert!(
+        html.contains("<code class=\"api__path\">/api/billing/credits/consume</code>"),
+        "html must contain the code-style path\n{html}"
+    );
+}
+
+#[test]
+fn check_rejects_api_without_method_or_interface_type() {
+    let workspace = TestWorkspace::new("api-missing-method");
+    workspace.write("api.adoc", MISSING_METHOD_API);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "api.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for an api with neither method nor interface_type"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.api_missing_method_or_interface_type]"),
+        "expected missing method/interface_type diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+}
+
+#[test]
+fn check_rejects_verified_api_with_only_reviewed_by_evidence() {
+    let workspace = TestWorkspace::new("api-reviewed-by-only");
+    workspace.write("api.adoc", VERIFIED_REVIEWED_BY_ONLY_API);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "api.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for a verified api whose only evidence is reviewed_by"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[api.verified_missing_schema_evidence]"),
+        "expected schema-evidence diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+}
+
+#[test]
+fn impacted_by_covers_verified_api_impacts_declaration() {
+    let workspace = TestWorkspace::new("api-impacted-by");
+    workspace.write("api.adoc", IMPACTS_API);
+
+    let build = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "api.adoc", "--out", "dist", "--no-embeddings"])
+        .output()
+        .expect("adoc build runs");
+    assert!(
+        build.status.success(),
+        "expected build to pass\nstdout:\n{}\nstderr:\n{}",
+        stdout(&build),
+        stderr(&build)
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["impacted-by", "openapi/billing.yaml", "--format", "json"])
+        .output()
+        .expect("adoc impacted-by runs");
+    assert_eq!(output.status.code(), Some(0));
+
+    let envelope: Value = serde_json::from_str(&stdout(&output)).unwrap_or_else(|error| {
+        panic!(
+            "impacted-by stdout is JSON: {error}\nstdout:\n{}\nstderr:\n{}",
+            stdout(&output),
+            stderr(&output)
+        )
+    });
+    let impacted_ids: Vec<&str> = envelope["impacted"]
+        .as_array()
+        .expect("impacted array")
+        .iter()
+        .map(|record| record["id"].as_str().expect("id"))
+        .collect();
+    assert!(
+        impacted_ids.contains(&"billing.consume-credit"),
+        "impacted-by must flag the verified api for its declared path: {impacted_ids:?}"
+    );
+}

--- a/crates/adoc-cli/tests/billing_pilot.rs
+++ b/crates/adoc-cli/tests/billing_pilot.rs
@@ -81,7 +81,7 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
         .expect("billing pilot graph JSON is written");
     let graph_json: Value =
         serde_json::from_str(&graph_json_text).expect("graph JSON is valid JSON");
-    assert_eq!(graph_json["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph_json["schema_version"], "adoc.graph.v4");
     let nodes = graph_json["nodes"]
         .as_array()
         .expect("graph JSON nodes is an array");

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -178,7 +178,7 @@ fn read_graph_artifact(path: &Path) -> Value {
 
 fn assert_graph_artifact(text: &str) -> Value {
     let graph: Value = serde_json::from_str(text).expect("graph artifact is valid JSON");
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
     assert!(graph["nodes"].as_array().is_some());
     assert!(graph["edges"].as_array().is_some());
     assert_eq!(
@@ -1773,7 +1773,9 @@ fn build_renders_v0_4_warning_to_graph_json() {
     let node = graph_node(&graph, "auth.session.clock-skew");
     assert_eq!(node["type"], "knowledge_object");
     assert_eq!(node["kind"], "warning");
-    assert_eq!(node["status"], "high");
+    // ADR-0039: no lifecycle status on warnings; severity is dedicated.
+    assert!(node.get("status").is_none());
+    assert_eq!(node["severity"], "high");
     assert!(node["fields"].get("severity").is_none());
     assert!(!workspace.root.join("dist").join("docs.agent.json").exists());
 }
@@ -1968,8 +1970,14 @@ fn build_renders_v0_4_core_object_set_to_graph_json() {
         "verified"
     );
     assert_eq!(graph_node(&graph, "billing.policy")["status"], "accepted");
+    // ADR-0039: warnings carry `severity`, never `status`.
+    assert!(
+        graph_node(&graph, "auth.session.clock-skew")
+            .get("status")
+            .is_none()
+    );
     assert_eq!(
-        graph_node(&graph, "auth.session.clock-skew")["status"],
+        graph_node(&graph, "auth.session.clock-skew")["severity"],
         "high"
     );
     assert!(

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -30,7 +30,7 @@ fn copy_valid_artifact(workspace: &TestWorkspace, relative_path: &str) {
     workspace.write(
         relative_path,
         r#"{
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-cli/tests/constraint_cli.rs
+++ b/crates/adoc-cli/tests/constraint_cli.rs
@@ -50,7 +50,7 @@ fn check_accepts_valid_constraint() {
 }
 
 #[test]
-fn build_emits_constraint_into_graph_v3() {
+fn build_emits_constraint_into_graph_v4() {
     let workspace = TestWorkspace::new("constraint-build");
     workspace.write("constraint.adoc", VALID_CONSTRAINT);
 
@@ -71,7 +71,7 @@ fn build_emits_constraint_into_graph_v3() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let constraint = graph["nodes"]
         .as_array()
@@ -81,9 +81,9 @@ fn build_emits_constraint_into_graph_v3() {
         .expect("graph contains a constraint node");
 
     assert_eq!(constraint["id"], "auth.session.no-local-storage");
-    // `status` keeps carrying the severity discriminant within adoc.graph.v3;
-    // the dedicated `severity` field is the ADR-0035 dual-emit.
-    assert_eq!(constraint["status"], "critical");
+    // ADR-0039: constraints carry no lifecycle status; `severity` is the
+    // sole, authored, hashed carrier.
+    assert!(constraint.get("status").is_none());
     assert_eq!(constraint["severity"], "critical");
     assert_eq!(
         constraint["body"],

--- a/crates/adoc-cli/tests/contradiction_cli.rs
+++ b/crates/adoc-cli/tests/contradiction_cli.rs
@@ -218,7 +218,7 @@ fn build_emits_contradiction_graph_node_with_expected_fields() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let node = graph["nodes"]
         .as_array()
@@ -230,9 +230,9 @@ fn build_emits_contradiction_graph_node_with_expected_fields() {
     assert_eq!(node["id"], "auth.session.conflict");
     // status carries the contradiction lifecycle status (discriminant slot).
     assert_eq!(node["status"], "unresolved");
-    // severity is a typed metadata field.
-    assert_eq!(node["fields"]["severity"], "high");
-    // ADR-0035 dual-emit: severity also appears as a top-level derived field.
+    // ADR-0039: the top-level `severity` field is the sole carrier — the v3
+    // fields["severity"] copy is gone.
+    assert!(node["fields"].get("severity").is_none());
     assert_eq!(node["severity"], "high");
     // contradiction_claims list contains both claim ids (sorted).
     let claims = node["contradiction_claims"]

--- a/crates/adoc-cli/tests/evidence_model_cli.rs
+++ b/crates/adoc-cli/tests/evidence_model_cli.rs
@@ -141,8 +141,8 @@ fn build_records_evidence_ref_in_typed_array_and_edge() {
 
     // schema_version guard
     assert_eq!(
-        graph["schema_version"], "adoc.graph.v3",
-        "schema_version must be adoc.graph.v3"
+        graph["schema_version"], "adoc.graph.v4",
+        "schema_version must be adoc.graph.v4"
     );
 
     // ---- find the claim node -----------------------------------------------
@@ -340,7 +340,7 @@ fn build_records_evidence_edge_for_accepted_decision() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let edges = graph["edges"]
         .as_array()

--- a/crates/adoc-cli/tests/example_cli.rs
+++ b/crates/adoc-cli/tests/example_cli.rs
@@ -125,7 +125,7 @@ fn build_emits_example_into_graph_v3() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let example = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/expanded_pilot.rs
+++ b/crates/adoc-cli/tests/expanded_pilot.rs
@@ -98,7 +98,7 @@ fn expanded_pilot_check_emits_documented_diagnostic_budget() {
     );
 }
 
-/// V5.10 acceptance: `adoc build` emits an `adoc.graph.v3` artifact carrying
+/// V5.10 acceptance: `adoc build` emits an `adoc.graph.v4` artifact carrying
 /// every V5 kind with exact per-kind node counts, the V5.8 evidence edges,
 /// V5.10 derived lifecycle fields (`effective_status`, `evidence_quality`),
 /// and pilot-scoped source spans; `docs.html` renders each kind distinctly.
@@ -132,7 +132,7 @@ fn expanded_pilot_build_emits_all_kinds_in_html_and_graph() {
     let graph_text = std::fs::read_to_string(output_directory.join("docs.graph.json"))
         .expect("pilot graph JSON is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph JSON is valid");
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let nodes = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/duplicate_id.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/duplicate_id.graph.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/malformed_artifact.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/malformed_artifact.graph.json
@@ -1,1 +1,1 @@
-{ "schema_version": "adoc.graph.v3", "nodes": [
+{ "schema_version": "adoc.graph.v4", "nodes": [

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact.graph.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [
     {
       "type": "page",
@@ -62,7 +62,7 @@
         "supersedes": [],
         "related_to": []
       },
-      "status": "high"
+      "severity": "high"
     },
     {
       "type": "knowledge_object",

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact_with_trust.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact_with_trust.graph.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [
     {
       "type": "page",
@@ -63,7 +63,7 @@
         "supersedes": [],
         "related_to": []
       },
-      "status": "high"
+      "severity": "high"
     },
     {
       "type": "knowledge_object",

--- a/crates/adoc-cli/tests/graph_cli.rs
+++ b/crates/adoc-cli/tests/graph_cli.rs
@@ -70,7 +70,7 @@ fn build_writes_graph_json_even_when_embeddings_are_skipped() {
         .expect("graph artifact is readable");
     let graph_json: serde_json::Value =
         serde_json::from_str(&graph_text).expect("graph artifact is JSON");
-    assert_eq!(graph_json["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph_json["schema_version"], "adoc.graph.v4");
     assert_eq!(
         graph_json["nodes"]
             .as_array()

--- a/crates/adoc-cli/tests/markdown_pilot.rs
+++ b/crates/adoc-cli/tests/markdown_pilot.rs
@@ -198,7 +198,7 @@ fn markdown_pilot_build_emits_safe_html_and_mixed_graph() {
     let graph_text = std::fs::read_to_string(output_directory.join("docs.graph.json"))
         .expect("pilot graph JSON is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph JSON is valid");
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let nodes = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/policy_cli.rs
+++ b/crates/adoc-cli/tests/policy_cli.rs
@@ -166,7 +166,7 @@ fn build_renders_approval_block_and_emits_policy_into_graph_v3() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let policy = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/procedure_cli.rs
+++ b/crates/adoc-cli/tests/procedure_cli.rs
@@ -95,12 +95,12 @@ fn build_renders_ordered_steps_and_emits_procedure_into_graph_v3() {
         "first step text with marker stripped\n{html}"
     );
 
-    // Graph: the procedure node is emitted into adoc.graph.v3 with verified metadata.
+    // Graph: the procedure node is emitted into adoc.graph.v4 with verified metadata.
     let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let procedure = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_flags.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/adoc-cli/tests/snapshots_cli.rs
+assertion_line: 299
 expression: combined
 ---
 exit-success: false
 ---stdout---
 unknown_kind.adoc:5:3: error[schema.unknown_kind] unknown typed-block kind `fact`
   object_id: billing.policy
-  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source. Custom schemas are deferred.
+  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. Custom schemas are deferred.
 1 errors, 0 warnings
 ---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_freeform_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_freeform_flags.snap
@@ -1,11 +1,12 @@
 ---
 source: crates/adoc-cli/tests/snapshots_cli.rs
+assertion_line: 310
 expression: combined
 ---
 exit-success: false
 ---stdout---
 unknown_kind_freeform.adoc:5:3: error[schema.unknown_kind] unknown typed-block kind `fact`
   object_id: billing.policy
-  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source. Custom schemas are deferred.
+  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. Custom schemas are deferred.
 1 errors, 0 warnings
 ---stderr---

--- a/crates/adoc-cli/tests/source_cli.rs
+++ b/crates/adoc-cli/tests/source_cli.rs
@@ -111,7 +111,7 @@ fn build_emits_source_graph_node_with_expected_fields() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
 
     let node = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/why_cli.rs
+++ b/crates/adoc-cli/tests/why_cli.rs
@@ -533,7 +533,7 @@ fn why_styled_shows_contradicted_chip_on_relation_target() {
     // Build the fixture JSON inline — same schema_version as the existing
     // valid_artifact.graph.json fixture.
     let fixture = serde_json::json!({
-        "schema_version": "adoc.graph.v3",
+        "schema_version": "adoc.graph.v4",
         "nodes": [
             {
                 "type": "page",

--- a/crates/adoc-core/src/application/artifact_inspection.rs
+++ b/crates/adoc-core/src/application/artifact_inspection.rs
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn graph_schema_constants_match_readers() {
-        assert_eq!(SUPPORTED_GRAPH_SCHEMA_VERSION, "adoc.graph.v3");
+        assert_eq!(SUPPORTED_GRAPH_SCHEMA_VERSION, "adoc.graph.v4");
         assert_eq!(SUPPORTED_SEARCH_SCHEMA_VERSION, "adoc.search.v0");
     }
 }

--- a/crates/adoc-core/src/application/patch.rs
+++ b/crates/adoc-core/src/application/patch.rs
@@ -229,7 +229,7 @@ mod tests {
 
     fn graph_document(objects: Vec<GraphKnowledgeObjectNode>) -> GraphArtifactDocument {
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes: std::iter::once(GraphNode::Page(GraphPageNode {
                 id: "team.page".to_string(),
                 order: 0,

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -893,7 +893,7 @@ mod tests {
         edges: Vec<GraphEdge>,
     ) -> GraphArtifactDocument {
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes: objects
                 .into_iter()
                 .map(GraphNode::KnowledgeObject)
@@ -936,7 +936,7 @@ mod tests {
             },
         }));
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),

--- a/crates/adoc-core/src/application/signals.rs
+++ b/crates/adoc-core/src/application/signals.rs
@@ -356,11 +356,10 @@ pub(crate) fn evaluate_contradictions(
         .filter(|node| include_all || node.status.as_deref() == Some("unresolved"))
         .map(|node| ContradictionRecord {
             id: node.id.clone(),
-            severity: node
-                .severity
-                .clone()
-                .or_else(|| node.fields.get("severity").cloned())
-                .unwrap_or_default(),
+            // ADR-0039: top-level `severity` is the sole carrier in v4; the
+            // v3 fields["severity"] fallback is dead (v3 artifacts are
+            // rejected at the version gate).
+            severity: node.severity.clone().unwrap_or_default(),
             status: node.status.clone().unwrap_or_default(),
             claims: node.contradiction_claims.clone(),
             owner: node.fields.get("owner").cloned(),
@@ -659,7 +658,7 @@ mod tests {
         })];
         all_nodes.extend(nodes);
         let document = GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes: all_nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),
@@ -993,11 +992,13 @@ mod tests {
             id,
             "contradiction",
             Some(status),
-            &[("severity", severity), ("owner", "platform-security")],
+            &[("owner", "platform-security")],
         );
         let GraphNode::KnowledgeObject(ko) = &mut node else {
             unreachable!("ko_node builds a knowledge object");
         };
+        // ADR-0039: severity is a dedicated node field, not a fields entry.
+        ko.severity = Some(severity.to_string());
         ko.contradiction_claims = claims.iter().map(|claim| (*claim).to_string()).collect();
         ko.body = body.to_string();
         node
@@ -1126,15 +1127,15 @@ mod tests {
         assert_eq!(envelope.contradictions[5].severity, "panic");
     }
 
-    /// The ADR-0035 top-level severity dual-emit wins over the fields map when
-    /// both are present.
+    /// ADR-0039: the top-level `severity` field is the sole carrier — a stray
+    /// fields["severity"] entry (impossible on a v4 artifact) is ignored.
     #[test]
-    fn contradiction_severity_prefers_top_level_dual_emit() {
-        let mut node = contradiction_node("conflict.dual", "low", "unresolved", &["c.a", "c.b"]);
+    fn contradiction_severity_reads_top_level_field_only() {
+        let mut node = contradiction_node("conflict.dual", "critical", "unresolved", &["c.a"]);
         let GraphNode::KnowledgeObject(ko) = &mut node else {
             unreachable!();
         };
-        ko.severity = Some("critical".to_string());
+        ko.fields.insert("severity".to_string(), "low".to_string());
 
         let session = session_with(vec![node]);
         let envelope = evaluate_contradictions(&session, false, Vec::new());

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -122,6 +122,17 @@ pub enum DiagnosticCode {
     SchemaSourceInvalidPath,
     SchemaSourceInvalidUrl,
     SchemaSourceKindTargetMismatch,
+    /// V6.5.1: `api` Knowledge Object (PRD §13.7).
+    SchemaApiMissingMethodOrInterfaceType,
+    SchemaApiConflictingMethodAndInterfaceType,
+    SchemaApiInvalidMethod,
+    SchemaApiMissingPathOrSymbol,
+    SchemaApiConflictingPathAndSymbol,
+    SchemaApiInvalidPath,
+    /// V6.5.1: a `verified` api has neither an inline `source_code` evidence
+    /// entry nor an `evidence_ref` resolving to an `api_schema`/`source_code`
+    /// source — an API contract is verified by its schema source.
+    ApiVerifiedMissingSchemaEvidence,
     /// V5.8 TB2: the `evidence_ref:` on a claim names an Object ID that does
     /// not exist anywhere in the workspace.
     SchemaEvidenceTargetNotFound,
@@ -251,6 +262,13 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaSourceInvalidPath,
             DiagnosticCode::SchemaSourceInvalidUrl,
             DiagnosticCode::SchemaSourceKindTargetMismatch,
+            DiagnosticCode::SchemaApiMissingMethodOrInterfaceType,
+            DiagnosticCode::SchemaApiConflictingMethodAndInterfaceType,
+            DiagnosticCode::SchemaApiInvalidMethod,
+            DiagnosticCode::SchemaApiMissingPathOrSymbol,
+            DiagnosticCode::SchemaApiConflictingPathAndSymbol,
+            DiagnosticCode::SchemaApiInvalidPath,
+            DiagnosticCode::ApiVerifiedMissingSchemaEvidence,
             DiagnosticCode::SchemaEvidenceTargetNotFound,
             DiagnosticCode::SchemaEvidenceTargetNotASource,
             DiagnosticCode::ClaimEvidenceQualityLow,
@@ -402,6 +420,21 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaSourceInvalidPath => "schema.source_invalid_path",
             DiagnosticCode::SchemaSourceInvalidUrl => "schema.source_invalid_url",
             DiagnosticCode::SchemaSourceKindTargetMismatch => "schema.source_kind_target_mismatch",
+            DiagnosticCode::SchemaApiMissingMethodOrInterfaceType => {
+                "schema.api_missing_method_or_interface_type"
+            }
+            DiagnosticCode::SchemaApiConflictingMethodAndInterfaceType => {
+                "schema.api_conflicting_method_and_interface_type"
+            }
+            DiagnosticCode::SchemaApiInvalidMethod => "schema.api_invalid_method",
+            DiagnosticCode::SchemaApiMissingPathOrSymbol => "schema.api_missing_path_or_symbol",
+            DiagnosticCode::SchemaApiConflictingPathAndSymbol => {
+                "schema.api_conflicting_path_and_symbol"
+            }
+            DiagnosticCode::SchemaApiInvalidPath => "schema.api_invalid_path",
+            DiagnosticCode::ApiVerifiedMissingSchemaEvidence => {
+                "api.verified_missing_schema_evidence"
+            }
             DiagnosticCode::SchemaEvidenceTargetNotFound => "schema.evidence_target_not_found",
             DiagnosticCode::SchemaEvidenceTargetNotASource => "schema.evidence_target_not_a_source",
             DiagnosticCode::ClaimEvidenceQualityLow => "claim.evidence_quality_low",
@@ -703,6 +736,27 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaSourceKindTargetMismatch => {
                 "The evidence kind restricts target to path-only or url-only. Adjust the `kind`, `path`, or `url` field accordingly."
             }
+            DiagnosticCode::SchemaApiMissingMethodOrInterfaceType => {
+                "Add either a `method` (HTTP method, e.g. POST) or an `interface_type` (e.g. grpc, graphql) field to the api object."
+            }
+            DiagnosticCode::SchemaApiConflictingMethodAndInterfaceType => {
+                "Provide only one of `method` or `interface_type` on an api object, not both."
+            }
+            DiagnosticCode::SchemaApiInvalidMethod => {
+                "Use an uppercase HTTP method: one of GET, HEAD, POST, PUT, DELETE, CONNECT, OPTIONS, TRACE, PATCH."
+            }
+            DiagnosticCode::SchemaApiMissingPathOrSymbol => {
+                "Add either a `path` (`/`-prefixed route template) or a `symbol` (code symbol) field to the api object."
+            }
+            DiagnosticCode::SchemaApiConflictingPathAndSymbol => {
+                "Provide only one of `path` or `symbol` on an api object, not both."
+            }
+            DiagnosticCode::SchemaApiInvalidPath => {
+                "Use a non-empty `/`-prefixed route template (e.g. `/api/billing/credits/consume`)."
+            }
+            DiagnosticCode::ApiVerifiedMissingSchemaEvidence => {
+                "A verified api requires schema evidence: an inline `source:` entry or an `evidence_ref` to an `api_schema`/`source_code` source object."
+            }
             DiagnosticCode::SchemaEvidenceTargetNotFound => {
                 "Ensure every `evidence_ref` ID refers to an existing `source` object in the workspace."
             }
@@ -853,6 +907,13 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "schema.source_invalid_path",
     "schema.source_invalid_url",
     "schema.source_kind_target_mismatch",
+    "schema.api_missing_method_or_interface_type",
+    "schema.api_conflicting_method_and_interface_type",
+    "schema.api_invalid_method",
+    "schema.api_missing_path_or_symbol",
+    "schema.api_conflicting_path_and_symbol",
+    "schema.api_invalid_path",
+    "api.verified_missing_schema_evidence",
     "schema.evidence_target_not_found",
     "schema.evidence_target_not_a_source",
     "claim.evidence_quality_low",

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -81,7 +81,7 @@ impl GraphArtifactDocument {
 
 // `GraphKnowledgeObjectNode` is large by design (carries all graph-node fields
 // inline for zero-copy serde). Boxing here would add indirection on every graph
-// traversal; the size asymmetry is acceptable per the `adoc.graph.v3` contract.
+// traversal; the size asymmetry is acceptable per the `adoc.graph.v4` contract.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -181,15 +181,14 @@ pub(crate) struct GraphKnowledgeObjectNode {
     pub(crate) content_hash: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) status: Option<String>,
-    /// ADR-0035 dual-emit: derived duplicate of the kind-specific severity
-    /// discriminant/field. Populated for `warning`, `constraint`, and
-    /// `contradiction` nodes. NOT hashed; additive within `adoc.graph.v3`.
+    /// ADR-0039: the authored severity carrier. Populated for `warning`,
+    /// `constraint`, and `contradiction` nodes; part of `content_hash`.
     /// Skipped when `None` so other kinds remain byte-stable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) severity: Option<String>,
-    /// ADR-0035 dual-emit: derived duplicate of the trust discriminant.
-    /// Populated for `agent_instruction` nodes only. NOT hashed; additive
-    /// within `adoc.graph.v3`. Skipped when `None`.
+    /// ADR-0039: the authored trust carrier. Populated for
+    /// `agent_instruction` nodes only; part of `content_hash`. Skipped when
+    /// `None`.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub(crate) trust: Option<String>,
     pub(crate) body: String,
@@ -719,7 +718,7 @@ mod tests {
 
     fn graph_document(content_hash: Option<&str>) -> GraphArtifactDocument {
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes: vec![
                 GraphNode::Page(GraphPageNode {
                     id: "team.page".to_string(),
@@ -813,7 +812,7 @@ mod tests {
             })
             .collect();
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),

--- a/crates/adoc-core/src/domain/knowledge_object/api.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/api.rs
@@ -1,0 +1,945 @@
+//! `api` Knowledge Object aggregate (V6.5.1, PRD §13.7).
+//!
+//! A typed API contract. Required fields: `id`, exactly one of `method`
+//! (closed [`HttpMethod`]) or `interface_type` (open string: `grpc`,
+//! `graphql`, …), exactly one of `path` (`/`-prefixed route template) or
+//! `symbol` (code symbol), and `body`. Both one-of invariants follow
+//! `source`'s path-XOR-url sum-type pattern. Statuses are the closed
+//! `draft | verified | deprecated` set (the procedure pattern) and optional;
+//! a `verified` api requires `owner`, `verified_at`, and evidence — the
+//! schema-quality evidence rule (`api.verified_missing_schema_evidence`)
+//! lives in `infrastructure/validate/api_verified_evidence.rs` because it
+//! resolves `evidence_ref` targets across the workspace.
+
+use std::collections::BTreeMap;
+
+use crate::domain::ast::ParsedTypedBlock;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
+use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId, ObjectIdError};
+use crate::domain::knowledge_object::Relations;
+use crate::domain::knowledge_object::claim::{
+    Evidence, OWNER_FIELD, Owner, REVIEWED_BY_FIELD, SOURCE_FIELD, TEST_FIELD, VERIFIED_AT_FIELD,
+    Verification, VerifiedAt,
+};
+use crate::domain::value_objects::http_method::{HttpMethod, HttpMethodError};
+use crate::domain::value_objects::rel_path::RelPath;
+use crate::domain::values::{Body, NonEmpty, OptionalFields, trim_ascii_edges};
+
+pub(crate) const METHOD_FIELD: &str = "method";
+pub(crate) const INTERFACE_TYPE_FIELD: &str = "interface_type";
+pub(crate) const PATH_FIELD: &str = "path";
+pub(crate) const SYMBOL_FIELD: &str = "symbol";
+const STATUS_FIELD: &str = "status";
+const VERIFIED_STATUS: &str = "verified";
+
+const API_INVALID_STATUS_HELP: &str = "Valid api statuses are: draft, verified, deprecated.";
+const API_MISSING_BODY_HELP: &str =
+    "Apis require non-empty body text describing the contract's behavior.";
+const VERIFIED_API_HELP: &str = "Verified apis require `owner`, `verified_at`, and schema \
+     evidence: an inline `source:` entry or an `evidence_ref` to an `api_schema`/`source_code` \
+     source object.";
+
+/// The operation half of the contract: a closed HTTP method or an open
+/// interface type (`grpc`, `graphql`, …) — exactly one, never both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ApiOperation {
+    Method(HttpMethod),
+    InterfaceType(String),
+}
+
+/// The location half of the contract: a `/`-prefixed route template or a
+/// code symbol — exactly one, never both.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ApiLocation {
+    Path(String),
+    Symbol(String),
+}
+
+/// A typed API contract (PRD §13.7, V6.5.1).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Api {
+    id: ObjectId,
+    status: Option<ApiStatus>,
+    operation: ApiOperation,
+    location: ApiLocation,
+    body: Body,
+    fields: OptionalFields,
+    verification: Option<Verification>,
+    evidence_refs: Vec<Evidence>,
+    relations: Relations,
+    impacts: Option<NonEmpty<RelPath>>,
+    span: SourceSpan,
+}
+
+/// Why an `api` failed to build from parsed input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ApiError {
+    InvalidId(ObjectIdError),
+    InvalidStatus(String),
+    MissingBody,
+    MissingMethodOrInterfaceType,
+    ConflictingMethodAndInterfaceType,
+    InvalidMethod(String),
+    MissingPathOrSymbol,
+    ConflictingPathAndSymbol,
+    InvalidPath(String),
+    // Constructed only by the test-only `try_new`; `build_from_parsed`
+    // decides the pairing itself so these never reach production diagnostics.
+    #[allow(dead_code)]
+    MissingVerification,
+    #[allow(dead_code)]
+    UnexpectedVerification,
+}
+
+impl Api {
+    pub(crate) fn build_from_parsed(
+        mut parsed: ParsedTypedBlock,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Self> {
+        if super::reject_duplicate_fields(&parsed, "api", diagnostics) {
+            return None;
+        }
+
+        let id = match ObjectId::new(&parsed.id_text) {
+            Ok(id) => Some(id),
+            Err(error) => {
+                emit_api_error(&parsed, ApiError::InvalidId(error), diagnostics);
+                None
+            }
+        };
+
+        let status = match parse_status(&mut parsed) {
+            Ok(status) => status,
+            Err(error) => {
+                emit_api_error(&parsed, error, diagnostics);
+                return None;
+            }
+        };
+
+        let operation = parse_operation(&mut parsed, diagnostics);
+        let location = parse_location(&mut parsed, diagnostics);
+
+        let body = match super::body_from_parsed(&parsed) {
+            Some(body) => Some(body),
+            None => {
+                emit_api_error(&parsed, ApiError::MissingBody, diagnostics);
+                None
+            }
+        };
+
+        // Parse evidence_refs BEFORE building verification so a verified api
+        // whose only evidence is an `evidence_ref:` is accepted (the claim
+        // precedent); the schema-quality gate is the workspace rule's job.
+        let evidence_refs = super::parse_evidence_refs(&mut parsed, diagnostics);
+        let verification = if status.as_ref().is_some_and(ApiStatus::is_verified) {
+            let has_refs = !evidence_refs.is_empty();
+            match build_verification(&parsed, &parsed.raw_fields, has_refs, diagnostics) {
+                Some(verification) => Some(verification),
+                None => return None,
+            }
+        } else {
+            None
+        };
+
+        if id.is_none() || operation.is_none() || location.is_none() || body.is_none() {
+            return None;
+        }
+
+        let relations = super::extract_relations(&mut parsed, diagnostics);
+        let impacts = super::extract_impacts(&mut parsed, diagnostics);
+        let mut optional_fields = std::mem::take(&mut parsed.raw_fields);
+        if verification.is_some() {
+            optional_fields.retain(|key, _| !is_verified_api_dedicated_field(key));
+        }
+
+        Some(Self {
+            id: id.expect("checked above"),
+            status,
+            operation: operation.expect("checked above"),
+            location: location.expect("checked above"),
+            body: body.expect("checked above"),
+            fields: OptionalFields::from_map(optional_fields),
+            verification,
+            evidence_refs,
+            relations,
+            impacts: None,
+            span: parsed.span.clone(),
+        })
+        .map(|api| api.with_impacts(impacts))
+    }
+
+    /// Test-only constructor that bypasses the parsed-block pipeline.
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new(
+        id_text: &str,
+        status_text: Option<&str>,
+        method_text: Option<&str>,
+        interface_type_text: Option<&str>,
+        path_text: Option<&str>,
+        symbol_text: Option<&str>,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        verification: Option<Verification>,
+        span: SourceSpan,
+    ) -> Result<Self, ApiError> {
+        let id = ObjectId::new(id_text).map_err(ApiError::InvalidId)?;
+        let status = status_text.map(ApiStatus::try_new).transpose()?;
+        let operation = match (method_text, interface_type_text) {
+            (Some(_), Some(_)) => return Err(ApiError::ConflictingMethodAndInterfaceType),
+            (None, None) => return Err(ApiError::MissingMethodOrInterfaceType),
+            (Some(method), None) => {
+                ApiOperation::Method(HttpMethod::try_new(method).map_err(|error| match error {
+                    HttpMethodError::Missing => ApiError::MissingMethodOrInterfaceType,
+                    HttpMethodError::Invalid(value) => ApiError::InvalidMethod(value),
+                })?)
+            }
+            (None, Some(interface_type)) => {
+                ApiOperation::InterfaceType(trim_ascii_edges(interface_type).to_string())
+            }
+        };
+        let location = match (path_text, symbol_text) {
+            (Some(_), Some(_)) => return Err(ApiError::ConflictingPathAndSymbol),
+            (None, None) => return Err(ApiError::MissingPathOrSymbol),
+            (Some(path), None) => ApiLocation::Path(parse_path_template(path)?),
+            (None, Some(symbol)) => ApiLocation::Symbol(trim_ascii_edges(symbol).to_string()),
+        };
+        let is_verified = status.as_ref().is_some_and(ApiStatus::is_verified);
+        if is_verified && verification.is_none() {
+            return Err(ApiError::MissingVerification);
+        }
+        if !is_verified && verification.is_some() {
+            return Err(ApiError::UnexpectedVerification);
+        }
+        let body = Body::from_plain_text(body_text).ok_or(ApiError::MissingBody)?;
+        Ok(Self {
+            id,
+            status,
+            operation,
+            location,
+            body,
+            fields: OptionalFields::from_map(optional_fields),
+            verification,
+            evidence_refs: Vec::new(),
+            relations: Relations::empty(),
+            impacts: None,
+            span,
+        })
+    }
+
+    pub(crate) fn with_impacts(mut self, impacts: Option<NonEmpty<RelPath>>) -> Self {
+        self.impacts = impacts;
+        self
+    }
+
+    // ── Accessors ────────────────────────────────────────────────────────────
+
+    pub(crate) fn id(&self) -> &ObjectId {
+        &self.id
+    }
+
+    pub(crate) fn status(&self) -> Option<&ApiStatus> {
+        self.status.as_ref()
+    }
+
+    pub(crate) fn method(&self) -> Option<HttpMethod> {
+        match &self.operation {
+            ApiOperation::Method(method) => Some(*method),
+            ApiOperation::InterfaceType(_) => None,
+        }
+    }
+
+    pub(crate) fn interface_type(&self) -> Option<&str> {
+        match &self.operation {
+            ApiOperation::Method(_) => None,
+            ApiOperation::InterfaceType(interface_type) => Some(interface_type),
+        }
+    }
+
+    pub(crate) fn path(&self) -> Option<&str> {
+        match &self.location {
+            ApiLocation::Path(path) => Some(path),
+            ApiLocation::Symbol(_) => None,
+        }
+    }
+
+    pub(crate) fn symbol(&self) -> Option<&str> {
+        match &self.location {
+            ApiLocation::Path(_) => None,
+            ApiLocation::Symbol(symbol) => Some(symbol),
+        }
+    }
+
+    pub(crate) fn body(&self) -> &Body {
+        &self.body
+    }
+
+    pub(crate) fn body_mut(&mut self) -> &mut Body {
+        &mut self.body
+    }
+
+    pub(crate) fn fields(&self) -> &OptionalFields {
+        &self.fields
+    }
+
+    pub(crate) fn verification(&self) -> Option<&Verification> {
+        self.verification.as_ref()
+    }
+
+    pub(crate) fn evidence_refs(&self) -> &[Evidence] {
+        &self.evidence_refs
+    }
+
+    pub(crate) fn relations(&self) -> &Relations {
+        &self.relations
+    }
+
+    pub(crate) fn impacts(&self) -> Option<&[RelPath]> {
+        self.impacts.as_ref().map(NonEmpty::as_slice)
+    }
+
+    pub(crate) fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+/// Optional closed status. `status:` absent → `None`; present-but-blank is
+/// also treated as absent (nothing to validate).
+fn parse_status(parsed: &mut ParsedTypedBlock) -> Result<Option<ApiStatus>, ApiError> {
+    let Some(raw) = parsed.raw_fields.remove(STATUS_FIELD) else {
+        return Ok(None);
+    };
+    let trimmed = trim_ascii_edges(&raw);
+    if trimmed.is_empty() {
+        return Ok(None);
+    }
+    ApiStatus::try_new(trimmed).map(Some)
+}
+
+fn parse_operation(
+    parsed: &mut ParsedTypedBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<ApiOperation> {
+    let method_raw = parsed.raw_fields.remove(METHOD_FIELD);
+    let interface_type_raw = parsed.raw_fields.remove(INTERFACE_TYPE_FIELD);
+
+    match (method_raw, interface_type_raw) {
+        (Some(_), Some(_)) => {
+            emit_api_error(
+                parsed,
+                ApiError::ConflictingMethodAndInterfaceType,
+                diagnostics,
+            );
+            None
+        }
+        (None, None) => {
+            emit_api_error(parsed, ApiError::MissingMethodOrInterfaceType, diagnostics);
+            None
+        }
+        (Some(method), None) => match HttpMethod::try_new(&method) {
+            Ok(method) => Some(ApiOperation::Method(method)),
+            Err(HttpMethodError::Missing) => {
+                emit_api_error(parsed, ApiError::MissingMethodOrInterfaceType, diagnostics);
+                None
+            }
+            Err(HttpMethodError::Invalid(value)) => {
+                emit_api_error(parsed, ApiError::InvalidMethod(value), diagnostics);
+                None
+            }
+        },
+        (None, Some(interface_type)) => {
+            let trimmed = trim_ascii_edges(&interface_type);
+            if trimmed.is_empty() {
+                emit_api_error(parsed, ApiError::MissingMethodOrInterfaceType, diagnostics);
+                return None;
+            }
+            Some(ApiOperation::InterfaceType(trimmed.to_string()))
+        }
+    }
+}
+
+fn parse_location(
+    parsed: &mut ParsedTypedBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<ApiLocation> {
+    let path_raw = parsed.raw_fields.remove(PATH_FIELD);
+    let symbol_raw = parsed.raw_fields.remove(SYMBOL_FIELD);
+
+    match (path_raw, symbol_raw) {
+        (Some(_), Some(_)) => {
+            emit_api_error(parsed, ApiError::ConflictingPathAndSymbol, diagnostics);
+            None
+        }
+        (None, None) => {
+            emit_api_error(parsed, ApiError::MissingPathOrSymbol, diagnostics);
+            None
+        }
+        (Some(path), None) => match parse_path_template(&path) {
+            Ok(path) => Some(ApiLocation::Path(path)),
+            Err(error) => {
+                emit_api_error(parsed, error, diagnostics);
+                None
+            }
+        },
+        (None, Some(symbol)) => {
+            let trimmed = trim_ascii_edges(&symbol);
+            if trimmed.is_empty() {
+                emit_api_error(parsed, ApiError::MissingPathOrSymbol, diagnostics);
+                return None;
+            }
+            Some(ApiLocation::Symbol(trimmed.to_string()))
+        }
+    }
+}
+
+/// A route template is a non-empty `/`-prefixed string — no deeper grammar
+/// (PRD §13.7 scope).
+fn parse_path_template(value: &str) -> Result<String, ApiError> {
+    let trimmed = trim_ascii_edges(value);
+    if !trimmed.starts_with('/') {
+        return Err(ApiError::InvalidPath(trimmed.to_string()));
+    }
+    Ok(trimmed.to_string())
+}
+
+/// Mirror of the claim/procedure verification builder: `owner`, `verified_at`,
+/// and at least one inline evidence entry OR one `evidence_ref`. The
+/// api-specific schema-quality requirement is enforced by the
+/// `api_verified_evidence` workspace rule, which can resolve ref targets.
+fn build_verification(
+    parsed: &ParsedTypedBlock,
+    fields: &BTreeMap<String, String>,
+    has_refs: bool,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<Verification> {
+    let owner = fields
+        .get(OWNER_FIELD)
+        .and_then(|value| Owner::try_new(value));
+    if owner.is_none() {
+        diagnostics.push(missing_verified_field_diagnostic(parsed, OWNER_FIELD));
+    }
+
+    let verified_at = fields
+        .get(VERIFIED_AT_FIELD)
+        .and_then(|value| VerifiedAt::try_new(value));
+    if verified_at.is_none() {
+        diagnostics.push(missing_verified_field_diagnostic(parsed, VERIFIED_AT_FIELD));
+    }
+
+    let mut evidence = Vec::new();
+    for field in [SOURCE_FIELD, TEST_FIELD, REVIEWED_BY_FIELD] {
+        if let Some(value) = fields
+            .get(field)
+            .and_then(|value| Evidence::from_field(field, value))
+        {
+            evidence.push(value);
+        }
+    }
+
+    let has_inline_evidence = !evidence.is_empty();
+    if !has_inline_evidence && !has_refs {
+        diagnostics.push(
+            Diagnostic::error(
+                DiagnosticCode::ApiVerifiedMissingSchemaEvidence,
+                format!(
+                    "verified api `{}` requires schema evidence: an inline `source:` entry or an `evidence_ref` to an `api_schema`/`source_code` source",
+                    parsed.id_text
+                ),
+            )
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text)
+            .with_help(VERIFIED_API_HELP),
+        );
+    }
+
+    if owner.is_none() || verified_at.is_none() || (!has_inline_evidence && !has_refs) {
+        return None;
+    }
+
+    Some(Verification::new(
+        owner.expect("owner checked above"),
+        verified_at.expect("verified_at checked above"),
+        evidence,
+    ))
+}
+
+fn is_verified_api_dedicated_field(key: &str) -> bool {
+    matches!(
+        key,
+        OWNER_FIELD | VERIFIED_AT_FIELD | SOURCE_FIELD | TEST_FIELD | REVIEWED_BY_FIELD
+    )
+}
+
+fn missing_verified_field_diagnostic(parsed: &ParsedTypedBlock, field: &str) -> Diagnostic {
+    Diagnostic::error(
+        DiagnosticCode::SchemaMissingField,
+        format!(
+            "verified api `{}` is missing required field `{field}`",
+            parsed.id_text
+        ),
+    )
+    .with_span(parsed.span.clone())
+    .with_object_id(&parsed.id_text)
+    .with_help(format!("Add `{field}`. {VERIFIED_API_HELP}"))
+}
+
+fn emit_api_error(parsed: &ParsedTypedBlock, error: ApiError, diagnostics: &mut Vec<Diagnostic>) {
+    let diagnostic = match error {
+        ApiError::InvalidId(error) => Diagnostic::error(
+            DiagnosticCode::IdInvalid,
+            format!("invalid api id `{}`: {error}", parsed.id_text),
+        )
+        .with_help(OBJECT_ID_GRAMMAR_HELP),
+        ApiError::InvalidStatus(status) => Diagnostic::error(
+            DiagnosticCode::SchemaInvalidStatus,
+            format!("api `{}` has invalid status `{status}`", parsed.id_text),
+        )
+        .with_help(API_INVALID_STATUS_HELP),
+        ApiError::MissingBody => Diagnostic::error(
+            DiagnosticCode::SchemaMissingField,
+            format!("api `{}` is missing required body", parsed.id_text),
+        )
+        .with_help(API_MISSING_BODY_HELP),
+        ApiError::MissingMethodOrInterfaceType => Diagnostic::error(
+            DiagnosticCode::SchemaApiMissingMethodOrInterfaceType,
+            format!(
+                "api `{}` requires one of `method` or `interface_type`",
+                parsed.id_text
+            ),
+        )
+        .with_help(DiagnosticCode::SchemaApiMissingMethodOrInterfaceType.default_help()),
+        ApiError::ConflictingMethodAndInterfaceType => Diagnostic::error(
+            DiagnosticCode::SchemaApiConflictingMethodAndInterfaceType,
+            format!(
+                "api `{}` provides both `method` and `interface_type`",
+                parsed.id_text
+            ),
+        )
+        .with_help(DiagnosticCode::SchemaApiConflictingMethodAndInterfaceType.default_help()),
+        ApiError::InvalidMethod(method) => Diagnostic::error(
+            DiagnosticCode::SchemaApiInvalidMethod,
+            format!("api `{}` has invalid method `{method}`", parsed.id_text),
+        )
+        .with_help(DiagnosticCode::SchemaApiInvalidMethod.default_help()),
+        ApiError::MissingPathOrSymbol => Diagnostic::error(
+            DiagnosticCode::SchemaApiMissingPathOrSymbol,
+            format!(
+                "api `{}` requires one of `path` or `symbol`",
+                parsed.id_text
+            ),
+        )
+        .with_help(DiagnosticCode::SchemaApiMissingPathOrSymbol.default_help()),
+        ApiError::ConflictingPathAndSymbol => Diagnostic::error(
+            DiagnosticCode::SchemaApiConflictingPathAndSymbol,
+            format!("api `{}` provides both `path` and `symbol`", parsed.id_text),
+        )
+        .with_help(DiagnosticCode::SchemaApiConflictingPathAndSymbol.default_help()),
+        ApiError::InvalidPath(path) => Diagnostic::error(
+            DiagnosticCode::SchemaApiInvalidPath,
+            format!("api `{}` has invalid path `{path}`", parsed.id_text),
+        )
+        .with_help(DiagnosticCode::SchemaApiInvalidPath.default_help()),
+        ApiError::MissingVerification | ApiError::UnexpectedVerification => {
+            unreachable!("verification pairing is decided by the builder, not authored input")
+        }
+    };
+    diagnostics.push(
+        diagnostic
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text),
+    );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ApiStatus {
+    Draft,
+    Verified,
+    Deprecated,
+}
+
+impl ApiStatus {
+    pub(crate) fn try_new(value: &str) -> Result<Self, ApiError> {
+        match trim_ascii_edges(value) {
+            "draft" => Ok(Self::Draft),
+            VERIFIED_STATUS => Ok(Self::Verified),
+            "deprecated" => Ok(Self::Deprecated),
+            other => Err(ApiError::InvalidStatus(other.to_string())),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::Draft => "draft",
+            Self::Verified => VERIFIED_STATUS,
+            Self::Deprecated => "deprecated",
+        }
+    }
+
+    pub(crate) fn is_verified(&self) -> bool {
+        matches!(self, Self::Verified)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+    use crate::domain::value_objects::evidence_kind::EvidenceKind;
+
+    fn span() -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from("test.adoc"),
+            start: SourcePosition {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line: 1,
+                column: 8,
+                offset: 7,
+            },
+        }
+    }
+
+    fn parsed_api(fields: BTreeMap<String, String>) -> ParsedTypedBlock {
+        let body_text = "Consumes one or more credits for a completed generation job.";
+        ParsedTypedBlock {
+            kind_word: "api".to_string(),
+            kind_word_span: span(),
+            id_text: "billing.consume-credit".to_string(),
+            raw_fields: fields,
+            raw_field_spans: BTreeMap::new(),
+            duplicate_keys: Vec::new(),
+            body_text: body_text.to_string(),
+            body_inlines: ParsedTypedBlock::test_body_inlines_from_text(body_text),
+            body_spans: Vec::new(),
+            content_spans: Vec::new(),
+            span: span(),
+            close_fence_span: span(),
+            body_separator_span: None,
+        }
+    }
+
+    fn verification() -> Verification {
+        Verification::new(
+            Owner::try_new("backend-platform").expect("owner"),
+            VerifiedAt::try_new("2026-05-06").expect("verified_at"),
+            vec![
+                Evidence::inline(EvidenceKind::SourceCode, "openapi/billing.yaml").expect("source"),
+            ],
+        )
+    }
+
+    #[test]
+    fn try_new_accepts_method_and_path() {
+        let api = Api::try_new(
+            "billing.consume-credit",
+            Some("draft"),
+            Some("POST"),
+            None,
+            Some("/api/billing/credits/consume"),
+            None,
+            "Consumes credits.",
+            BTreeMap::new(),
+            None,
+            span(),
+        )
+        .expect("valid api");
+
+        assert_eq!(api.id().as_str(), "billing.consume-credit");
+        assert_eq!(api.method().map(|m| m.as_str()), Some("POST"));
+        assert_eq!(api.path(), Some("/api/billing/credits/consume"));
+        assert_eq!(api.interface_type(), None);
+        assert_eq!(api.symbol(), None);
+        assert_eq!(api.status().map(ApiStatus::as_str), Some("draft"));
+    }
+
+    #[test]
+    fn try_new_accepts_interface_type_and_symbol() {
+        let api = Api::try_new(
+            "billing.consume-credit-grpc",
+            None,
+            None,
+            Some("grpc"),
+            None,
+            Some("billing.v1.CreditService/Consume"),
+            "Consumes credits over gRPC.",
+            BTreeMap::new(),
+            None,
+            span(),
+        )
+        .expect("valid api");
+
+        assert_eq!(api.interface_type(), Some("grpc"));
+        assert_eq!(api.symbol(), Some("billing.v1.CreditService/Consume"));
+        assert!(api.status().is_none());
+    }
+
+    #[test]
+    fn try_new_rejects_both_method_and_interface_type() {
+        let result = Api::try_new(
+            "billing.consume-credit",
+            None,
+            Some("POST"),
+            Some("grpc"),
+            Some("/api/x"),
+            None,
+            "Body.",
+            BTreeMap::new(),
+            None,
+            span(),
+        );
+
+        assert_eq!(result, Err(ApiError::ConflictingMethodAndInterfaceType));
+    }
+
+    #[test]
+    fn try_new_rejects_neither_path_nor_symbol() {
+        let result = Api::try_new(
+            "billing.consume-credit",
+            None,
+            Some("POST"),
+            None,
+            None,
+            None,
+            "Body.",
+            BTreeMap::new(),
+            None,
+            span(),
+        );
+
+        assert_eq!(result, Err(ApiError::MissingPathOrSymbol));
+    }
+
+    #[test]
+    fn try_new_rejects_unprefixed_path() {
+        let result = Api::try_new(
+            "billing.consume-credit",
+            None,
+            Some("POST"),
+            None,
+            Some("api/billing"),
+            None,
+            "Body.",
+            BTreeMap::new(),
+            None,
+            span(),
+        );
+
+        assert_eq!(
+            result,
+            Err(ApiError::InvalidPath("api/billing".to_string()))
+        );
+    }
+
+    #[test]
+    fn try_new_requires_verification_for_verified_status() {
+        let result = Api::try_new(
+            "billing.consume-credit",
+            Some("verified"),
+            Some("POST"),
+            None,
+            Some("/api/x"),
+            None,
+            "Body.",
+            BTreeMap::new(),
+            None,
+            span(),
+        );
+
+        assert_eq!(result, Err(ApiError::MissingVerification));
+    }
+
+    #[test]
+    fn try_new_rejects_verification_for_non_verified_status() {
+        let result = Api::try_new(
+            "billing.consume-credit",
+            Some("draft"),
+            Some("POST"),
+            None,
+            Some("/api/x"),
+            None,
+            "Body.",
+            BTreeMap::new(),
+            Some(verification()),
+            span(),
+        );
+
+        assert_eq!(result, Err(ApiError::UnexpectedVerification));
+    }
+
+    #[test]
+    fn build_from_parsed_accepts_the_prd_example() {
+        // PRD §13.7 verbatim field set.
+        let parsed = parsed_api(BTreeMap::from([
+            ("method".to_string(), "POST".to_string()),
+            (
+                "path".to_string(),
+                "/api/billing/credits/consume".to_string(),
+            ),
+            ("status".to_string(), "verified".to_string()),
+            (
+                "source".to_string(),
+                "openapi/billing.yaml#/paths/~1credits~1consume".to_string(),
+            ),
+            ("owner".to_string(), "backend-platform".to_string()),
+            ("verified_at".to_string(), "2026-05-06".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics).expect("valid api");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(api.method().map(|m| m.as_str()), Some("POST"));
+        assert_eq!(api.path(), Some("/api/billing/credits/consume"));
+        assert!(api.status().expect("status").is_verified());
+        let verification = api.verification().expect("verification");
+        assert_eq!(verification.owner().as_str(), "backend-platform");
+        assert_eq!(verification.evidence().len(), 1);
+        assert_eq!(
+            verification.evidence()[0].kind(),
+            Some(EvidenceKind::SourceCode)
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_missing_method_or_interface_type() {
+        let parsed = parsed_api(BTreeMap::from([(
+            "path".to_string(),
+            "/api/billing/credits/consume".to_string(),
+        )]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(api.is_none());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaApiMissingMethodOrInterfaceType
+        );
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("billing.consume-credit")
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_conflicting_method_and_interface_type() {
+        let parsed = parsed_api(BTreeMap::from([
+            ("method".to_string(), "POST".to_string()),
+            ("interface_type".to_string(), "grpc".to_string()),
+            ("path".to_string(), "/api/x".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(api.is_none());
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaApiConflictingMethodAndInterfaceType
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_invalid_method() {
+        let parsed = parsed_api(BTreeMap::from([
+            ("method".to_string(), "post".to_string()),
+            ("path".to_string(), "/api/x".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(api.is_none());
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaApiInvalidMethod);
+    }
+
+    #[test]
+    fn build_from_parsed_reports_verified_with_only_reviewed_by_as_missing_schema_evidence() {
+        // Acceptance case: `reviewed_by:` alone is inline HumanReview evidence,
+        // which satisfies the generic verification shape — but the aggregate
+        // still owns nothing api-specific here; the schema-quality rejection
+        // happens in the api_verified_evidence workspace rule. This test pins
+        // the aggregate-level part: verification builds, evidence is HumanReview.
+        let parsed = parsed_api(BTreeMap::from([
+            ("method".to_string(), "POST".to_string()),
+            ("path".to_string(), "/api/x".to_string()),
+            ("status".to_string(), "verified".to_string()),
+            ("owner".to_string(), "backend-platform".to_string()),
+            ("verified_at".to_string(), "2026-05-06".to_string()),
+            ("reviewed_by".to_string(), "api-guild".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics).expect("valid api");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        let verification = api.verification().expect("verification");
+        assert_eq!(
+            verification.evidence()[0].kind(),
+            Some(EvidenceKind::HumanReview)
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_verified_without_any_evidence() {
+        let parsed = parsed_api(BTreeMap::from([
+            ("method".to_string(), "POST".to_string()),
+            ("path".to_string(), "/api/x".to_string()),
+            ("status".to_string(), "verified".to_string()),
+            ("owner".to_string(), "backend-platform".to_string()),
+            ("verified_at".to_string(), "2026-05-06".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(api.is_none());
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::ApiVerifiedMissingSchemaEvidence
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_captures_impacts_and_relations() {
+        let parsed = parsed_api(BTreeMap::from([
+            ("method".to_string(), "POST".to_string()),
+            ("path".to_string(), "/api/x".to_string()),
+            ("impacts".to_string(), "[openapi/billing.yaml]".to_string()),
+            ("depends_on".to_string(), "billing.credits".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let api = Api::build_from_parsed(parsed, &mut diagnostics).expect("valid api");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        let impacts: Vec<&str> = api
+            .impacts()
+            .expect("impacts present")
+            .iter()
+            .map(RelPath::as_str)
+            .collect();
+        assert_eq!(impacts, vec!["openapi/billing.yaml"]);
+        let depends_on: Vec<&str> = api
+            .relations()
+            .targets(crate::domain::graph::GraphRelationKind::DependsOn)
+            .iter()
+            .map(|target| target.id().as_str())
+            .collect();
+        assert_eq!(depends_on, vec!["billing.credits"]);
+    }
+
+    #[test]
+    fn status_try_new_rejects_unknown_values() {
+        assert_eq!(
+            ApiStatus::try_new("active"),
+            Err(ApiError::InvalidStatus("active".to_string()))
+        );
+    }
+}

--- a/crates/adoc-core/src/domain/knowledge_object/draft.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/draft.rs
@@ -4,6 +4,9 @@ use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::domain::graph::GraphRelationKind;
 use crate::domain::identity::ObjectId;
 use crate::domain::knowledge_object::EVIDENCE_REF_FIELD;
+use crate::domain::knowledge_object::api::{
+    ApiStatus, INTERFACE_TYPE_FIELD, METHOD_FIELD, PATH_FIELD as API_PATH_FIELD, SYMBOL_FIELD,
+};
 use crate::domain::knowledge_object::claim::{
     ClaimStatus, Evidence, OWNER_FIELD, Owner, REVIEWED_BY_FIELD, SOURCE_FIELD, TEST_FIELD,
     VERIFIED_AT_FIELD, VERIFIED_STATUS, VerifiedAt,
@@ -11,6 +14,7 @@ use crate::domain::knowledge_object::claim::{
 use crate::domain::knowledge_object::decision::{
     ACCEPTED_STATUS, DECIDED_BY_FIELD, DecidedBy, DecisionStatus,
 };
+use crate::domain::value_objects::http_method::HttpMethod;
 use crate::domain::value_objects::severity::Severity;
 use crate::domain::values::NonEmptyText;
 
@@ -61,6 +65,7 @@ impl DraftValidator<'_> {
             "decision" => self.validate_decision(),
             "glossary" => self.validate_glossary(),
             "warning" => self.validate_warning(),
+            "api" => self.validate_api(),
             kind => self.error(format!("unknown Knowledge Object kind `{kind}`")),
         }
     }
@@ -109,6 +114,84 @@ impl DraftValidator<'_> {
                 None => self.error("warning requires severity"),
             }
         }
+    }
+
+    fn validate_api(&mut self) {
+        // Status is optional; when present it must be the closed set.
+        if let Some(status) = self.draft.status
+            && ApiStatus::try_new(status).is_err()
+        {
+            self.error(format!("api has invalid status `{status}`"));
+            return;
+        }
+
+        let has_method = self.draft.fields.contains_key(METHOD_FIELD);
+        let has_interface_type = self.draft.fields.contains_key(INTERFACE_TYPE_FIELD);
+        match (has_method, has_interface_type) {
+            (true, true) => self.error("api provides both `method` and `interface_type`"),
+            (false, false) => self.error("api requires one of `method` or `interface_type`"),
+            _ => {}
+        }
+        if let Some(method) = self.draft.fields.get(METHOD_FIELD)
+            && HttpMethod::try_new(method).is_err()
+        {
+            self.error(format!("api has invalid method `{method}`"));
+        }
+
+        let has_path = self.draft.fields.contains_key(API_PATH_FIELD);
+        let has_symbol = self.draft.fields.contains_key(SYMBOL_FIELD);
+        match (has_path, has_symbol) {
+            (true, true) => self.error("api provides both `path` and `symbol`"),
+            (false, false) => self.error("api requires one of `path` or `symbol`"),
+            _ => {}
+        }
+        if let Some(path) = self.draft.fields.get(API_PATH_FIELD)
+            && !path.trim().starts_with('/')
+        {
+            self.error(format!("api has invalid path `{path}`"));
+        }
+
+        if self.draft.status == Some(VERIFIED_STATUS) {
+            self.validate_verified_api_obligation();
+        }
+    }
+
+    fn validate_verified_api_obligation(&mut self) {
+        let owner = self
+            .draft
+            .fields
+            .get(OWNER_FIELD)
+            .and_then(|value| Owner::try_new(value));
+        let verified_at = self
+            .draft
+            .fields
+            .get(VERIFIED_AT_FIELD)
+            .and_then(|value| VerifiedAt::try_new(value));
+        let has_schema_evidence = self
+            .draft
+            .fields
+            .get(SOURCE_FIELD)
+            .and_then(|value| Evidence::from_field(SOURCE_FIELD, value))
+            .is_some()
+            || self
+                .draft
+                .fields
+                .get(EVIDENCE_REF_FIELD)
+                .map(|v| !v.trim().is_empty())
+                .unwrap_or(false);
+
+        let reason = if owner.is_some() && verified_at.is_some() && has_schema_evidence {
+            "Verified api creation requires schema-evidence review before approval."
+        } else {
+            "Verified api creation is missing complete schema evidence."
+        };
+
+        self.validation
+            .proof_obligations
+            .push(DraftProofObligation {
+                object_id: self.draft.id.as_str().to_string(),
+                reason: reason.to_string(),
+            });
     }
 
     fn validate_fields(&mut self) {

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -15,6 +15,7 @@ pub(super) const IMPACTS_FIELD: &str = "impacts";
 pub(crate) const APPROVED_BY_FIELD: &str = "approved_by";
 
 pub(crate) mod agent_instruction;
+pub(crate) mod api;
 pub(crate) mod claim;
 pub(crate) mod constraint;
 pub(crate) mod contradiction;
@@ -30,6 +31,7 @@ pub(crate) mod source;
 pub(crate) mod warning;
 
 use agent_instruction::AgentInstruction;
+use api::Api;
 use claim::Claim;
 use constraint::Constraint;
 use contradiction::Contradiction;
@@ -815,6 +817,7 @@ pub(crate) enum BlockKind {
     AgentInstruction,
     Contradiction,
     Source,
+    Api,
 }
 
 impl BlockKind {
@@ -830,6 +833,7 @@ impl BlockKind {
         Self::AgentInstruction,
         Self::Contradiction,
         Self::Source,
+        Self::Api,
     ];
 
     pub(crate) const fn as_str(self) -> &'static str {
@@ -845,6 +849,7 @@ impl BlockKind {
             Self::AgentInstruction => "agent_instruction",
             Self::Contradiction => "contradiction",
             Self::Source => "source",
+            Self::Api => "api",
         }
     }
 
@@ -877,6 +882,7 @@ pub(crate) enum KnowledgeObject {
     AgentInstruction(AgentInstruction),
     Contradiction(Contradiction),
     Source(Source),
+    Api(Api),
 }
 
 impl KnowledgeObject {
@@ -893,6 +899,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(_) => BlockKind::AgentInstruction,
             Self::Contradiction(_) => BlockKind::Contradiction,
             Self::Source(_) => BlockKind::Source,
+            Self::Api(_) => BlockKind::Api,
         }
     }
 
@@ -909,6 +916,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(ai) => ai.id(),
             Self::Contradiction(contradiction) => contradiction.id(),
             Self::Source(source) => source.id(),
+            Self::Api(api) => api.id(),
         }
     }
 
@@ -925,6 +933,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(ai) => ai.span(),
             Self::Contradiction(contradiction) => contradiction.span(),
             Self::Source(source) => source.span(),
+            Self::Api(api) => api.span(),
         }
     }
 
@@ -941,6 +950,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(ai) => ai.body(),
             Self::Contradiction(contradiction) => contradiction.body(),
             Self::Source(source) => source.body(),
+            Self::Api(api) => api.body(),
         }
     }
 
@@ -957,6 +967,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(ai) => ai.body_mut(),
             Self::Contradiction(contradiction) => contradiction.body_mut(),
             Self::Source(source) => source.body_mut(),
+            Self::Api(api) => api.body_mut(),
         }
     }
 
@@ -973,6 +984,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(ai) => ai.relations(),
             Self::Contradiction(contradiction) => contradiction.relations(),
             Self::Source(source) => source.relations(),
+            Self::Api(api) => api.relations(),
         }
     }
 
@@ -982,6 +994,7 @@ impl KnowledgeObject {
     pub(crate) fn impacts(&self) -> &[RelPath] {
         match self {
             Self::Claim(claim) => claim.impacts().unwrap_or(&[]),
+            Self::Api(api) => api.impacts().unwrap_or(&[]),
             Self::Decision(decision) => decision.impacts().unwrap_or(&[]),
             Self::Constraint(constraint) => constraint.impacts().unwrap_or(&[]),
             Self::Policy(policy) => policy.impacts().unwrap_or(&[]),
@@ -1008,6 +1021,7 @@ impl KnowledgeObject {
             Self::AgentInstruction(ai) => ai.fields(),
             Self::Contradiction(contradiction) => contradiction.fields(),
             Self::Source(source) => source.fields(),
+            Self::Api(api) => api.fields(),
         }
     }
 }
@@ -1289,6 +1303,7 @@ mod tests {
                 BlockKind::AgentInstruction,
                 BlockKind::Contradiction,
                 BlockKind::Source,
+                BlockKind::Api,
             ]
         );
     }

--- a/crates/adoc-core/src/domain/knowledge_object/projection.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/projection.rs
@@ -23,6 +23,11 @@ const URL_FIELD: &str = "url";
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct KnowledgeObjectMetadata<'a> {
     discriminant: Option<MetadataDiscriminant<'a>>,
+    /// ADR-0039: the authored severity for `warning`/`constraint`/
+    /// `contradiction`. Lives beside the lifecycle discriminant, never in it.
+    severity: Option<&'a Severity>,
+    /// ADR-0039: the authored trust level for `agent_instruction`.
+    trust: Option<&'a Trust>,
     fields: Vec<MetadataField<'a>>,
     /// V5.8: typed evidence entries, separated from the flat `fields` map.
     /// These are converted to `GraphEvidence` and stored in
@@ -46,26 +51,16 @@ impl<'a> KnowledgeObjectMetadata<'a> {
         &self.evidence
     }
 
-    /// ADR-0035: the typed severity for kinds that carry one — `warning` and
-    /// `constraint` store it as the status-slot discriminant; `contradiction`
-    /// stores it as a metadata field. `None` for every other kind.
+    /// ADR-0039: the typed severity for `warning`/`constraint`/
+    /// `contradiction`. `None` for every other kind.
     pub(crate) fn severity(&self) -> Option<&'a Severity> {
-        if let Some(MetadataDiscriminant::Severity(severity)) = self.discriminant {
-            return Some(severity);
-        }
-        self.fields.iter().find_map(|field| match field {
-            MetadataField::Severity(severity) => Some(*severity),
-            _ => None,
-        })
+        self.severity
     }
 
-    /// ADR-0035: the typed trust level for `agent_instruction` (stored as the
-    /// status-slot discriminant). `None` for every other kind.
+    /// ADR-0039: the typed trust level for `agent_instruction`. `None` for
+    /// every other kind.
     pub(crate) fn trust(&self) -> Option<&'a Trust> {
-        match self.discriminant {
-            Some(MetadataDiscriminant::Trust(trust)) => Some(trust),
-            _ => None,
-        }
+        self.trust
     }
 
     /// Convert the typed evidence slice to the `GraphEvidence` wire format.
@@ -91,6 +86,11 @@ impl<'a> KnowledgeObjectMetadata<'a> {
     }
 }
 
+/// ADR-0039: lifecycle-only by construction. Kinds without a lifecycle
+/// (`warning`, `constraint`, `agent_instruction`, `source`) have no
+/// discriminant; their Severity/Trust live in the dedicated projection slots.
+// The uniform `Status` postfix is the point: every variant IS a lifecycle status.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum MetadataDiscriminant<'a> {
     ClaimStatus(&'a ClaimStatus),
@@ -98,12 +98,7 @@ pub(crate) enum MetadataDiscriminant<'a> {
     PolicyStatus(&'a PolicyStatus),
     ProcedureStatus(&'a ProcedureStatus),
     ExampleStatus(&'a ExampleStatus),
-    Severity(&'a Severity),
-    /// V5.5: trust level for `agent_instruction`. Stored in the graph node's
-    /// `status` slot so it participates in the diff projection correctly.
-    Trust(&'a Trust),
-    /// V5.6: lifecycle status for `contradiction`. Stored in the graph node's
-    /// `status` slot so it participates in the diff projection correctly.
+    /// V5.6: lifecycle status for `contradiction`.
     ContradictionStatus(&'a ContradictionStatus),
 }
 
@@ -115,8 +110,6 @@ impl<'a> MetadataDiscriminant<'a> {
             Self::PolicyStatus(status) => status.as_str(),
             Self::ProcedureStatus(status) => status.as_str(),
             Self::ExampleStatus(status) => status.as_str(),
-            Self::Severity(severity) => severity.as_str(),
-            Self::Trust(trust) => trust.as_str(),
             Self::ContradictionStatus(status) => status.as_str(),
         }
     }
@@ -125,7 +118,6 @@ impl<'a> MetadataDiscriminant<'a> {
 const EFFECTIVE_AT_FIELD: &str = "effective_at";
 const REVIEW_INTERVAL_FIELD: &str = "review_interval";
 const SCOPE_FIELD: &str = "scope";
-const SEVERITY_FIELD: &str = "severity";
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum MetadataField<'a> {
@@ -145,10 +137,6 @@ pub(crate) enum MetadataField<'a> {
     ReviewInterval(&'a ReviewInterval),
     /// V5.5: agent_instruction `scope` glob string.
     Scope(&'a Scope),
-    /// V5.6: contradiction `severity` typed value. Emitted as a metadata field
-    /// (key `severity`) so it appears in the graph `fields` map; it is NOT the
-    /// discriminant (the discriminant is the `ContradictionStatus`).
-    Severity(&'a Severity),
 }
 
 impl MetadataField<'_> {
@@ -161,7 +149,6 @@ impl MetadataField<'_> {
             Self::EffectiveAt(_) => EFFECTIVE_AT_FIELD,
             Self::ReviewInterval(_) => REVIEW_INTERVAL_FIELD,
             Self::Scope(_) => SCOPE_FIELD,
-            Self::Severity(_) => SEVERITY_FIELD,
         }
     }
 
@@ -174,7 +161,6 @@ impl MetadataField<'_> {
             Self::EffectiveAt(effective_at) => effective_at.as_str(),
             Self::ReviewInterval(review_interval) => review_interval.as_str(),
             Self::Scope(scope) => scope.as_str(),
-            Self::Severity(severity) => severity.as_str(),
         }
     }
 }
@@ -191,6 +177,8 @@ impl KnowledgeObject {
             .collect();
 
         let mut evidence: Vec<&Evidence> = Vec::new();
+        let mut severity: Option<&Severity> = None;
+        let mut trust: Option<&Trust> = None;
 
         let discriminant = match self {
             Self::Claim(claim) => {
@@ -207,9 +195,15 @@ impl KnowledgeObject {
                 Some(MetadataDiscriminant::DecisionStatus(decision.status()))
             }
             Self::Glossary(_) => None,
-            Self::Warning(warning) => Some(MetadataDiscriminant::Severity(warning.severity())),
+            // ADR-0039: warning/constraint have no lifecycle — severity lives
+            // in its dedicated slot, never in the status discriminant.
+            Self::Warning(warning) => {
+                severity = Some(warning.severity());
+                None
+            }
             Self::Constraint(constraint) => {
-                Some(MetadataDiscriminant::Severity(constraint.severity()))
+                severity = Some(constraint.severity());
+                None
             }
             Self::Policy(policy) => {
                 fields.push(MetadataField::Owner(policy.owner()));
@@ -229,10 +223,13 @@ impl KnowledgeObject {
             }
             Self::AgentInstruction(ai) => {
                 fields.push(MetadataField::Scope(ai.scope()));
-                Some(MetadataDiscriminant::Trust(ai.trust()))
+                trust = Some(ai.trust());
+                None
             }
             Self::Contradiction(contradiction) => {
-                fields.push(MetadataField::Severity(contradiction.severity()));
+                // ADR-0039: severity's sole home is the dedicated slot — the
+                // v3 fields["severity"] copy is gone.
+                severity = Some(contradiction.severity());
                 Some(MetadataDiscriminant::ContradictionStatus(
                     contradiction.status(),
                 ))
@@ -262,6 +259,8 @@ impl KnowledgeObject {
 
         KnowledgeObjectMetadata {
             discriminant,
+            severity,
+            trust,
             fields,
             evidence,
         }
@@ -502,7 +501,7 @@ mod tests {
     }
 
     #[test]
-    fn warning_projection_has_severity_discriminant_and_sorted_stored_fields() {
+    fn warning_projection_is_lifecycle_free_with_dedicated_severity_slot() {
         let object = KnowledgeObject::Warning(
             Warning::try_new(
                 "auth.session",
@@ -519,12 +518,9 @@ mod tests {
 
         let projection = object.metadata_projection();
 
-        assert_eq!(
-            projection
-                .discriminant()
-                .map(MetadataDiscriminant::value_as_str),
-            Some("critical")
-        );
+        // ADR-0039: no lifecycle discriminant; severity has its own slot.
+        assert_eq!(projection.discriminant(), None);
+        assert_eq!(projection.severity().map(|s| s.as_str()), Some("critical"));
         assert_eq!(
             field_entries(&projection),
             vec![entry("audience", "sre"), entry("owner", "platform")]

--- a/crates/adoc-core/src/domain/knowledge_object/projection.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/projection.rs
@@ -1,6 +1,9 @@
 use crate::domain::graph::GraphEvidence;
 use crate::domain::knowledge_object::{
     KnowledgeObject,
+    api::{
+        ApiStatus, INTERFACE_TYPE_FIELD, METHOD_FIELD, PATH_FIELD as API_PATH_FIELD, SYMBOL_FIELD,
+    },
     claim::{
         ClaimStatus, Evidence, OWNER_FIELD, Owner, VERIFIED_AT_FIELD, Verification, VerifiedAt,
     },
@@ -100,6 +103,8 @@ pub(crate) enum MetadataDiscriminant<'a> {
     ExampleStatus(&'a ExampleStatus),
     /// V5.6: lifecycle status for `contradiction`.
     ContradictionStatus(&'a ContradictionStatus),
+    /// V6.5.1: lifecycle status for `api`.
+    ApiStatus(&'a ApiStatus),
 }
 
 impl<'a> MetadataDiscriminant<'a> {
@@ -111,6 +116,7 @@ impl<'a> MetadataDiscriminant<'a> {
             Self::ProcedureStatus(status) => status.as_str(),
             Self::ExampleStatus(status) => status.as_str(),
             Self::ContradictionStatus(status) => status.as_str(),
+            Self::ApiStatus(status) => status.as_str(),
         }
     }
 }
@@ -233,6 +239,35 @@ impl KnowledgeObject {
                 Some(MetadataDiscriminant::ContradictionStatus(
                     contradiction.status(),
                 ))
+            }
+            Self::Api(api) => {
+                // Operation and location project as stored scalars so they
+                // enter the hashed graph `fields` map (and the diff/review
+                // projection reads them from there).
+                if let Some(method) = api.method() {
+                    fields.push(MetadataField::Stored {
+                        key: METHOD_FIELD,
+                        value: method.as_str(),
+                    });
+                } else if let Some(interface_type) = api.interface_type() {
+                    fields.push(MetadataField::Stored {
+                        key: INTERFACE_TYPE_FIELD,
+                        value: interface_type,
+                    });
+                }
+                if let Some(path) = api.path() {
+                    fields.push(MetadataField::Stored {
+                        key: API_PATH_FIELD,
+                        value: path,
+                    });
+                } else if let Some(symbol) = api.symbol() {
+                    fields.push(MetadataField::Stored {
+                        key: SYMBOL_FIELD,
+                        value: symbol,
+                    });
+                }
+                append_verification_fields(&mut fields, &mut evidence, api.verification());
+                api.status().map(MetadataDiscriminant::ApiStatus)
             }
             Self::Source(source) => {
                 // Evidence kind projected as a stored scalar under key "kind".

--- a/crates/adoc-core/src/domain/patch/mod.rs
+++ b/crates/adoc-core/src/domain/patch/mod.rs
@@ -666,7 +666,7 @@ mod tests {
 
     fn graph(objects: Vec<GraphKnowledgeObjectNode>) -> GraphIndex {
         GraphIndex::from_document(GraphArtifactDocument {
-            schema_version: "adoc.graph.v3".to_string(),
+            schema_version: "adoc.graph.v4".to_string(),
             nodes: std::iter::once(GraphNode::Page(GraphPageNode {
                 id: "team.page".to_string(),
                 order: 0,

--- a/crates/adoc-core/src/domain/retrieval/metadata.rs
+++ b/crates/adoc-core/src/domain/retrieval/metadata.rs
@@ -59,7 +59,15 @@ pub(crate) fn indexed_field_values(object: &GraphKnowledgeObjectNode) -> Vec<&st
 }
 
 pub(crate) fn embedding_input(object: &GraphKnowledgeObjectNode) -> String {
-    let status = object.status.as_deref().unwrap_or("unknown");
+    // ponytail: severity/trust reuse the [status: …] line so the v4 embedding
+    // text stays byte-identical to v3; dedicated labels would be an Embedding
+    // Composition change, i.e. an adoc.search contract bump (ADR-0039).
+    let status = object
+        .status
+        .as_deref()
+        .or(object.severity.as_deref())
+        .or(object.trust.as_deref())
+        .unwrap_or("unknown");
     let owner = owner(object).unwrap_or("unknown");
     let body = normalized_embedding_body(&object.body);
     format!(

--- a/crates/adoc-core/src/domain/retrieval/retrieval_record.rs
+++ b/crates/adoc-core/src/domain/retrieval/retrieval_record.rs
@@ -11,14 +11,12 @@ pub struct RetrievalRecord {
     pub kind: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub status: Option<String>,
-    /// ADR-0035 dual-emit: derived duplicate of the kind-specific severity
-    /// (`warning`, `constraint`, `contradiction`). Not authored, not hashed.
-    /// Clone-through from the graph node.
+    /// ADR-0039: the authored severity carrier (`warning`, `constraint`,
+    /// `contradiction`). Clone-through from the graph node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub severity: Option<String>,
-    /// ADR-0035 dual-emit: derived duplicate of the trust discriminant
-    /// (`agent_instruction` only). Not authored, not hashed. Clone-through
-    /// from the graph node.
+    /// ADR-0039: the authored trust carrier (`agent_instruction` only).
+    /// Clone-through from the graph node.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub trust: Option<String>,
     pub content_hash: String,

--- a/crates/adoc-core/src/domain/review/field_change.rs
+++ b/crates/adoc-core/src/domain/review/field_change.rs
@@ -120,6 +120,16 @@ pub enum FieldChange {
     ContradictionClaimsRemoved {
         value: String,
     },
+    /// V6.5.1: the `method` on an `api` object changed.
+    ApiMethod {
+        before: Option<String>,
+        after: Option<String>,
+    },
+    /// V6.5.1: the `path` on an `api` object changed.
+    ApiPath {
+        before: Option<String>,
+        after: Option<String>,
+    },
 }
 
 impl FieldChange {
@@ -157,6 +167,8 @@ impl FieldChange {
             FieldChange::ForbiddenActionsRemoved { .. } => "forbidden_actions removed",
             FieldChange::ContradictionClaimsAdded { .. } => "contradiction_claims added",
             FieldChange::ContradictionClaimsRemoved { .. } => "contradiction_claims removed",
+            FieldChange::ApiMethod { .. } => "method changed",
+            FieldChange::ApiPath { .. } => "path changed",
         }
     }
 }
@@ -243,6 +255,18 @@ impl fmt::Display for FieldChange {
             FieldChange::ContradictionClaimsRemoved { value } => {
                 write!(f, "contradiction_claims: -{value}")
             }
+            FieldChange::ApiMethod { before, after } => write!(
+                f,
+                "method: {} → {}",
+                optional(before.as_deref()),
+                optional(after.as_deref())
+            ),
+            FieldChange::ApiPath { before, after } => write!(
+                f,
+                "path: {} → {}",
+                optional(before.as_deref()),
+                optional(after.as_deref())
+            ),
         }
     }
 }
@@ -934,6 +958,72 @@ mod tests {
             }
             .to_string(),
             "contradiction_claims: -auth.b"
+        );
+    }
+
+    // ── V6.5.1 api variants ────────────────────────────────────────────────
+
+    #[test]
+    fn api_method_variant_serializes_with_snake_case_tag() {
+        let change = FieldChange::ApiMethod {
+            before: Some("POST".to_string()),
+            after: Some("PUT".to_string()),
+        };
+
+        let value = serde_json::to_value(&change).expect("FieldChange serializes");
+
+        assert_eq!(value["type"], "api_method");
+        assert_eq!(value["before"], "POST");
+        assert_eq!(value["after"], "PUT");
+    }
+
+    #[test]
+    fn api_path_variant_serializes_with_snake_case_tag() {
+        let change = FieldChange::ApiPath {
+            before: Some("/api/v1/consume".to_string()),
+            after: Some("/api/v2/consume".to_string()),
+        };
+
+        let value = serde_json::to_value(&change).expect("FieldChange serializes");
+
+        assert_eq!(value["type"], "api_path");
+        assert_eq!(value["before"], "/api/v1/consume");
+        assert_eq!(value["after"], "/api/v2/consume");
+    }
+
+    #[test]
+    fn summary_label_and_display_cover_v6_5_api_variants() {
+        assert_eq!(
+            FieldChange::ApiMethod {
+                before: None,
+                after: None,
+            }
+            .summary_label(),
+            "method changed"
+        );
+        assert_eq!(
+            FieldChange::ApiPath {
+                before: None,
+                after: None,
+            }
+            .summary_label(),
+            "path changed"
+        );
+        assert_eq!(
+            FieldChange::ApiMethod {
+                before: Some("POST".to_string()),
+                after: Some("PUT".to_string()),
+            }
+            .to_string(),
+            "method: POST → PUT"
+        );
+        assert_eq!(
+            FieldChange::ApiPath {
+                before: Some("/a".to_string()),
+                after: Some("/b".to_string()),
+            }
+            .to_string(),
+            "path: /a → /b"
         );
     }
 

--- a/crates/adoc-core/src/domain/review/impact.rs
+++ b/crates/adoc-core/src/domain/review/impact.rs
@@ -18,6 +18,7 @@ use super::object_diff::ObjectDiff;
 
 const CLAIM_KIND: &str = "claim";
 const DECISION_KIND: &str = "decision";
+const API_KIND: &str = "api";
 const VERIFIED_STATUS: &str = "verified";
 const ACCEPTED_STATUS: &str = "accepted";
 const SOURCE_KIND: &str = "source";
@@ -216,6 +217,9 @@ fn is_verified_subject(node: &GraphKnowledgeObjectNode) -> bool {
     match node.kind.as_str() {
         CLAIM_KIND => status == VERIFIED_STATUS,
         DECISION_KIND => status == ACCEPTED_STATUS,
+        // V6.5.1 (within the ADR-0038 reason set): a verified api naturally
+        // declares its schema/source files via `impacts:`.
+        API_KIND => status == VERIFIED_STATUS,
         _ => false,
     }
 }

--- a/crates/adoc-core/src/domain/review/obligation_rules.rs
+++ b/crates/adoc-core/src/domain/review/obligation_rules.rs
@@ -22,6 +22,7 @@ use super::object_change::ChangedObject;
 
 const CLAIM_KIND: &str = "claim";
 const POLICY_KIND: &str = "policy";
+const API_KIND: &str = "api";
 const AGENT_INSTRUCTION_KIND: &str = "agent_instruction";
 const CONTRADICTION_KIND: &str = "contradiction";
 const VERIFIED_STATUS: &str = "verified";
@@ -46,6 +47,8 @@ pub(crate) const REASON_SECURITY_REVIEW_TRUST_UPGRADE: &str = "security review (
 pub(crate) const REASON_SECURITY_REVIEW_FORBIDDEN_REMOVED: &str =
     "security review (forbidden action removed)";
 pub(crate) const REASON_OWNER_REASSERT: &str = "owner re-assert (unresolved contradiction changed)";
+pub(crate) const REASON_REVERIFY_API_CONTRACT: &str =
+    "re-verify api contract (method/path changed)";
 
 /// Dispatch the V3.4 trigger table against one `Changed` entry.
 ///
@@ -175,6 +178,19 @@ fn push_for_field_change(
                 required_evidence: Vec::new(),
             });
         }
+        // V6.5.1: a method or path change on a verified api invalidates the
+        // schema evidence the verification rested on.
+        FieldChange::ApiMethod { .. } | FieldChange::ApiPath { .. } if is_verified_api(head) => {
+            out.push(ProofObligation {
+                object_id: id.to_string(),
+                reason: REASON_REVERIFY_API_CONTRACT.to_string(),
+                required_evidence: vec![
+                    crate::domain::value_objects::evidence_kind::EvidenceKind::ApiSchema
+                        .as_str()
+                        .to_string(),
+                ],
+            });
+        }
         // EvidenceAdded, ApprovedByAdded, RelationAdded/Removed,
         // ImpactsAdded/Removed, AllowedActionsAdded/Removed,
         // ForbiddenActionsAdded, Trust (downgrade/same), plus future
@@ -214,6 +230,10 @@ fn is_active_policy(node: &GraphKnowledgeObjectNode) -> bool {
     node.kind == POLICY_KIND && node.status.as_deref() == Some(ACTIVE_STATUS)
 }
 
+fn is_verified_api(node: &GraphKnowledgeObjectNode) -> bool {
+    node.kind == API_KIND && node.status.as_deref() == Some(VERIFIED_STATUS)
+}
+
 fn is_agent_instruction(node: &GraphKnowledgeObjectNode) -> bool {
     node.kind == AGENT_INSTRUCTION_KIND
 }
@@ -227,9 +247,9 @@ fn is_unresolved_contradiction(node: &GraphKnowledgeObjectNode) -> bool {
 
 /// Return `true` when a trust change is an upgrade (after > before).
 ///
-/// Both sides are optional strings taken from the graph node's `status` slot,
-/// where trust is stored for `agent_instruction` nodes. Returns `false` if
-/// either side is absent or cannot be parsed as a valid `Trust`.
+/// Both sides are optional strings taken from the graph node's dedicated
+/// `trust` field (ADR-0039). Returns `false` if either side is absent or
+/// cannot be parsed as a valid `Trust`.
 fn trust_is_upgrade(before: &Option<String>, after: &Option<String>) -> bool {
     use crate::domain::value_objects::trust::Trust;
     let (Some(b), Some(a)) = (before, after) else {
@@ -696,6 +716,53 @@ mod tests {
         assert_eq!(obligations.len(), 1);
         assert_eq!(obligations[0].reason, REASON_REAPPROVE_APPROVER_REMOVED);
         assert_eq!(obligations[0].required_evidence, vec!["approved_by"]);
+    }
+
+    fn verified_api(id: &str) -> GraphKnowledgeObjectNode {
+        let mut node = test_node(id, "sha256:dummy");
+        node.kind = API_KIND.to_string();
+        node.status = Some(VERIFIED_STATUS.to_string());
+        node
+    }
+
+    #[test]
+    fn method_change_on_verified_api_emits_reverify_obligation() {
+        let base = verified_api("billing.consume-credit");
+        let head = verified_api("billing.consume-credit");
+        let change = changed_with(
+            "billing.consume-credit",
+            base,
+            head,
+            vec![FieldChange::ApiMethod {
+                before: Some("POST".to_string()),
+                after: Some("PUT".to_string()),
+            }],
+        );
+
+        let obligations = obligations_for_change(&change);
+
+        assert_eq!(obligations.len(), 1);
+        assert_eq!(obligations[0].reason, REASON_REVERIFY_API_CONTRACT);
+        assert_eq!(obligations[0].required_evidence, vec!["api_schema"]);
+    }
+
+    #[test]
+    fn path_change_on_non_verified_api_emits_no_obligation() {
+        let mut base = verified_api("billing.consume-credit");
+        base.status = Some("draft".to_string());
+        let mut head = verified_api("billing.consume-credit");
+        head.status = Some("draft".to_string());
+        let change = changed_with(
+            "billing.consume-credit",
+            base,
+            head,
+            vec![FieldChange::ApiPath {
+                before: Some("/api/v1".to_string()),
+                after: Some("/api/v2".to_string()),
+            }],
+        );
+
+        assert!(obligations_for_change(&change).is_empty());
     }
 
     #[test]

--- a/crates/adoc-core/src/domain/review/projection.rs
+++ b/crates/adoc-core/src/domain/review/projection.rs
@@ -15,6 +15,10 @@
 
 use std::collections::BTreeSet;
 
+use crate::domain::knowledge_object::BlockKind;
+use crate::domain::knowledge_object::api::{
+    METHOD_FIELD as API_METHOD_FIELD, PATH_FIELD as API_PATH_FIELD,
+};
 use crate::domain::knowledge_object::metadata::KnowledgeObjectMetadata;
 
 const EFFECTIVE_AT_FIELD: &str = "effective_at";
@@ -149,6 +153,28 @@ pub(crate) fn project_changed(c: &ChangedObject) -> Vec<FieldChange> {
     }
 
     project_approved_by(&mut out, &base.approved_by, &head.approved_by);
+
+    // V6.5.1: api method/path scalar diffs off the graph fields map, gated on
+    // kind — `source` nodes also project a `path` into fields, and an
+    // ungated diff would mislabel a source path edit as `api_path`.
+    if head.kind == BlockKind::Api.as_str() {
+        let base_method = base.fields.get(API_METHOD_FIELD).map(String::as_str);
+        let head_method = head.fields.get(API_METHOD_FIELD).map(String::as_str);
+        if base_method != head_method {
+            out.push(FieldChange::ApiMethod {
+                before: base_method.map(str::to_string),
+                after: head_method.map(str::to_string),
+            });
+        }
+        let base_path = base.fields.get(API_PATH_FIELD).map(String::as_str);
+        let head_path = head.fields.get(API_PATH_FIELD).map(String::as_str);
+        if base_path != head_path {
+            out.push(FieldChange::ApiPath {
+                before: base_path.map(str::to_string),
+                after: head_path.map(str::to_string),
+            });
+        }
+    }
 
     // V5.5: agent_instruction scope scalar diff and action-set diffs. `scope`
     // lives in the graph fields map (unlike `trust`, which has its own node
@@ -872,6 +898,97 @@ mod tests {
         head.approved_by = vec!["approver-a".to_string(), "approver-b".to_string()];
 
         assert!(project_changed(&changed_from(base, head)).is_empty());
+    }
+
+    // ── V6.5.1 api method/path diffs ───────────────────────────────────────
+
+    fn api_node(content_hash: &str, method: &str, path: &str) -> GraphKnowledgeObjectNode {
+        let mut n = node(
+            "billing.consume-credit",
+            content_hash,
+            "Consumes credits.",
+            Some("verified"),
+            BTreeMap::from([
+                ("method".to_string(), method.to_string()),
+                ("path".to_string(), path.to_string()),
+            ]),
+            GraphRelations::default(),
+        );
+        n.kind = "api".to_string();
+        n
+    }
+
+    #[test]
+    fn api_method_change_emits_api_method_field_change() {
+        let base = api_node("sha256:a", "POST", "/api/v1/consume");
+        let head = api_node("sha256:b", "PUT", "/api/v1/consume");
+
+        assert_eq!(
+            project_changed(&ChangedObject::new(
+                "billing.consume-credit".to_string(),
+                base,
+                head,
+            )),
+            vec![FieldChange::ApiMethod {
+                before: Some("POST".to_string()),
+                after: Some("PUT".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn api_path_change_emits_api_path_field_change() {
+        let base = api_node("sha256:a", "POST", "/api/v1/consume");
+        let head = api_node("sha256:b", "POST", "/api/v2/consume");
+
+        assert_eq!(
+            project_changed(&ChangedObject::new(
+                "billing.consume-credit".to_string(),
+                base,
+                head,
+            )),
+            vec![FieldChange::ApiPath {
+                before: Some("/api/v1/consume".to_string()),
+                after: Some("/api/v2/consume".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn source_path_edit_does_not_emit_api_path_field_change() {
+        // `source` nodes project `path` into the fields map too; the api diff
+        // is kind-gated so a source path edit stays out of the api vocabulary.
+        let source_node = |content_hash: &str, path: &str| {
+            let mut n = node(
+                "billing.openapi",
+                content_hash,
+                "The billing OpenAPI schema.",
+                None,
+                BTreeMap::from([
+                    ("kind".to_string(), "api_schema".to_string()),
+                    ("path".to_string(), path.to_string()),
+                ]),
+                GraphRelations::default(),
+            );
+            n.kind = "source".to_string();
+            n
+        };
+
+        let base = source_node("sha256:a", "openapi/billing.yaml");
+        let head = source_node("sha256:b", "openapi/billing-v2.yaml");
+
+        let changes = project_changed(&ChangedObject::new(
+            "billing.openapi".to_string(),
+            base,
+            head,
+        ));
+
+        assert!(
+            !changes
+                .iter()
+                .any(|change| matches!(change, FieldChange::ApiPath { .. })),
+            "source path edits must not project as api_path: {changes:?}"
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/domain/review/projection.rs
+++ b/crates/adoc-core/src/domain/review/projection.rs
@@ -15,7 +15,6 @@
 
 use std::collections::BTreeSet;
 
-use crate::domain::knowledge_object::BlockKind;
 use crate::domain::knowledge_object::metadata::KnowledgeObjectMetadata;
 
 const EFFECTIVE_AT_FIELD: &str = "effective_at";
@@ -44,20 +43,27 @@ pub(crate) fn project_changed(c: &ChangedObject) -> Vec<FieldChange> {
         });
     }
 
+    // ADR-0039: `status` is lifecycle-only; `severity`/`trust` are dedicated
+    // node fields. Three independent diffs — the v3 kind-keyed re-labeling
+    // (and its warning-not-relabeled quirk) is retired.
     if base.status != head.status {
-        let before = base.status.clone();
-        let after = head.status.clone();
-        // Some kinds repurpose the graph node's `status` slot for a typed
-        // discriminant rather than a lifecycle status: `constraint` stores its
-        // shared `Severity`, and `agent_instruction` stores its `Trust`. Project
-        // the delta under the matching variant so the change is not mislabelled
-        // as a lifecycle Status change (and not double-counted below).
-        out.push(if head.kind.as_str() == BlockKind::Constraint.as_str() {
-            FieldChange::Severity { before, after }
-        } else if head.kind.as_str() == BlockKind::AgentInstruction.as_str() {
-            FieldChange::Trust { before, after }
-        } else {
-            FieldChange::Status { before, after }
+        out.push(FieldChange::Status {
+            before: base.status.clone(),
+            after: head.status.clone(),
+        });
+    }
+
+    if base.severity != head.severity {
+        out.push(FieldChange::Severity {
+            before: base.severity.clone(),
+            after: head.severity.clone(),
+        });
+    }
+
+    if base.trust != head.trust {
+        out.push(FieldChange::Trust {
+            before: base.trust.clone(),
+            after: head.trust.clone(),
         });
     }
 
@@ -145,8 +151,8 @@ pub(crate) fn project_changed(c: &ChangedObject) -> Vec<FieldChange> {
     project_approved_by(&mut out, &base.approved_by, &head.approved_by);
 
     // V5.5: agent_instruction scope scalar diff and action-set diffs. `scope`
-    // lives in the graph fields map (unlike `trust`, which rides the `status`
-    // slot and is projected as `FieldChange::Trust` above).
+    // lives in the graph fields map (unlike `trust`, which has its own node
+    // field and is projected as `FieldChange::Trust` above).
     let base_scope = base.fields.get(SCOPE_FIELD).map(String::as_str);
     let head_scope = head.fields.get(SCOPE_FIELD).map(String::as_str);
     if base_scope != head_scope {
@@ -387,8 +393,8 @@ mod tests {
             id: "auth.session.no-local-storage".to_string(),
             kind: "constraint".to_string(),
             content_hash: content_hash.to_string(),
-            status: Some(severity.to_string()),
-            severity: None,
+            status: None,
+            severity: Some(severity.to_string()),
             trust: None,
             body: "Session tokens must not be stored in localStorage.".to_string(),
             page_id: "team.auth".to_string(),
@@ -426,18 +432,52 @@ mod tests {
         );
     }
 
+    /// ADR-0039: the v3 quirk (warning severity deltas mislabelled as
+    /// `Status`) is retired — warnings emit `Severity` like constraints.
+    #[test]
+    fn warning_severity_change_emits_severity_field_change_not_status() {
+        let warning_node = |content_hash: &str, severity: &str| {
+            let mut n = node(
+                "auth.session.clock-skew",
+                content_hash,
+                "Clock skew breaks sessions.",
+                None,
+                BTreeMap::new(),
+                GraphRelations::default(),
+            );
+            n.kind = "warning".to_string();
+            n.severity = Some(severity.to_string());
+            n
+        };
+
+        let base = warning_node("sha256:a", "high");
+        let head = warning_node("sha256:b", "critical");
+
+        assert_eq!(
+            project_changed(&ChangedObject::new(
+                "auth.session.clock-skew".to_string(),
+                base,
+                head,
+            )),
+            vec![FieldChange::Severity {
+                before: Some("high".to_string()),
+                after: Some("critical".to_string()),
+            }]
+        );
+    }
+
     #[test]
     fn agent_instruction_trust_change_emits_only_trust_field_change_not_status() {
-        // `trust` rides the `status` slot via the discriminant projection; a
-        // trust change must surface as exactly one `Trust` variant — never a
-        // mislabelled `Status` change, and never both.
+        // ADR-0039: `trust` is a dedicated node field; a trust change must
+        // surface as exactly one `Trust` variant — never a mislabelled
+        // `Status` change, and never both.
         let agent_node = |content_hash: &str, trust: &str| GraphKnowledgeObjectNode {
             id: "auth.docs-answering-policy".to_string(),
             kind: "agent_instruction".to_string(),
             content_hash: content_hash.to_string(),
-            status: Some(trust.to_string()),
+            status: None,
             severity: None,
-            trust: None,
+            trust: Some(trust.to_string()),
             body: "Prefer verified claims over draft notes.".to_string(),
             page_id: "team.auth".to_string(),
             source_span: GraphSourceSpan {

--- a/crates/adoc-core/src/domain/services/resolve_pending_block.rs
+++ b/crates/adoc-core/src/domain/services/resolve_pending_block.rs
@@ -8,7 +8,7 @@ use crate::domain::ast::ParsedTypedBlock;
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::domain::identity::ObjectId;
 use crate::domain::knowledge_object::{
-    BlockKind, KnowledgeObject, agent_instruction::AgentInstruction, claim::Claim,
+    BlockKind, KnowledgeObject, agent_instruction::AgentInstruction, api::Api, claim::Claim,
     constraint::Constraint, contradiction::Contradiction, decision::Decision, example::Example,
     glossary::Glossary, policy::Policy, procedure::Procedure, source::Source, warning::Warning,
 };
@@ -66,6 +66,10 @@ const RESOLVERS: &[KnowledgeObjectResolver] = &[
     KnowledgeObjectResolver {
         kind: BlockKind::Source,
         build: build_source,
+    },
+    KnowledgeObjectResolver {
+        kind: BlockKind::Api,
+        build: build_api,
     },
 ];
 
@@ -177,6 +181,13 @@ fn build_source(
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<KnowledgeObject> {
     Source::build_from_parsed(parsed, diagnostics).map(KnowledgeObject::Source)
+}
+
+fn build_api(
+    parsed: ParsedTypedBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<KnowledgeObject> {
+    Api::build_from_parsed(parsed, diagnostics).map(KnowledgeObject::Api)
 }
 
 fn unknown_kind_diagnostic(parsed: &ParsedTypedBlock) -> Diagnostic {
@@ -303,7 +314,7 @@ mod tests {
 
         assert_eq!(
             help,
-            "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source. \
+            "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. \
             Custom schemas are deferred."
         );
         for kind in BlockKind::ALL {

--- a/crates/adoc-core/src/domain/value_objects/http_method.rs
+++ b/crates/adoc-core/src/domain/value_objects/http_method.rs
@@ -1,0 +1,91 @@
+//! HTTP method value object for the `api` Knowledge Object (V6.5.1, PRD §13.7).
+//!
+//! Closed set: the RFC 9110 registry plus `PATCH` (RFC 5789). Uppercase-exact
+//! parse, mirroring [`super::severity::Severity`]'s strictness — `post` is
+//! rejected so authored contracts read like wire traffic.
+
+use crate::domain::values::trim_ascii_edges;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+#[non_exhaustive]
+pub(crate) enum HttpMethod {
+    Get,
+    Head,
+    Post,
+    Put,
+    Delete,
+    Connect,
+    Options,
+    Trace,
+    Patch,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum HttpMethodError {
+    Missing,
+    Invalid(String),
+}
+
+impl HttpMethod {
+    pub(crate) fn try_new(value: &str) -> Result<Self, HttpMethodError> {
+        let trimmed = trim_ascii_edges(value);
+        if trimmed.is_empty() {
+            return Err(HttpMethodError::Missing);
+        }
+        match trimmed {
+            "GET" => Ok(Self::Get),
+            "HEAD" => Ok(Self::Head),
+            "POST" => Ok(Self::Post),
+            "PUT" => Ok(Self::Put),
+            "DELETE" => Ok(Self::Delete),
+            "CONNECT" => Ok(Self::Connect),
+            "OPTIONS" => Ok(Self::Options),
+            "TRACE" => Ok(Self::Trace),
+            "PATCH" => Ok(Self::Patch),
+            other => Err(HttpMethodError::Invalid(other.to_string())),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &'static str {
+        match self {
+            Self::Get => "GET",
+            Self::Head => "HEAD",
+            Self::Post => "POST",
+            Self::Put => "PUT",
+            Self::Delete => "DELETE",
+            Self::Connect => "CONNECT",
+            Self::Options => "OPTIONS",
+            Self::Trace => "TRACE",
+            Self::Patch => "PATCH",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn try_new_accepts_the_closed_uppercase_set_and_trims() {
+        assert_eq!(HttpMethod::try_new("  POST  "), Ok(HttpMethod::Post));
+        assert_eq!(HttpMethod::try_new("GET").expect("GET").as_str(), "GET");
+        assert_eq!(HttpMethod::try_new("PATCH"), Ok(HttpMethod::Patch));
+    }
+
+    #[test]
+    fn try_new_rejects_empty_as_missing() {
+        assert_eq!(HttpMethod::try_new("  "), Err(HttpMethodError::Missing));
+    }
+
+    #[test]
+    fn try_new_rejects_lowercase_and_unknown_methods() {
+        assert_eq!(
+            HttpMethod::try_new("post"),
+            Err(HttpMethodError::Invalid("post".to_string()))
+        );
+        assert_eq!(
+            HttpMethod::try_new("FETCH"),
+            Err(HttpMethodError::Invalid("FETCH".to_string()))
+        );
+    }
+}

--- a/crates/adoc-core/src/domain/value_objects/mod.rs
+++ b/crates/adoc-core/src/domain/value_objects/mod.rs
@@ -13,6 +13,7 @@ pub(crate) mod contradiction_status;
 pub(crate) mod effective_date;
 pub(crate) mod evidence;
 pub(crate) mod evidence_kind;
+pub(crate) mod http_method;
 pub(crate) mod lang;
 pub(crate) mod rel_path;
 pub(crate) mod review_interval;

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -145,6 +145,7 @@ impl GraphJsonArtifact {
                 let refs_slice = match ko.as_ref() {
                     KnowledgeObject::Claim(claim) => claim.evidence_refs(),
                     KnowledgeObject::Decision(decision) => decision.evidence_refs(),
+                    KnowledgeObject::Api(api) => api.evidence_refs(),
                     _ => return None,
                 };
                 if refs_slice.is_empty() {

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -25,7 +25,7 @@ use crate::domain::value_objects::evidence_kind::EvidenceKind;
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct GraphJsonArtifact;
 
-pub(crate) const SUPPORTED_GRAPH_SCHEMA_VERSION: &str = "adoc.graph.v3";
+pub(crate) const SUPPORTED_GRAPH_SCHEMA_VERSION: &str = "adoc.graph.v4";
 
 pub(crate) fn read_graph_artifact_document(
     path: &Path,
@@ -324,7 +324,7 @@ fn block_to_graph_node(
         }),
         // V4.2: GFM Table, FootnoteDefinition, and UnknownExtension also
         // project to a single prose block whose text is the original source
-        // text. The graph schema (`adoc.graph.v3`) is unchanged.
+        // text. The graph schema is unchanged by these projections.
         BlockAst::Table(table) => GraphNode::Paragraph(GraphBlockNode {
             id: id.to_string(),
             page_id: page_id.to_string(),
@@ -423,7 +423,7 @@ fn knowledge_object_to_graph_node_without_hash(
         kind: knowledge_object.kind().as_str().to_string(),
         content_hash: String::new(),
         status,
-        // ADR-0035 dual-emit: derived — NOT part of content_hash.
+        // ADR-0039: sole authored carriers — part of content_hash.
         severity: metadata.severity().map(|s| s.as_str().to_string()),
         trust: metadata.trust().map(|t| t.as_str().to_string()),
         body: knowledge_object.body().to_source(),
@@ -661,6 +661,12 @@ struct KnowledgeObjectHashPayload<'a> {
     id: &'a str,
     kind: &'a str,
     status: &'a Option<String>,
+    /// ADR-0039: authored carriers, hashed. Omitted when absent so kinds that
+    /// carry neither keep their v3 `content_hash` byte-for-byte.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    severity: &'a Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    trust: &'a Option<String>,
     body: &'a str,
     page_id: &'a str,
     source_span: &'a GraphSourceSpan,
@@ -697,6 +703,8 @@ pub(crate) fn graph_knowledge_object_content_hash(node: &GraphKnowledgeObjectNod
         id: &node.id,
         kind: &node.kind,
         status: &node.status,
+        severity: &node.severity,
+        trust: &node.trust,
         body: &node.body,
         page_id: &node.page_id,
         source_span: &node.source_span,
@@ -1614,23 +1622,59 @@ mod tests {
         );
     }
 
-    /// `content_hash` must be identical whether or not the ADR-0035 dual-emit
-    /// `severity`/`trust` fields are set, proving they are excluded from the
-    /// hash payload like the other derived fields.
+    /// ADR-0039: `severity`/`trust` are authored carriers and MUST enter the
+    /// hash payload — a severity or trust edit changes `content_hash`.
     #[test]
-    fn content_hash_is_stable_regardless_of_severity_and_trust() {
+    fn content_hash_covers_severity_and_trust() {
         let node_without = make_ko_node(None, None);
-        let mut node_with = make_ko_node(None, None);
-        node_with.severity = Some("critical".to_string());
-        node_with.trust = Some("team".to_string());
+        let mut node_with_severity = make_ko_node(None, None);
+        node_with_severity.severity = Some("critical".to_string());
+        let mut node_with_trust = make_ko_node(None, None);
+        node_with_trust.trust = Some("team".to_string());
 
         let hash_without = graph_knowledge_object_content_hash(&node_without);
-        let hash_with = graph_knowledge_object_content_hash(&node_with);
 
-        assert_eq!(
-            hash_without, hash_with,
-            "content_hash must be identical whether or not severity/trust are set; \
-             the ADR-0035 dual-emit fields are not part of the hash payload"
+        assert_ne!(
+            hash_without,
+            graph_knowledge_object_content_hash(&node_with_severity),
+            "content_hash must change when severity changes; severity is an \
+             authored, hashed carrier per ADR-0039"
+        );
+        assert_ne!(
+            hash_without,
+            graph_knowledge_object_content_hash(&node_with_trust),
+            "content_hash must change when trust changes; trust is an \
+             authored, hashed carrier per ADR-0039"
+        );
+    }
+
+    /// ADR-0039: kinds that carry neither severity nor trust keep their v3
+    /// hash payload byte-for-byte — the absent fields are skipped, not null.
+    #[test]
+    fn hash_payload_omits_absent_severity_and_trust() {
+        let node = make_ko_node(None, None);
+        let payload = KnowledgeObjectHashPayload {
+            id: &node.id,
+            kind: &node.kind,
+            status: &node.status,
+            severity: &node.severity,
+            trust: &node.trust,
+            body: &node.body,
+            page_id: &node.page_id,
+            source_span: &node.source_span,
+            fields: &node.fields,
+            relations: &node.relations,
+            impacts: &node.impacts,
+            approved_by: &node.approved_by,
+            allowed_actions: &node.allowed_actions,
+            forbidden_actions: &node.forbidden_actions,
+            contradiction_claims: &node.contradiction_claims,
+            evidence: &node.evidence,
+        };
+        let canonical = serde_json::to_string(&payload).expect("payload serializes");
+        assert!(
+            !canonical.contains("severity") && !canonical.contains("trust"),
+            "absent severity/trust must be omitted from the hash payload: {canonical}"
         );
     }
 

--- a/crates/adoc-core/src/infrastructure/artifact/mod.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/mod.rs
@@ -58,7 +58,7 @@ mod tests {
 
         let graph_document = GraphJsonArtifact.build(&workspace, &[]);
 
-        assert_eq!(graph_document.schema_version, "adoc.graph.v3");
+        assert_eq!(graph_document.schema_version, "adoc.graph.v4");
         assert!(graph_document.nodes.is_empty());
         assert!(graph_document.edges.is_empty());
     }

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -12,7 +12,7 @@ use crate::domain::knowledge_object::{
     contradiction::Contradiction,
     policy::Policy,
     procedure::ordered_step_marker_len,
-    projection::{KnowledgeObjectMetadata, MetadataDiscriminant, MetadataField},
+    projection::{KnowledgeObjectMetadata, MetadataField},
 };
 use crate::domain::url_safety::verdict;
 use crate::infrastructure::artifact::graph_json::derive_effective_status;
@@ -373,7 +373,7 @@ fn render_glossary(
     html: &mut String,
 ) {
     render_object_section_open(knowledge_object, "glossary", html);
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
     render_object_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);
     html.push_str("</section>\n");
@@ -384,11 +384,11 @@ fn render_warning(
     metadata: &KnowledgeObjectMetadata<'_>,
     html: &mut String,
 ) {
-    let discriminant = severity_discriminant(metadata);
-    let class = format!("warning warning--{}", discriminant.value_as_str());
+    let severity = required_severity(metadata);
+    let class = format!("warning warning--{severity}");
 
     render_object_section_open(knowledge_object, &class, html);
-    render_object_header(knowledge_object, Some(discriminant), html);
+    render_object_header(knowledge_object, Some(("severity", severity)), html);
     render_object_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);
     html.push_str("</section>\n");
@@ -399,11 +399,11 @@ fn render_constraint(
     metadata: &KnowledgeObjectMetadata<'_>,
     html: &mut String,
 ) {
-    let discriminant = severity_discriminant(metadata);
-    let class = format!("constraint constraint--{}", discriminant.value_as_str());
+    let severity = required_severity(metadata);
+    let class = format!("constraint constraint--{severity}");
 
     render_object_section_open(knowledge_object, &class, html);
-    render_object_header(knowledge_object, Some(discriminant), html);
+    render_object_header(knowledge_object, Some(("severity", severity)), html);
     render_object_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);
     html.push_str("</section>\n");
@@ -414,20 +414,13 @@ fn render_contradiction(
     metadata: &KnowledgeObjectMetadata<'_>,
     html: &mut String,
 ) {
-    // For contradiction the discriminant is the status; severity is a field.
-    // Use `metadata.discriminant()` directly for status, and read severity
-    // from the MetadataField list (the existing `severity_discriminant` helper
-    // assumes the discriminant IS severity, which is wrong for contradiction).
+    // For contradiction the discriminant is the lifecycle status; severity
+    // lives in its dedicated ADR-0039 slot.
     let status_str = metadata
         .discriminant()
         .map(|d| d.value_as_str())
         .unwrap_or("unresolved");
-    let severity_str = metadata
-        .fields()
-        .iter()
-        .find(|f| f.key() == "severity")
-        .map(|f| f.value_as_str())
-        .unwrap_or("low");
+    let severity_str = required_severity(metadata);
     let class =
         format!("contradiction contradiction--{status_str} contradiction--severity-{severity_str}");
 
@@ -438,7 +431,7 @@ fn render_contradiction(
     html.push_str(&escape_html(severity_str));
     html.push_str("</span>\n");
 
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
 
     // Status line.
     html.push_str("<p class=\"contradiction__status\">status: ");
@@ -516,7 +509,7 @@ fn render_procedure(
     html: &mut String,
 ) {
     render_object_section_open(knowledge_object, "procedure", html);
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
     render_procedure_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);
     html.push_str("</section>\n");
@@ -528,7 +521,7 @@ fn render_policy(
     html: &mut String,
 ) {
     render_object_section_open(knowledge_object, "policy", html);
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
     render_object_body(knowledge_object, html);
 
     // Approval block: list effective_at, each approver, and optional review_interval.
@@ -569,7 +562,8 @@ fn render_agent_instruction(
     // ADR-0025: mandatory "NOT runtime ACL" banner — exact text is non-negotiable.
     html.push_str("<div class=\"agent_instruction__banner\"><p>Agent Instruction. Authored knowledge, NOT runtime ACL. See <a href=\"adoc://agent/v0/agent-instruction-guide\">agent-instruction-guide</a>.</p></div>\n");
 
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    let trust_badge = metadata.trust().map(|trust| ("trust", trust.as_str()));
+    render_object_header(knowledge_object, trust_badge, html);
 
     let KnowledgeObject::AgentInstruction(ai) = knowledge_object else {
         unreachable!("render_agent_instruction called with non-agent_instruction object");
@@ -707,7 +701,7 @@ fn render_example(
     html: &mut String,
 ) {
     render_object_section_open(knowledge_object, "example", html);
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
 
     // Render optional checks/sandbox metadata above the code body.
     let KnowledgeObject::Example(example) = knowledge_object else {
@@ -753,12 +747,11 @@ fn render_example(
     html.push_str("</section>\n");
 }
 
-fn severity_discriminant<'a>(metadata: &KnowledgeObjectMetadata<'a>) -> MetadataDiscriminant<'a> {
-    match metadata.discriminant() {
-        Some(discriminant @ MetadataDiscriminant::Severity(_)) => discriminant,
-        Some(_) => unreachable!("severity-bearing kind metadata projection must use severity"),
-        None => unreachable!("severity-bearing kind metadata projection must include severity"),
-    }
+fn required_severity<'a>(metadata: &KnowledgeObjectMetadata<'a>) -> &'a str {
+    metadata
+        .severity()
+        .map(|severity| severity.as_str())
+        .expect("severity-bearing kind metadata projection must include severity")
 }
 
 fn render_decision(
@@ -772,7 +765,7 @@ fn render_decision(
         "decision"
     };
     render_object_section_open(knowledge_object, class, html);
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
     render_object_body(knowledge_object, html);
     if let Some(decided_by) = accepted_decision_field(metadata) {
         html.push_str("<div class=\"decision__verdict\"><dl>");
@@ -798,7 +791,7 @@ fn render_claim(
         "claim"
     };
     render_object_section_open(knowledge_object, class, html);
-    render_object_header(knowledge_object, metadata.discriminant(), html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
     render_object_body(knowledge_object, html);
 
     if let (Some(owner), Some(verified_at)) = (
@@ -906,9 +899,12 @@ fn render_object_section_open(
     html.push_str("\">\n");
 }
 
+/// Header badge: `(field_name, value)` — `("status", …)` for lifecycle
+/// discriminants, `("severity", …)`/`("trust", …)` for the dedicated
+/// ADR-0039 carriers.
 fn render_object_header(
     knowledge_object: &KnowledgeObject,
-    discriminant: Option<MetadataDiscriminant<'_>>,
+    badge: Option<(&str, &str)>,
     html: &mut String,
 ) {
     let kind = knowledge_object.kind().as_str();
@@ -927,30 +923,23 @@ fn render_object_header(
     html.push_str(&escape_html(knowledge_object.id().as_str()));
     html.push_str("</code>");
 
-    if let Some(discriminant) = discriminant {
+    if let Some((field_name, value)) = badge {
         html.push_str("<span class=\"");
         html.push_str(kind);
         html.push_str("__");
-        html.push_str(discriminant_field_name(discriminant));
+        html.push_str(field_name);
         html.push_str("\">");
-        html.push_str(&escape_html(discriminant.value_as_str()));
+        html.push_str(&escape_html(value));
         html.push_str("</span>");
     }
 
     html.push_str("</header>\n");
 }
 
-fn discriminant_field_name(discriminant: MetadataDiscriminant<'_>) -> &'static str {
-    match discriminant {
-        MetadataDiscriminant::ClaimStatus(_)
-        | MetadataDiscriminant::DecisionStatus(_)
-        | MetadataDiscriminant::PolicyStatus(_)
-        | MetadataDiscriminant::ProcedureStatus(_)
-        | MetadataDiscriminant::ExampleStatus(_)
-        | MetadataDiscriminant::ContradictionStatus(_) => "status",
-        MetadataDiscriminant::Severity(_) => "severity",
-        MetadataDiscriminant::Trust(_) => "trust",
-    }
+fn status_badge<'a>(metadata: &KnowledgeObjectMetadata<'a>) -> Option<(&'static str, &'a str)> {
+    metadata
+        .discriminant()
+        .map(|discriminant| ("status", discriminant.value_as_str()))
 }
 
 fn render_object_body(knowledge_object: &KnowledgeObject, html: &mut String) {

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -350,6 +350,9 @@ fn render_knowledge_object(
         KnowledgeObject::Source(_) => {
             render_source(knowledge_object, &metadata, html);
         }
+        KnowledgeObject::Api(_) => {
+            render_api(knowledge_object, &metadata, html);
+        }
     }
 
     // V5.10: append effective_status badge after the section close tag if set.
@@ -485,6 +488,46 @@ fn render_source(
         html.push_str("</a></dd>\n");
     }
     html.push_str("</dl>\n</div>\n");
+
+    render_object_body(knowledge_object, html);
+    render_object_metadata(knowledge_object, metadata, html);
+    html.push_str("</section>\n");
+}
+
+fn render_api(
+    knowledge_object: &KnowledgeObject,
+    metadata: &KnowledgeObjectMetadata<'_>,
+    html: &mut String,
+) {
+    let KnowledgeObject::Api(api) = knowledge_object else {
+        unreachable!("render_api called with non-api object");
+    };
+
+    render_object_section_open(knowledge_object, "api", html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
+
+    // Endpoint signature: method badge (or interface type) plus path/symbol
+    // in code style, above the prose body (PRD §13.7).
+    html.push_str("<div class=\"api__signature\">");
+    if let Some(method) = api.method() {
+        html.push_str("<span class=\"api__method\">");
+        html.push_str(method.as_str());
+        html.push_str("</span>");
+    } else if let Some(interface_type) = api.interface_type() {
+        html.push_str("<span class=\"api__interface-type\">");
+        html.push_str(&escape_html(interface_type));
+        html.push_str("</span>");
+    }
+    if let Some(path) = api.path() {
+        html.push_str("<code class=\"api__path\">");
+        html.push_str(&escape_html(path));
+        html.push_str("</code>");
+    } else if let Some(symbol) = api.symbol() {
+        html.push_str("<code class=\"api__symbol\">");
+        html.push_str(&escape_html(symbol));
+        html.push_str("</code>");
+    }
+    html.push_str("</div>\n");
 
     render_object_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);

--- a/crates/adoc-core/src/infrastructure/validate/api_verified_evidence.rs
+++ b/crates/adoc-core/src/infrastructure/validate/api_verified_evidence.rs
@@ -1,0 +1,79 @@
+//! `api.verified_missing_schema_evidence` (V6.5.1, PRD §15.4).
+//!
+//! A verified `api` is verified by its schema source, not by human assertion:
+//! it must carry at least one inline `source:` (SourceCode) evidence entry or
+//! an `evidence_ref` resolving to a `source` object whose kind is
+//! `api_schema` or `source_code`. This is a workspace rule (not a per-page
+//! rule) because ref targets may live on other pages — the same reason
+//! [`super::evidence_ref_resolves::EvidenceRefResolves`] is one.
+
+use std::collections::HashMap;
+
+use crate::domain::ast::{BlockAst, WorkspaceAst};
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::domain::identity::ObjectId;
+use crate::domain::knowledge_object::KnowledgeObject;
+use crate::domain::rules::WorkspaceRule;
+use crate::domain::value_objects::evidence_kind::EvidenceKind;
+
+pub(crate) struct ApiVerifiedEvidence;
+
+impl WorkspaceRule for ApiVerifiedEvidence {
+    fn check(&self, workspace: &WorkspaceAst, sink: &mut Vec<Diagnostic>) {
+        // Map source object id -> its evidence kind, one workspace pass.
+        let mut source_kinds: HashMap<&ObjectId, EvidenceKind> = HashMap::new();
+        for page in &workspace.pages {
+            for block in &page.blocks {
+                let BlockAst::KnowledgeObject(ko) = block else {
+                    continue;
+                };
+                if let KnowledgeObject::Source(source) = ko.as_ref() {
+                    source_kinds.insert(source.id(), source.kind());
+                }
+            }
+        }
+
+        for page in &workspace.pages {
+            for block in &page.blocks {
+                let BlockAst::KnowledgeObject(ko) = block else {
+                    continue;
+                };
+                let KnowledgeObject::Api(api) = ko.as_ref() else {
+                    continue;
+                };
+                let Some(verification) = api.verification() else {
+                    continue; // non-verified apis carry no evidence obligation
+                };
+
+                let has_inline_schema_evidence = verification
+                    .evidence()
+                    .iter()
+                    .any(|entry| entry.kind() == Some(EvidenceKind::SourceCode));
+
+                let has_schema_ref = api.evidence_refs().iter().any(|entry| {
+                    entry
+                        .target_id()
+                        .and_then(|ref_id| source_kinds.get(ref_id))
+                        .is_some_and(|kind| {
+                            matches!(kind, EvidenceKind::ApiSchema | EvidenceKind::SourceCode)
+                        })
+                });
+
+                if !has_inline_schema_evidence && !has_schema_ref {
+                    sink.push(
+                        Diagnostic::error(
+                            DiagnosticCode::ApiVerifiedMissingSchemaEvidence,
+                            format!(
+                                "verified api `{}` requires schema evidence: an inline `source:` entry or an `evidence_ref` to an `api_schema`/`source_code` source",
+                                api.id()
+                            ),
+                        )
+                        .with_span(api.span().clone())
+                        .with_object_id(api.id().as_str())
+                        .with_help(DiagnosticCode::ApiVerifiedMissingSchemaEvidence.default_help()),
+                    );
+                }
+            }
+        }
+    }
+}

--- a/crates/adoc-core/src/infrastructure/validate/evidence_ref_resolves.rs
+++ b/crates/adoc-core/src/infrastructure/validate/evidence_ref_resolves.rs
@@ -28,7 +28,7 @@ impl WorkspaceRule for EvidenceRefResolves {
             }
         }
 
-        // For every claim and decision, check each evidence_ref id.
+        // For every claim, decision, and api, check each evidence_ref id.
         for page in &workspace.pages {
             for block in &page.blocks {
                 let BlockAst::KnowledgeObject(ko) = block else {
@@ -41,6 +41,7 @@ impl WorkspaceRule for EvidenceRefResolves {
                     KnowledgeObject::Decision(decision) => {
                         (decision.id(), decision.span(), decision.evidence_refs())
                     }
+                    KnowledgeObject::Api(api) => (api.id(), api.span(), api.evidence_refs()),
                     _ => continue,
                 };
                 for ev in refs {

--- a/crates/adoc-core/src/infrastructure/validate/mod.rs
+++ b/crates/adoc-core/src/infrastructure/validate/mod.rs
@@ -13,6 +13,7 @@
 //! `application/` and call domain services where aggregate-family behavior is
 //! needed.
 
+mod api_verified_evidence;
 mod claim_contradicted_nudge;
 mod compat;
 mod contradiction_claims_resolve;
@@ -28,6 +29,7 @@ mod raw_html_forbidden;
 mod unsafe_link_forbidden;
 pub(crate) mod url_walker;
 
+use api_verified_evidence::ApiVerifiedEvidence;
 use chrono::NaiveDate;
 use claim_contradicted_nudge::ClaimContradictedNudge;
 use contradiction_claims_resolve::ContradictionClaimsResolve;
@@ -56,6 +58,7 @@ const WORKSPACE_RULES: &[&dyn WorkspaceRule] = &[
     &KnowledgeObjectUniqueIds,
     &ContradictionClaimsResolve,
     &EvidenceRefResolves,
+    &ApiVerifiedEvidence,
     &ClaimContradictedNudge,
 ];
 

--- a/crates/adoc-core/tests/artifact_inspection.rs
+++ b/crates/adoc-core/tests/artifact_inspection.rs
@@ -21,7 +21,7 @@ fn valid_source() -> &'static str {
 
 fn valid_graph_json() -> String {
     serde_json::to_string_pretty(&json!({
-        "schema_version": "adoc.graph.v3",
+        "schema_version": "adoc.graph.v4",
         "nodes": [
             {
                 "type": "page",
@@ -107,7 +107,7 @@ fn graph_artifact_inspector_reports_missing_malformed_and_unsupported() {
     );
 
     let unsupported_path = root.join("unsupported.graph.json");
-    let unsupported_json = valid_graph_json().replace("adoc.graph.v3", "adoc.graph.v99");
+    let unsupported_json = valid_graph_json().replace("adoc.graph.v4", "adoc.graph.v99");
     write(&unsupported_path, &unsupported_json);
     let unsupported = inspect_graph_artifact(GraphArtifactInspectionInput {
         graph_artifact_path: unsupported_path,
@@ -133,7 +133,7 @@ fn graph_artifact_inspector_rejects_invalid_object_ids_and_counts_valid_objects(
         graph_artifact_path: valid_path,
     });
     assert_eq!(valid.load_status, ArtifactLoadStatus::Readable);
-    assert_eq!(valid.schema_version.as_deref(), Some("adoc.graph.v3"));
+    assert_eq!(valid.schema_version.as_deref(), Some("adoc.graph.v4"));
     assert_eq!(valid.object_count, Some(1));
 
     let invalid_path = root.join("invalid.graph.json");

--- a/crates/adoc-core/tests/clean_artifact_fixtures.rs
+++ b/crates/adoc-core/tests/clean_artifact_fixtures.rs
@@ -49,7 +49,7 @@ impl CleanFixture {
 
         let graph_json: serde_json::Value =
             serde_json::from_str(&artifacts.graph_json).expect("graph JSON is valid");
-        assert_eq!(graph_json["schema_version"], "adoc.graph.v3");
+        assert_eq!(graph_json["schema_version"], "adoc.graph.v4");
         assert!(
             graph_json["nodes"]
                 .as_array()

--- a/crates/adoc-core/tests/compile_workspace.rs
+++ b/crates/adoc-core/tests/compile_workspace.rs
@@ -36,6 +36,9 @@ struct TestGraphObject {
     id: String,
     kind: String,
     status: Option<String>,
+    /// ADR-0039: dedicated severity carrier.
+    #[serde(default)]
+    severity: Option<String>,
     body: String,
     page_id: String,
     source_span: TestGraphSourceSpan,
@@ -471,7 +474,9 @@ fn compile_workspace_resolves_warning_into_artifacts() {
     let record = first_graph_object(&artifacts);
     assert_eq!(record.id, "auth.session.clock-skew");
     assert_eq!(record.kind, "warning");
-    assert_eq!(record.status.as_deref(), Some("high"));
+    // ADR-0039: warnings carry no lifecycle status; severity is dedicated.
+    assert_eq!(record.status, None);
+    assert_eq!(record.severity.as_deref(), Some("high"));
     assert_eq!(
         record.body,
         "Session clocks can drift enough to reject otherwise valid tokens."

--- a/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
@@ -17,6 +17,6 @@
       }
     },
     "object_id": "billing.unknown",
-    "help": "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source. Custom schemas are deferred."
+    "help": "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. Custom schemas are deferred."
   }
 ]

--- a/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.graph.json
+++ b/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.graph.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-core/tests/graph.rs
+++ b/crates/adoc-core/tests/graph.rs
@@ -58,7 +58,7 @@ fn relation_edge(source: &str, relation: GraphRelationKind, target: &str) -> Val
 
 fn graph_document(nodes: Vec<Value>, edges: Vec<Value>) -> String {
     serde_json::to_string_pretty(&json!({
-        "schema_version": "adoc.graph.v3",
+        "schema_version": "adoc.graph.v4",
         "nodes": nodes,
         "edges": edges,
         "diagnostics": []
@@ -165,7 +165,7 @@ fn graph_artifact_serializes_with_v2_shape() {
 
     let value: Value = serde_json::from_str(&artifact).expect("graph artifact serializes");
 
-    assert_eq!(value["schema_version"], "adoc.graph.v3");
+    assert_eq!(value["schema_version"], "adoc.graph.v4");
     assert_eq!(value.get("graph_artifact_hash"), None);
     assert!(
         !artifact.contains("\"html\""),
@@ -331,7 +331,7 @@ fn build_workspace_emits_graph_artifact_with_deterministic_order_when_embeddings
     );
     let artifacts = result.artifacts.expect("artifacts are produced");
     let graph: Value = serde_json::from_str(&artifacts.graph_json).expect("graph artifact is JSON");
-    assert_eq!(graph["schema_version"], "adoc.graph.v3");
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
     assert!(
         !artifacts.graph_json.contains("\"html\""),
         "graph artifact must not serialize HTML fragments: {}",

--- a/crates/adoc-core/tests/graph.rs
+++ b/crates/adoc-core/tests/graph.rs
@@ -504,3 +504,54 @@ fn graph_traversal_applies_direction_and_relation_filters() {
     assert_eq!(traversal.edges[0].target, "billing.a");
     assert_eq!(traversal.edges[0].relation, GraphRelationKind::RelatedTo);
 }
+
+// ── V6.5.1: v4 golden api node ───────────────────────────────────────────────
+
+/// Pins the `adoc.graph.v4` api node shape: lifecycle-only `status`, method
+/// and path in the hashed `fields` map, and no `severity`/`trust` carriers —
+/// api is born under the ADR-0039 lifecycle-only rule.
+#[test]
+fn built_api_node_is_lifecycle_only_with_method_and_path_fields() {
+    let graph = build_graph_value(
+        "# Billing API @doc(team.billing-api)\n\
+         \n\
+         ::api billing.consume-credit\n\
+         method: POST\n\
+         path: /api/billing/credits/consume\n\
+         status: verified\n\
+         source: openapi/billing.yaml#/paths/~1credits~1consume\n\
+         owner: backend-platform\n\
+         verified_at: 2026-04-30\n\
+         --\n\
+         Consumes one or more credits for a completed generation job.\n\
+         ::\n",
+    );
+
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+
+    let api = graph["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .find(|node| node["kind"] == "api")
+        .expect("graph contains the api node");
+
+    assert_eq!(api["id"], "billing.consume-credit");
+    assert_eq!(api["status"], "verified");
+    assert_eq!(api["fields"]["method"], "POST");
+    assert_eq!(api["fields"]["path"], "/api/billing/credits/consume");
+    assert_eq!(api["fields"]["owner"], "backend-platform");
+    assert_eq!(api["fields"]["verified_at"], "2026-04-30");
+    assert!(
+        api.get("severity").is_none() && api.get("trust").is_none(),
+        "api nodes carry no severity/trust: {api}"
+    );
+    // Inline `source:` evidence lands in the typed evidence array.
+    assert_eq!(api["evidence"][0]["kind"], "source_code");
+    assert!(
+        api["content_hash"]
+            .as_str()
+            .expect("content_hash")
+            .starts_with("sha256:")
+    );
+}

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -125,7 +125,7 @@ fn sha256_prefixed(bytes: &[u8]) -> String {
 
 fn graph_json_from_objects(objects: Vec<Value>, edges: Vec<Value>) -> String {
     let document = json!({
-        "schema_version": "adoc.graph.v3",
+        "schema_version": "adoc.graph.v4",
         "nodes": objects,
         "edges": edges,
         "diagnostics": []
@@ -1747,7 +1747,7 @@ fn load_retrieval_session_rejects_invalid_object_ids_inside_artifact() {
     let artifact = write_temp_artifact(
         "invalid-object-id",
         r#"{
-          "schema_version": "adoc.graph.v3",
+          "schema_version": "adoc.graph.v4",
           "nodes": [
             {
               "type": "knowledge_object",
@@ -1783,7 +1783,7 @@ fn load_retrieval_session_rejects_duplicate_object_ids_inside_artifact() {
     let artifact = write_temp_artifact(
         "duplicate",
         r#"{
-          "schema_version": "adoc.graph.v3",
+          "schema_version": "adoc.graph.v4",
           "nodes": [
             {
               "type": "knowledge_object",
@@ -1860,7 +1860,7 @@ fn prose_only_graph_artifact(prose_blocks: usize) -> tempfile::NamedTempFile {
         }));
     }
     let document = json!({
-        "schema_version": "adoc.graph.v3",
+        "schema_version": "adoc.graph.v4",
         "nodes": nodes,
         "edges": [],
         "diagnostics": []
@@ -1873,7 +1873,7 @@ fn prose_only_graph_artifact(prose_blocks: usize) -> tempfile::NamedTempFile {
 
 fn empty_graph_artifact() -> tempfile::NamedTempFile {
     let document = json!({
-        "schema_version": "adoc.graph.v3",
+        "schema_version": "adoc.graph.v4",
         "nodes": [],
         "edges": [],
         "diagnostics": []

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -2039,3 +2039,43 @@ fn migration_hint_appears_in_retrieval_envelope() {
     );
     assert_eq!(diagnostics[0]["severity"], "warning");
 }
+
+// ── V6.5.1: api Knowledge Object retrieval coverage ─────────────────────────
+
+/// The retrieval pipeline is kind-generic by construction: an `api` node's
+/// body is BM25-findable and its record echoes kind, lifecycle status, and
+/// the method/path riding the fields map.
+#[test]
+fn api_object_is_lexically_findable_with_method_and_path_fields() {
+    let mut api = retrieval_search_object(
+        "billing.consume-credit",
+        "api",
+        Some("verified"),
+        Some("backend-platform"),
+        "docs/billing-api.adoc",
+        "Consumes one or more credits for a completed generation job.",
+    );
+    api["fields"]["method"] = json!("POST");
+    api["fields"]["path"] = json!("/api/billing/credits/consume");
+
+    let session = load_session_from_objects(vec![api]);
+
+    let result = search(
+        &session,
+        lexical_query("generation job credits", 3, SearchFilters::default()),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), vec!["billing.consume-credit"]);
+    let record = &result.records[0];
+    assert_eq!(record.kind, "api");
+    assert_eq!(record.status.as_deref(), Some("verified"));
+    assert_eq!(
+        record.fields.get("method").map(String::as_str),
+        Some("POST")
+    );
+    assert_eq!(
+        record.fields.get("path").map(String::as_str),
+        Some("/api/billing/credits/consume")
+    );
+}

--- a/crates/adoc-local/tests/local_workflow.rs
+++ b/crates/adoc-local/tests/local_workflow.rs
@@ -458,7 +458,7 @@ fn project_status_build_refresh_writes_artifacts_and_reports_readiness() {
     assert!(outcome.artifacts.graph.exists);
     assert_eq!(
         outcome.artifacts.graph.schema_version.as_deref(),
-        Some("adoc.graph.v3")
+        Some("adoc.graph.v4")
     );
     assert_eq!(outcome.artifacts.graph.object_count, Some(1));
     assert_eq!(

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -63,6 +63,14 @@ const RESOURCES: &[AgentResource] = &[
         contents: include_str!("../../../docs/agent/v0/source-guide.md"),
     },
     AgentResource {
+        uri: "adoc://agent/v0/api-guide",
+        name: "agent-api-guide",
+        title: "API Guide",
+        description: "V6.5.1 api objects are typed API contracts; verified apis require schema evidence.",
+        mime_type: MARKDOWN,
+        contents: include_str!("../../../docs/agent/v0/api-guide.md"),
+    },
+    AgentResource {
         uri: "adoc://agent/v0/patch-contract",
         name: "agent-patch-contract",
         title: "Agent Patch Contract",

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -221,7 +221,7 @@ fn project_status_tool_can_refresh_with_check_or_build() {
     assert_eq!(build["refresh"]["exit_code"], 0);
     assert_eq!(
         build["artifacts"]["graph"]["schema_version"],
-        "adoc.graph.v3"
+        "adoc.graph.v4"
     );
     assert_eq!(build["artifacts"]["graph"]["object_count"], 1);
     assert_eq!(build["readiness"]["patch_validation"], true);

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -265,6 +265,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/agent-instruction-guide",
         "adoc://agent/v0/contradiction-guide",
         "adoc://agent/v0/source-guide",
+        "adoc://agent/v0/api-guide",
         "adoc://agent/v0/patch-contract",
         "adoc://agent/v0/patch-apply-guide",
         "adoc://agent/v0/project-status-guide",

--- a/docs/adr/0039-adoc-graph-v4.md
+++ b/docs/adr/0039-adoc-graph-v4.md
@@ -1,0 +1,107 @@
+# ADR-0039: `adoc.graph.v4` — Kind Expansion and Status-Slot Cleanup
+
+**Status:** Accepted
+**Date:** 2026-07-02
+**Slice:** V6.5.1 (TB1); the version covers all four V6.5 kinds (`api`,
+`observation`, `question`, `task`) per the ADR-0028 bump-once precedent
+
+Fills the number reserved by ROADMAP-V6.md and noted in ADR-0041; recorded
+after ADR-0041 by design — V7.1 landed before V6.5.1.
+
+## Context
+
+ADR-0028 established the graph-artifact versioning discipline: one constant
+(`SUPPORTED_GRAPH_SCHEMA_VERSION` in `infrastructure/artifact/graph_json.rs`),
+written on emit, exact-matched on read, bumped once per cycle covering all new
+kinds. ADR-0035 documented the `status`-slot overload (Severity riding
+`status` on `warning`/`constraint`, Trust on `agent_instruction`,
+contradiction severity living in `fields["severity"]`), shipped a dual-emit
+stopgap within v3 (derived, unhashed top-level `severity`/`trust`), and
+planned a v4 cleanup in its §5.
+
+V6.5 adds four kinds. New `kind` strings in the payload demand a loud version
+bump, and a bump forces a full rebuild and re-embed anyway — so this is the
+cheapest moment to execute the planned cleanup.
+
+## Decision
+
+**Bump to `adoc.graph.v4`. The `status` slot is lifecycle-only.
+`severity`/`trust` become the sole, authored, hashed carriers.**
+
+1. `status` is absent for kinds without a lifecycle: `warning`, `constraint`,
+   `agent_instruction` (and `source`, unchanged). The `MetadataDiscriminant`
+   projection loses its `Severity`/`Trust` variants; the four V6.5 kinds are
+   born under the lifecycle-only rule.
+2. Top-level `severity` (on `warning`/`constraint`/`contradiction`) and
+   `trust` (on `agent_instruction`) switch from derived dual-emit to sole
+   carriers of the authored values, and **enter `KnowledgeObjectHashPayload`**
+   as optional fields serialized only when present — so the hash payload (and
+   therefore `content_hash`) of every kind that carries neither is
+   byte-identical to v3.
+3. Contradiction severity collapses from three locations to one: the
+   `fields["severity"]` copy disappears from the artifact; the top-level
+   `severity` is the authored, hashed home.
+4. **v4 is not purely additive the way v3 was.** Node contents change for
+   exactly four kinds: `warning`, `constraint`, `agent_instruction` (status
+   slot vacated, carrier fields now hashed) and `contradiction` (severity
+   carrier collapsed). Their `content_hash`/`base_hash` values regenerate on
+   first build; in-flight patches against old hashes fail loudly via the
+   existing base-hash mismatch — designed behavior. The additive invariant is
+   scoped to untouched shapes, proven by goldens.
+5. The review/diff projection re-keys its reads from the `status` slot to the
+   dedicated `severity`/`trust` node fields: three independent diffs
+   (`status` → `FieldChange::Status`, `severity` → `FieldChange::Severity`,
+   `trust` → `FieldChange::Trust`), retiring the kind-keyed re-labeling.
+   **The envelope half of ADR-0035 §5 is explicitly re-deferred**: typed
+   `FieldChange` payloads do not ship; `adoc.diff.v0` and `adoc.review.v0`
+   keep their string payloads and stay at v0. ADR-0035 §5 coupled the re-key
+   "alongside typed `FieldChange` payloads"; this ADR resolves that coupling
+   in favor of the split, so the deferral is a decision, not an accident.
+
+## Behavior deltas (enumerated, all deliberate)
+
+- **Warning re-label quirk fixed.** A `warning` severity delta now emits
+  `FieldChange::Severity` (v3 emitted `FieldChange::Status`, the ADR-0035
+  known quirk). The re-key makes the three carriers symmetric.
+- **Contradiction severity becomes diff-visible.** In v3 it lived only in
+  `fields` and the projection has no generic-fields diff, so a severity edit
+  was invisible to diff/review. It now emits `FieldChange::Severity` — and
+  consequently trips the existing any-field-change-on-unresolved-contradiction
+  re-assert obligation. That is a bug fix, not a regression.
+- **`--status` no longer matches severity/trust strings.** `adoc search
+  --status critical` matched warnings in v3 by accident of the overload; in
+  v4 it matches nothing for the three kinds. This is the designed PRD §18.4
+  lifecycle semantics. No severity filter is added; add one when a real
+  consumer asks.
+- **Embedding composition is unchanged.** `embedding_input` keeps its
+  `[status: …]` line by falling back status → severity → trust, so embedding
+  text is byte-identical to v3 and the forced full re-embed comes only from
+  the `graph_artifact_hash` change, not from a composition change.
+- **Envelopes stay v0 with visible record-content deltas.** Retrieval, diff,
+  review, and stale records embed graph nodes; fresh records lose the `status`
+  key for the three kinds and lose `fields["severity"]` on contradictions.
+  All four envelopes are tolerant-reader by contract (the ADR-0035 precedent
+  in reverse: keys may disappear as well as appear); the versioned artifact
+  underneath is what bumped. The published envelope schemas gain the optional
+  `severity`/`trust` keys they were missing since ADR-0035.
+- **The patch-draft status slot keeps its own overload.** `adoc.patch.v0`
+  `create_object` drafts still map a draft `status` change onto Severity for
+  warning drafts (`domain/knowledge_object/draft.rs`). That is the patch
+  envelope's seam, not the graph's; it stays v0 and is untouched. Noted so
+  the asymmetry is a recorded decision.
+
+## Consequences
+
+- First `adoc build` after upgrading rejects nothing but regenerates
+  everything: `graph_artifact_hash` changes, forcing a full re-embed; old
+  artifacts on disk fail the exact-match version gate with
+  `SchemaUnsupportedVersion`, per ADR-0028.
+- Golden fixtures for the four affected kinds change contents, not just the
+  version string; goldens for untouched kinds change only the version string —
+  both facts are asserted, which is what scopes the additive invariant.
+- The scoped grep — `grep -r adoc.graph.v3 crates/ examples/ README.md
+  docs/agent/` — returns zero hits after TB1; `docs/adr/`, `V*-DESIGN.md`,
+  and ROADMAP history keep their historical mentions.
+- V6.5.2–V6.5.4 add their kinds within v4. A later kind slice discovering it
+  needs a graph shape change is a design failure to escalate, not a second
+  bump.

--- a/docs/agent/v0/agent-instruction-guide.md
+++ b/docs/agent/v0/agent-instruction-guide.md
@@ -25,4 +25,4 @@ Treat an `agent_instruction` the way you treat any other Knowledge Object: as ci
 
 ## Wire surface
 
-`agent_instruction` nodes are emitted into the graph artifact (`adoc.graph.v3`) with `kind: "agent_instruction"`, the typed `trust`, the `scope`, and both action sets, and fold into the retrieval surface (`adoc.retrieval.v0`) like any other Knowledge Object. No new envelope version is introduced.
+`agent_instruction` nodes are emitted into the graph artifact (`adoc.graph.v4`) with `kind: "agent_instruction"`, the typed `trust` (top-level node field; these nodes carry no `status`, per ADR-0039), the `scope`, and both action sets, and fold into the retrieval surface (`adoc.retrieval.v0`) like any other Knowledge Object. No new envelope version is introduced.

--- a/docs/agent/v0/api-guide.md
+++ b/docs/agent/v0/api-guide.md
@@ -1,0 +1,65 @@
+# AgentDoc API Guide
+
+`api` Knowledge Objects are typed API contracts (PRD §13.7, V6.5.1). Each one names a single operation — an HTTP endpoint or a non-HTTP interface entry point — with its behavior described in prose and its shape carried by typed fields.
+
+## What an api object is
+
+An `api` object records the documented contract for one operation: what it is called on the wire (`method` + `path`, or `interface_type` + `symbol`) and what it does (the body). A `verified` api is verified by its schema source, not by human assertion — verification requires schema evidence.
+
+## Required fields
+
+| Field | Notes |
+|-------|-------|
+| `id` | Object ID — dot-separated lowercase identifier, e.g. `billing.consume-credit` |
+| `method` **or** `interface_type` | Exactly one. `method` is a closed uppercase HTTP method (`GET`, `HEAD`, `POST`, `PUT`, `DELETE`, `CONNECT`, `OPTIONS`, `TRACE`, `PATCH`); `interface_type` is an open string (`grpc`, `graphql`, …) |
+| `path` **or** `symbol` | Exactly one. `path` is a non-empty `/`-prefixed route template; `symbol` names a code entry point |
+| `body` | Non-empty prose describing the contract's behavior |
+
+Providing both sides of a one-of pair emits `schema.api_conflicting_method_and_interface_type` / `schema.api_conflicting_path_and_symbol`; providing neither emits `schema.api_missing_method_or_interface_type` / `schema.api_missing_path_or_symbol`.
+
+## Optional fields
+
+| Field | Notes |
+|-------|-------|
+| `status` | Closed set: `draft`, `verified`, `deprecated` |
+| `owner` | Required when `status: verified` |
+| `verified_at` | Required when `status: verified` (ISO 8601 date) |
+| `impacts` | Repo-relative paths this contract depends on — an api naturally declares its OpenAPI/proto file |
+| `evidence_ref` | Object IDs of `source` objects backing the contract |
+
+## The verified-api evidence rule
+
+A `verified` api must carry **schema evidence**: an inline `source:` entry, or an `evidence_ref` resolving to a `source` object whose kind is `api_schema` or `source_code`. Human review alone (`reviewed_by:`) is not sufficient — that emits `api.verified_missing_schema_evidence`.
+
+## Authoring syntax
+
+```
+::api billing.consume-credit
+method: POST
+path: /api/billing/credits/consume
+status: verified
+source: openapi/billing.yaml#/paths/~1credits~1consume
+owner: backend-platform
+verified_at: 2026-04-30
+--
+Consumes one or more credits for a completed generation job.
+::
+```
+
+## Wire surface
+
+`api` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+
+- `kind: "api"` — the node-level kind discriminant
+- `status` — the lifecycle status, when authored (lifecycle-only per ADR-0039)
+- `fields["method"]` / `fields["interface_type"]` — the operation half
+- `fields["path"]` / `fields["symbol"]` — the location half
+- `body` — the prose contract description
+
+They fold into the retrieval surface (`adoc.retrieval.v0`) like any other Knowledge Object. A verified api with `impacts:` participates in `adoc impacted-by`: a change to its declared schema file flags the api for contract re-verification.
+
+## How to cite api objects in answers
+
+- **Reference by Object ID.** Cite the api object's ID when answering questions about endpoint behavior.
+- **Report the signature as stored.** Surface `fields["method"]` and `fields["path"]` (or their interface/symbol counterparts) exactly as recorded; do not guess routes or methods.
+- **Respect the lifecycle.** Prefer `verified` apis over `draft` ones; flag `deprecated` contracts when citing them.

--- a/docs/agent/v0/compat-guide.md
+++ b/docs/agent/v0/compat-guide.md
@@ -1,6 +1,6 @@
 # AgentDoc Markdown Compatibility Guide
 
-V4 introduces **Compatibility Mode**: AgentDoc accepts `.md` source alongside `.adoc`, parses it with a CommonMark + GFM parser, and emits the same `adoc.graph.v3` artifact and `dist/docs.html` as native AgentDoc Source. Compatibility Mode is selected purely by file extension; `.adoc` files always validate under Strict Mode, `.md` files always validate under Compatibility Mode. There is no flag or config block to toggle this (ADR-0022).
+V4 introduces **Compatibility Mode**: AgentDoc accepts `.md` source alongside `.adoc`, parses it with a CommonMark + GFM parser, and emits the same `adoc.graph.v4` artifact and `dist/docs.html` as native AgentDoc Source. Compatibility Mode is selected purely by file extension; `.adoc` files always validate under Strict Mode, `.md` files always validate under Compatibility Mode. There is no flag or config block to toggle this (ADR-0022).
 
 This guide tells MCP agents how to reason about `.md` content correctly.
 

--- a/docs/agent/v0/contradiction-guide.md
+++ b/docs/agent/v0/contradiction-guide.md
@@ -41,11 +41,11 @@ Only `unresolved` contradictions are **active** and must be surfaced when answer
 
 ## Wire surface
 
-`contradiction` nodes are emitted into the graph artifact (`adoc.graph.v3`) with:
+`contradiction` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
 
 - `kind: "contradiction"`
 - `status`: the lifecycle status (`unresolved`, `resolved`, `dismissed`)
-- `fields.severity`: the severity level
+- `severity`: the severity level (top-level node field, ADR-0039)
 - `contradiction_claims`: the list of conflicting claim Object IDs (sorted, deduplicated)
 - `body`: the prose explanation
 

--- a/docs/agent/v0/schema/adoc.stale.v0.schema.json
+++ b/docs/agent/v0/schema/adoc.stale.v0.schema.json
@@ -36,7 +36,7 @@
           "enum": ["stale", "review_overdue", "expiring_soon"]
         },
         "authored_status": {
-          "description": "The status slot as authored. For warning/constraint/agent_instruction this slot carries Severity/Trust until the adoc.graph.v4 cleanup (ADR-0035).",
+          "description": "The lifecycle status as authored. Absent for kinds without a lifecycle (warning/constraint/agent_instruction/source), per ADR-0039.",
           "type": "string"
         },
         "effective_status": {

--- a/docs/agent/v0/schema/retrieval-envelope.json
+++ b/docs/agent/v0/schema/retrieval-envelope.json
@@ -16,6 +16,8 @@
           "kind": { "type": "string" },
           "content_hash": { "type": "string", "pattern": "^sha256:" },
           "status": { "type": ["string", "null"] },
+          "severity": { "type": "string" },
+          "trust": { "type": "string" },
           "owner": { "type": "string" },
           "verified_at": { "type": "string" },
           "body": { "type": "string" },

--- a/docs/agent/v0/schema/stale.md
+++ b/docs/agent/v0/schema/stale.md
@@ -14,4 +14,4 @@ Records sort most-overdue first, then by Object ID; one object can legitimately 
 
 The query is not a gate: exit code 0 (and a normal envelope) whether or not records exist. Non-zero exit codes occur only on artifact-load failure, with fix-oriented diagnostics and an empty `records` array.
 
-One ADR-0035 caveat: until the `adoc.graph.v4` cleanup, the `authored_status` slot carries Severity for `warning`/`constraint` records and Trust for `agent_instruction` records, should such objects ever carry `expires_at`.
+`authored_status` is the lifecycle status only; records for kinds without a lifecycle (`warning`/`constraint`/`agent_instruction`) omit it, per ADR-0039.

--- a/docs/agent/v0/source-guide.md
+++ b/docs/agent/v0/source-guide.md
@@ -6,7 +6,7 @@
 
 A `source` object (PRD §13.15) is a named, reusable reference to evidence outside the documentation workspace. It can point to a repo-relative file path (e.g. a source code file or test) or an absolute URL (e.g. a pull request, incident report, or external specification). Once authored, a `source` object can be cited anywhere a Knowledge Object ID is accepted.
 
-Source objects appear in `adoc.graph.v3` nodes with `kind: "source"`. Evidence kind and path or URL are projected into the node's `fields` map.
+Source objects appear in `adoc.graph.v4` nodes with `kind: "source"`. Evidence kind and path or URL are projected into the node's `fields` map.
 
 ## Required fields
 
@@ -96,7 +96,7 @@ Stripe Charges API documentation. Referenced by the payment processing claim.
 
 ## Wire surface
 
-`source` nodes are emitted into the graph artifact (`adoc.graph.v3`) with:
+`source` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
 
 - `kind: "source"` — the node-level kind discriminant
 - `fields["kind"]` — the evidence kind string (e.g. `"source_code"`)

--- a/examples/expanded-pilot/meta/REVIEW-CHECKLIST.md
+++ b/examples/expanded-pilot/meta/REVIEW-CHECKLIST.md
@@ -16,7 +16,7 @@ Use this checklist when hand-reviewing the generated `docs.html` and
 
 ## Graph JSON
 
-- `schema_version` is `adoc.graph.v3`.
+- `schema_version` is `adoc.graph.v4`.
 - 18 Knowledge Object nodes: 6 claim, 1 decision, 2 glossary, 1 constraint, 1 procedure, 2 example, 1 policy, 1 agent_instruction, 1 contradiction, 2 source.
 - Two `evidence` edges: `billing.credits.consume` and `billing.credits.use-ledger` → `billing.consume-use-case`.
 - `relation` and `reference` edges preserve source direction.

--- a/tests/fixtures/v1_2_search/empty.graph.json
+++ b/tests/fixtures/v1_2_search/empty.graph.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [],
   "edges": [],
   "diagnostics": []

--- a/tests/fixtures/v1_2_search/pilot_subset.graph.json
+++ b/tests/fixtures/v1_2_search/pilot_subset.graph.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.graph.v3",
+  "schema_version": "adoc.graph.v4",
   "nodes": [
     {
       "type": "page",
@@ -301,7 +301,7 @@
         "supersedes": [],
         "related_to": []
       },
-      "status": "high"
+      "severity": "high"
     },
     {
       "type": "knowledge_object",
@@ -325,7 +325,7 @@
           "billing.ledger"
         ]
       },
-      "status": "medium"
+      "severity": "medium"
     },
     {
       "type": "knowledge_object",

--- a/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
+++ b/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
@@ -5,7 +5,7 @@
     "provider": "deterministic",
     "dim": 4
   },
-  "graph_artifact_hash": "sha256:af48fe4f5f5445ad3f39aec411dfd5688c0fb9113e5c2f89426e0fcace1f1216",
+  "graph_artifact_hash": "sha256:55e05141fdffc8a33506635849f773d7778cab5869cc8122299c4247885da943",
   "embeddings": [
     {
       "id": "billing.credits",


### PR DESCRIPTION
## Summary

Implements **V6.5.1**, the second slice of the V7 cycle and the opening (and only serialization point) of the **V6.5 Vocabulary Completion** milestone, per [docs/ROADMAP-V7.md](docs/ROADMAP-V7.md). Two tracer bullets:

### TB1 — `adoc.graph.v3` → `adoc.graph.v4` (ADR-0039)

- **`status` is lifecycle-only.** Absent for `warning`/`constraint`/`agent_instruction`; the `MetadataDiscriminant` projection loses its Severity/Trust variants, so all four V6.5 kinds are born under the lifecycle-only rule.
- **`severity`/`trust` become sole authored carriers and enter `KnowledgeObjectHashPayload`** (skip-if-none, so kinds carrying neither keep their v3 `content_hash` byte-for-byte — the additive invariant is scoped to untouched shapes and pinned by tests).
- **Contradiction severity collapses to one home**: the top-level field; the v3 `fields["severity"]` copy is gone.
- **Review projection re-keyed** to three independent diffs (`status`/`severity`/`trust`), retiring the kind-keyed re-labeling. Two deliberate behavior deltas, recorded in ADR-0039: warning severity edits now emit `FieldChange::Severity` (the ADR-0035 known quirk, fixed), and contradiction severity edits become diff-visible for the first time.
- Ripples beyond the roadmap's checklist, handled: HTML render re-key (would otherwise hit `unreachable!()`), CLI presenters print `Severity:`/`Trust:` from the dedicated record fields (also fixes constraints mislabelled `Status: critical`), embedding composition stays byte-identical via a status→severity→trust fallback (no re-embed beyond the version-driven one), and the strict MCP envelope schemas gain the optional `severity`/`trust` keys missing since ADR-0035.
- Envelopes stay v0 (typed `FieldChange` payloads explicitly re-deferred); scoped grep for `adoc.graph.v3` over `crates/ examples/ README.md docs/agent/` returns zero.

### TB2 — the `api` Knowledge Object (PRD §13.7)

Twelfth kind, full vertical per the policy/source pattern:

- Aggregate with both one-of invariants as sum types (`method` XOR `interface_type`, `path` XOR `symbol`), closed `HttpMethod` value object (RFC 9110 + PATCH, uppercase-exact), optional `draft | verified | deprecated` status, claim-style refs-aware verification.
- `api.verified_missing_schema_evidence` as a **WorkspaceRule**: a verified api needs an inline `source:` entry or an `evidence_ref` resolving to an `api_schema`/`source_code` source.
- `FieldChange::ApiMethod`/`ApiPath` gated on `kind == api` (source `path` edits cannot mislabel); method/path changes on a verified api trigger a re-verify obligation requiring `api_schema` evidence; verified apis join `is_verified_subject` so `adoc impacted-by` covers their `impacts:` declarations.
- `render_api` endpoint signature (method badge + code-style path), `create_object` draft support, `docs/agent/v0/api-guide.md` published via MCP resources, README `<!-- adoc:kinds -->` anchor updated (the V7.1 `docs_manifest_guard` enforced it, as designed).

## Deviations from the roadmap, resolved and recorded

- The roadmap's "verbatim" PRD §13.7 acceptance fixture omits `verified_at`, contradicting the slice's own scope text that requires it on verified apis. Resolved in favor of the explicit requirement; the fixture gains `verified_at: 2026-04-30` (wide-margin fixed past date). Noted in the closing commit body.
- Two conflicting-* diagnostics (`schema.api_conflicting_method_and_interface_type`, `schema.api_conflicting_path_and_symbol`) added beyond the roadmap's list — implied by "mirroring source's path-XOR-url pattern".

## Breaking / operational notes

First `adoc build` after this change regenerates everything: `graph_artifact_hash` moves (forcing a full re-embed) and `content_hash`/`base_hash` regenerate for the four affected kinds (`warning`, `constraint`, `agent_instruction`, `contradiction`). In-flight patches fail loudly on base-hash mismatch — designed behavior per ADR-0028/0039.

## Test plan

- [x] `cargo test --workspace --locked` — all targets green
- [x] `cargo clippy --workspace --all-targets --locked` — zero warnings
- [x] Scoped grep gate: `grep -r adoc.graph.v3 crates/ examples/ README.md docs/agent/` → zero hits
- [x] Hash invariants pinned: claim-only hashes byte-identical across the bump; severity/trust edits change `content_hash`
- [x] Four roadmap acceptance cases in `api_cli.rs` (PRD example exit 0; missing method/interface_type; verified-with-only-reviewed_by; impacted-by coverage); v4 golden api node in `graph.rs`
- [x] End-to-end with the real binary: built a scratch project with the PRD api + a warning; verified the rendered `POST` signature, v4 graph shape, `adoc search` showing `Severity: high`, and `adoc why` resolving the api

Unblocks V6.5.2–V6.5.4 (observation/question/task), which parallelize from here per the roadmap's sequencing rationale.