### PR TITLE
feat(core): observation Knowledge Object (V6.5.2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,7 @@ Supported object kinds:
 - `contradiction`
 - `source`
 - `api`
+- `observation`
 <!-- /adoc:kinds -->
 
 Supported relation fields:

--- a/crates/adoc-cli/tests/observation_cli.rs
+++ b/crates/adoc-cli/tests/observation_cli.rs
@@ -1,0 +1,154 @@
+//! V6.5.2 `observation` Knowledge Object CLI acceptance (PRD §13.9).
+
+mod support;
+
+use std::fs;
+
+use serde_json::Value;
+
+use support::{TestWorkspace, adoc_command, stderr, stdout};
+
+/// The PRD §13.9 example, verbatim.
+const PRD_EXAMPLE_OBSERVATION: &str = "\
+# Onboarding findings @doc(team.onboarding-findings)
+
+Findings from support, analytics, and research.
+
+::observation onboarding.credit-confusion
+status: observed
+source: support_tickets
+sample_size: 37
+observed_at: 2026-04-30
+--
+Users often misunderstand credit usage before their first generation.
+::
+";
+
+const NEGATIVE_SAMPLE_SIZE_OBSERVATION: &str = "\
+# Onboarding findings @doc(team.onboarding-findings)
+
+Findings from support, analytics, and research.
+
+::observation onboarding.credit-confusion
+status: observed
+sample_size: -3
+--
+Users often misunderstand credit usage before their first generation.
+::
+";
+
+const VERIFIED_STATUS_OBSERVATION: &str = "\
+# Onboarding findings @doc(team.onboarding-findings)
+
+Findings from support, analytics, and research.
+
+::observation onboarding.credit-confusion
+status: verified
+--
+Users often misunderstand credit usage before their first generation.
+::
+";
+
+#[test]
+fn build_accepts_prd_example_and_emits_observation_into_graph_v4() {
+    let workspace = TestWorkspace::new("observation-build");
+    workspace.write("observation.adoc", PRD_EXAMPLE_OBSERVATION);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "observation.adoc", "--out", "dist"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected the PRD §13.9 example to build\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+
+    // Graph: kind observation with sample_size/observed_at preserved in the
+    // hashed fields map and the inline source as evidence.
+    let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
+        .expect("graph artifact is written");
+    let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
+
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+
+    let observation = graph["nodes"]
+        .as_array()
+        .expect("nodes is an array")
+        .iter()
+        .find(|node| node["kind"] == "observation")
+        .expect("graph contains an observation node");
+
+    assert_eq!(observation["id"], "onboarding.credit-confusion");
+    assert_eq!(observation["status"], "observed");
+    assert_eq!(observation["fields"]["sample_size"], "37");
+    assert_eq!(observation["fields"]["observed_at"], "2026-04-30");
+    // ADR-0039: observation is born lifecycle-only — no severity/trust carriers.
+    assert!(observation.get("severity").is_none());
+    assert!(observation.get("trust").is_none());
+    // The inline `source:` plugs into the V5 evidence model.
+    assert_eq!(observation["evidence"][0]["value"], "support_tickets");
+
+    // HTML: sample size and observed date as metadata chips.
+    let html = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
+        .expect("html artifact is written");
+    assert!(
+        html.contains("<span class=\"observation__sample-size\">n=37</span>"),
+        "html must contain the sample-size chip\n{html}"
+    );
+    assert!(
+        html.contains("<span class=\"observation__observed-at\">2026-04-30</span>"),
+        "html must contain the observed-at chip\n{html}"
+    );
+}
+
+#[test]
+fn check_rejects_negative_sample_size() {
+    let workspace = TestWorkspace::new("observation-negative-sample-size");
+    workspace.write("observation.adoc", NEGATIVE_SAMPLE_SIZE_OBSERVATION);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "observation.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for a negative sample_size"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.observation_invalid_sample_size]"),
+        "expected invalid sample_size diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+}
+
+#[test]
+fn check_rejects_verified_status() {
+    let workspace = TestWorkspace::new("observation-verified-status");
+    workspace.write("observation.adoc", VERIFIED_STATUS_OBSERVATION);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "observation.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for status `verified` — observations are only ever observed"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.observation_invalid_status]"),
+        "expected invalid status diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+}

--- a/crates/adoc-cli/tests/observation_cli.rs
+++ b/crates/adoc-cli/tests/observation_cli.rs
@@ -37,6 +37,19 @@ Users often misunderstand credit usage before their first generation.
 ::
 ";
 
+const DANGLING_EVIDENCE_REF_OBSERVATION: &str = "\
+# Onboarding findings @doc(team.onboarding-findings)
+
+Findings from support, analytics, and research.
+
+::observation onboarding.credit-confusion
+status: observed
+evidence_ref: no.such.source
+--
+Users often misunderstand credit usage before their first generation.
+::
+";
+
 const VERIFIED_STATUS_OBSERVATION: &str = "\
 # Onboarding findings @doc(team.onboarding-findings)
 
@@ -124,6 +137,30 @@ fn check_rejects_negative_sample_size() {
     assert!(
         combined.contains("error[schema.observation_invalid_sample_size]"),
         "expected invalid sample_size diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+}
+
+#[test]
+fn check_rejects_dangling_evidence_ref() {
+    let workspace = TestWorkspace::new("observation-dangling-evidence-ref");
+    workspace.write("observation.adoc", DANGLING_EVIDENCE_REF_OBSERVATION);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "observation.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for an evidence_ref to a missing source"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.evidence_target_not_found]"),
+        "expected evidence_target_not_found diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
         stdout(&output),
         stderr(&output)
     );

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_flags.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/adoc-cli/tests/snapshots_cli.rs
-assertion_line: 299
 expression: combined
 ---
 exit-success: false
 ---stdout---
 unknown_kind.adoc:5:3: error[schema.unknown_kind] unknown typed-block kind `fact`
   object_id: billing.policy
-  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. Custom schemas are deferred.
+  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation. Custom schemas are deferred.
 1 errors, 0 warnings
 ---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_freeform_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_freeform_flags.snap
@@ -1,12 +1,11 @@
 ---
 source: crates/adoc-cli/tests/snapshots_cli.rs
-assertion_line: 310
 expression: combined
 ---
 exit-success: false
 ---stdout---
 unknown_kind_freeform.adoc:5:3: error[schema.unknown_kind] unknown typed-block kind `fact`
   object_id: billing.policy
-  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. Custom schemas are deferred.
+  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation. Custom schemas are deferred.
 1 errors, 0 warnings
 ---stderr---

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -133,6 +133,11 @@ pub enum DiagnosticCode {
     /// entry nor an `evidence_ref` resolving to an `api_schema`/`source_code`
     /// source — an API contract is verified by its schema source.
     ApiVerifiedMissingSchemaEvidence,
+    /// V6.5.2: `observation` Knowledge Object (PRD §13.9).
+    SchemaObservationMissingStatus,
+    SchemaObservationInvalidStatus,
+    SchemaObservationInvalidSampleSize,
+    SchemaObservationInvalidObservedAt,
     /// V5.8 TB2: the `evidence_ref:` on a claim names an Object ID that does
     /// not exist anywhere in the workspace.
     SchemaEvidenceTargetNotFound,
@@ -269,6 +274,10 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaApiConflictingPathAndSymbol,
             DiagnosticCode::SchemaApiInvalidPath,
             DiagnosticCode::ApiVerifiedMissingSchemaEvidence,
+            DiagnosticCode::SchemaObservationMissingStatus,
+            DiagnosticCode::SchemaObservationInvalidStatus,
+            DiagnosticCode::SchemaObservationInvalidSampleSize,
+            DiagnosticCode::SchemaObservationInvalidObservedAt,
             DiagnosticCode::SchemaEvidenceTargetNotFound,
             DiagnosticCode::SchemaEvidenceTargetNotASource,
             DiagnosticCode::ClaimEvidenceQualityLow,
@@ -432,6 +441,14 @@ impl DiagnosticCode {
                 "schema.api_conflicting_path_and_symbol"
             }
             DiagnosticCode::SchemaApiInvalidPath => "schema.api_invalid_path",
+            DiagnosticCode::SchemaObservationMissingStatus => "schema.observation_missing_status",
+            DiagnosticCode::SchemaObservationInvalidStatus => "schema.observation_invalid_status",
+            DiagnosticCode::SchemaObservationInvalidSampleSize => {
+                "schema.observation_invalid_sample_size"
+            }
+            DiagnosticCode::SchemaObservationInvalidObservedAt => {
+                "schema.observation_invalid_observed_at"
+            }
             DiagnosticCode::ApiVerifiedMissingSchemaEvidence => {
                 "api.verified_missing_schema_evidence"
             }
@@ -757,6 +774,18 @@ impl DiagnosticCode {
             DiagnosticCode::ApiVerifiedMissingSchemaEvidence => {
                 "A verified api requires schema evidence: an inline `source:` entry or an `evidence_ref` to an `api_schema`/`source_code` source object."
             }
+            DiagnosticCode::SchemaObservationMissingStatus => {
+                "Add a `status` field to the observation. The only valid observation status is: observed."
+            }
+            DiagnosticCode::SchemaObservationInvalidStatus => {
+                "The only valid observation status is: observed."
+            }
+            DiagnosticCode::SchemaObservationInvalidSampleSize => {
+                "Use a positive integer for `sample_size` (e.g. `37`)."
+            }
+            DiagnosticCode::SchemaObservationInvalidObservedAt => {
+                "Use a valid `YYYY-MM-DD` date for `observed_at`."
+            }
             DiagnosticCode::SchemaEvidenceTargetNotFound => {
                 "Ensure every `evidence_ref` ID refers to an existing `source` object in the workspace."
             }
@@ -914,6 +943,10 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "schema.api_conflicting_path_and_symbol",
     "schema.api_invalid_path",
     "api.verified_missing_schema_evidence",
+    "schema.observation_missing_status",
+    "schema.observation_invalid_status",
+    "schema.observation_invalid_sample_size",
+    "schema.observation_invalid_observed_at",
     "schema.evidence_target_not_found",
     "schema.evidence_target_not_a_source",
     "claim.evidence_quality_low",

--- a/crates/adoc-core/src/domain/knowledge_object/draft.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/draft.rs
@@ -14,7 +14,12 @@ use crate::domain::knowledge_object::claim::{
 use crate::domain::knowledge_object::decision::{
     ACCEPTED_STATUS, DECIDED_BY_FIELD, DecidedBy, DecisionStatus,
 };
+use crate::domain::knowledge_object::observation::{
+    OBSERVED_AT_FIELD, ObservationStatus, SAMPLE_SIZE_FIELD,
+};
+use crate::domain::value_objects::effective_date::EffectiveDate;
 use crate::domain::value_objects::http_method::HttpMethod;
+use crate::domain::value_objects::sample_size::SampleSize;
 use crate::domain::value_objects::severity::Severity;
 use crate::domain::values::NonEmptyText;
 
@@ -66,6 +71,7 @@ impl DraftValidator<'_> {
             "glossary" => self.validate_glossary(),
             "warning" => self.validate_warning(),
             "api" => self.validate_api(),
+            "observation" => self.validate_observation(),
             kind => self.error(format!("unknown Knowledge Object kind `{kind}`")),
         }
     }
@@ -153,6 +159,32 @@ impl DraftValidator<'_> {
 
         if self.draft.status == Some(VERIFIED_STATUS) {
             self.validate_verified_api_obligation();
+        }
+    }
+
+    fn validate_observation(&mut self) {
+        match self.draft.status {
+            Some(status) => {
+                if ObservationStatus::try_new(status).is_err() {
+                    self.error(format!("observation has invalid status `{status}`"));
+                }
+            }
+            None => self.error("observation requires status"),
+        }
+
+        if let Some(sample_size) = self.draft.fields.get(SAMPLE_SIZE_FIELD)
+            && SampleSize::try_new(sample_size).is_err()
+        {
+            self.error(format!(
+                "observation has invalid sample_size `{sample_size}`"
+            ));
+        }
+        if let Some(observed_at) = self.draft.fields.get(OBSERVED_AT_FIELD)
+            && EffectiveDate::try_new(observed_at).is_err()
+        {
+            self.error(format!(
+                "observation has invalid observed_at `{observed_at}`"
+            ));
         }
     }
 

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -1268,6 +1268,7 @@ mod tests {
         assert_eq!(BlockKind::AgentInstruction.as_str(), "agent_instruction");
         assert_eq!(BlockKind::Contradiction.as_str(), "contradiction");
         assert_eq!(BlockKind::Source.as_str(), "source");
+        assert_eq!(BlockKind::Api.as_str(), "api");
         assert_eq!(BlockKind::Observation.as_str(), "observation");
     }
 
@@ -1314,6 +1315,7 @@ mod tests {
             BlockKind::from_fence_word("source"),
             Some(BlockKind::Source)
         );
+        assert_eq!(BlockKind::from_fence_word("api"), Some(BlockKind::Api));
         assert_eq!(
             BlockKind::from_fence_word("observation"),
             Some(BlockKind::Observation)

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -24,6 +24,7 @@ pub(crate) mod draft;
 pub(crate) mod example;
 pub(crate) mod glossary;
 pub(crate) mod metadata;
+pub(crate) mod observation;
 pub(crate) mod policy;
 pub(crate) mod procedure;
 pub(crate) mod projection;
@@ -38,6 +39,7 @@ use contradiction::Contradiction;
 use decision::Decision;
 use example::Example;
 use glossary::Glossary;
+use observation::Observation;
 use policy::Policy;
 use procedure::Procedure;
 use source::Source;
@@ -818,6 +820,7 @@ pub(crate) enum BlockKind {
     Contradiction,
     Source,
     Api,
+    Observation,
 }
 
 impl BlockKind {
@@ -834,6 +837,7 @@ impl BlockKind {
         Self::Contradiction,
         Self::Source,
         Self::Api,
+        Self::Observation,
     ];
 
     pub(crate) const fn as_str(self) -> &'static str {
@@ -850,6 +854,7 @@ impl BlockKind {
             Self::Contradiction => "contradiction",
             Self::Source => "source",
             Self::Api => "api",
+            Self::Observation => "observation",
         }
     }
 
@@ -883,6 +888,7 @@ pub(crate) enum KnowledgeObject {
     Contradiction(Contradiction),
     Source(Source),
     Api(Api),
+    Observation(Observation),
 }
 
 impl KnowledgeObject {
@@ -900,6 +906,7 @@ impl KnowledgeObject {
             Self::Contradiction(_) => BlockKind::Contradiction,
             Self::Source(_) => BlockKind::Source,
             Self::Api(_) => BlockKind::Api,
+            Self::Observation(_) => BlockKind::Observation,
         }
     }
 
@@ -917,6 +924,7 @@ impl KnowledgeObject {
             Self::Contradiction(contradiction) => contradiction.id(),
             Self::Source(source) => source.id(),
             Self::Api(api) => api.id(),
+            Self::Observation(observation) => observation.id(),
         }
     }
 
@@ -934,6 +942,7 @@ impl KnowledgeObject {
             Self::Contradiction(contradiction) => contradiction.span(),
             Self::Source(source) => source.span(),
             Self::Api(api) => api.span(),
+            Self::Observation(observation) => observation.span(),
         }
     }
 
@@ -951,6 +960,7 @@ impl KnowledgeObject {
             Self::Contradiction(contradiction) => contradiction.body(),
             Self::Source(source) => source.body(),
             Self::Api(api) => api.body(),
+            Self::Observation(observation) => observation.body(),
         }
     }
 
@@ -968,6 +978,7 @@ impl KnowledgeObject {
             Self::Contradiction(contradiction) => contradiction.body_mut(),
             Self::Source(source) => source.body_mut(),
             Self::Api(api) => api.body_mut(),
+            Self::Observation(observation) => observation.body_mut(),
         }
     }
 
@@ -985,12 +996,13 @@ impl KnowledgeObject {
             Self::Contradiction(contradiction) => contradiction.relations(),
             Self::Source(source) => source.relations(),
             Self::Api(api) => api.relations(),
+            Self::Observation(observation) => observation.relations(),
         }
     }
 
     /// V3.3 opt-in `impacts:` list. Empty slice for kinds that do not carry
-    /// this field (`glossary`, `warning`, `agent_instruction`, `contradiction`)
-    /// or for objects without it.
+    /// this field (`glossary`, `warning`, `agent_instruction`, `contradiction`,
+    /// `observation`) or for objects without it.
     pub(crate) fn impacts(&self) -> &[RelPath] {
         match self {
             Self::Claim(claim) => claim.impacts().unwrap_or(&[]),
@@ -1004,7 +1016,8 @@ impl KnowledgeObject {
             | Self::Warning(_)
             | Self::AgentInstruction(_)
             | Self::Contradiction(_)
-            | Self::Source(_) => &[],
+            | Self::Source(_)
+            | Self::Observation(_) => &[],
         }
     }
 
@@ -1022,6 +1035,7 @@ impl KnowledgeObject {
             Self::Contradiction(contradiction) => contradiction.fields(),
             Self::Source(source) => source.fields(),
             Self::Api(api) => api.fields(),
+            Self::Observation(observation) => observation.fields(),
         }
     }
 }
@@ -1041,6 +1055,7 @@ mod tests {
     use crate::domain::knowledge_object::decision::{AcceptedVerdict, DecidedBy, Decision};
     use crate::domain::knowledge_object::example::Example;
     use crate::domain::knowledge_object::glossary::Glossary;
+    use crate::domain::knowledge_object::observation::Observation;
     use crate::domain::knowledge_object::policy::Policy;
     use crate::domain::knowledge_object::procedure::Procedure;
     use crate::domain::knowledge_object::source::Source;
@@ -1225,6 +1240,21 @@ mod tests {
         )
     }
 
+    fn observation_object() -> KnowledgeObject {
+        KnowledgeObject::Observation(
+            Observation::try_new(
+                "onboarding.credit-confusion",
+                "observed",
+                Some("37"),
+                Some("2026-04-30"),
+                "Users misunderstand credit usage.",
+                BTreeMap::from([("owner".to_string(), "product-growth".to_string())]),
+                span("observation.adoc", 27, 1),
+            )
+            .expect("valid observation"),
+        )
+    }
+
     #[test]
     fn block_kind_labels_match_source_fence_words() {
         assert_eq!(BlockKind::Claim.as_str(), "claim");
@@ -1238,6 +1268,7 @@ mod tests {
         assert_eq!(BlockKind::AgentInstruction.as_str(), "agent_instruction");
         assert_eq!(BlockKind::Contradiction.as_str(), "contradiction");
         assert_eq!(BlockKind::Source.as_str(), "source");
+        assert_eq!(BlockKind::Observation.as_str(), "observation");
     }
 
     #[test]
@@ -1283,6 +1314,10 @@ mod tests {
             BlockKind::from_fence_word("source"),
             Some(BlockKind::Source)
         );
+        assert_eq!(
+            BlockKind::from_fence_word("observation"),
+            Some(BlockKind::Observation)
+        );
         assert_eq!(BlockKind::from_fence_word("fact"), None);
         assert_eq!(BlockKind::from_fence_word("Claim"), None);
     }
@@ -1304,6 +1339,7 @@ mod tests {
                 BlockKind::Contradiction,
                 BlockKind::Source,
                 BlockKind::Api,
+                BlockKind::Observation,
             ]
         );
     }
@@ -1425,6 +1461,15 @@ mod tests {
                 "Source implementation for credit consumption.",
                 "source.adoc",
                 25,
+                "owner",
+            ),
+            (
+                observation_object(),
+                BlockKind::Observation,
+                "onboarding.credit-confusion",
+                "Users misunderstand credit usage.",
+                "observation.adoc",
+                27,
                 "owner",
             ),
         ];

--- a/crates/adoc-core/src/domain/knowledge_object/observation.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/observation.rs
@@ -149,26 +149,28 @@ impl Observation {
     ) -> Result<Self, ObservationError> {
         let id = ObjectId::new(id_text).map_err(ObservationError::InvalidId)?;
         let status = ObservationStatus::try_new(status_text)?;
-        let sample_size = sample_size_text
-            .map(|value| {
-                SampleSize::try_new(value).map_err(|error| match error {
-                    SampleSizeError::Missing => ObservationError::InvalidSampleSize(String::new()),
-                    SampleSizeError::Invalid(value) => ObservationError::InvalidSampleSize(value),
-                })
-            })
-            .transpose()?;
-        let observed_at = observed_at_text
-            .map(|value| {
-                EffectiveDate::try_new(value).map_err(|error| match error {
-                    EffectiveDateError::Missing => {
-                        ObservationError::InvalidObservedAt(String::new())
-                    }
-                    EffectiveDateError::Invalid(value) => {
-                        ObservationError::InvalidObservedAt(value)
-                    }
-                })
-            })
-            .transpose()?;
+        // Present-but-blank optional fields are absent, matching the parser
+        // paths (`parse_sample_size` / `parse_observed_at`).
+        let sample_size = match sample_size_text {
+            Some(value) => match SampleSize::try_new(value) {
+                Ok(sample_size) => Some(sample_size),
+                Err(SampleSizeError::Missing) => None,
+                Err(SampleSizeError::Invalid(value)) => {
+                    return Err(ObservationError::InvalidSampleSize(value));
+                }
+            },
+            None => None,
+        };
+        let observed_at = match observed_at_text {
+            Some(value) => match EffectiveDate::try_new(value) {
+                Ok(observed_at) => Some(observed_at),
+                Err(EffectiveDateError::Missing) => None,
+                Err(EffectiveDateError::Invalid(value)) => {
+                    return Err(ObservationError::InvalidObservedAt(value));
+                }
+            },
+            None => None,
+        };
         let body = Body::from_plain_text(body_text).ok_or(ObservationError::MissingBody)?;
         Ok(Self {
             id,
@@ -439,6 +441,25 @@ mod tests {
             observation.observed_at().map(EffectiveDate::as_str),
             Some("2026-04-30")
         );
+    }
+
+    #[test]
+    fn try_new_treats_blank_optional_fields_as_absent() {
+        // Mirrors the parser path: present-but-blank `sample_size` /
+        // `observed_at` behave like absent fields.
+        let observation = Observation::try_new(
+            "onboarding.credit-confusion",
+            "observed",
+            Some(""),
+            Some("   "),
+            "Users often misunderstand credit usage.",
+            BTreeMap::new(),
+            span(),
+        )
+        .expect("blank optional fields are absent, not invalid");
+
+        assert!(observation.sample_size().is_none());
+        assert!(observation.observed_at().is_none());
     }
 
     #[test]

--- a/crates/adoc-core/src/domain/knowledge_object/observation.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/observation.rs
@@ -27,7 +27,6 @@ pub(crate) const SAMPLE_SIZE_FIELD: &str = "sample_size";
 pub(crate) const OBSERVED_AT_FIELD: &str = "observed_at";
 const STATUS_FIELD: &str = "status";
 
-const OBSERVATION_INVALID_STATUS_HELP: &str = "The only valid observation status is: observed.";
 const OBSERVATION_MISSING_BODY_HELP: &str =
     "Observations require non-empty body text describing what was seen.";
 
@@ -324,7 +323,7 @@ fn emit_observation_error(
                 parsed.id_text
             ),
         )
-        .with_help(OBSERVATION_INVALID_STATUS_HELP),
+        .with_help(DiagnosticCode::SchemaObservationInvalidStatus.default_help()),
         ObservationError::MissingBody => Diagnostic::error(
             DiagnosticCode::SchemaMissingField,
             format!("observation `{}` is missing required body", parsed.id_text),

--- a/crates/adoc-core/src/domain/knowledge_object/observation.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/observation.rs
@@ -1,0 +1,598 @@
+//! `observation` Knowledge Object aggregate (V6.5.2, PRD §13.9).
+//!
+//! A recorded finding from support, analytics, research, or ops. Required
+//! fields: `id`, `status`, `body`. The status set is the closed single-value
+//! enum `observed` — observations record what was seen and are never
+//! `verified` (the policy precedent: authority comes from elsewhere, here
+//! from the data itself). Optional: `source` (inline evidence, coexisting
+//! with `evidence_ref` per ADR-0027), `sample_size` (positive integer), and
+//! `observed_at` (`YYYY-MM-DD` date). Observations plug into the V5 evidence
+//! model rather than inventing a parallel one, so derived `evidence_quality`
+//! applies unchanged when evidence is present; no observation-specific
+//! workspace rule exists.
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+
+use crate::domain::ast::ParsedTypedBlock;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
+use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId, ObjectIdError};
+use crate::domain::knowledge_object::Relations;
+use crate::domain::knowledge_object::claim::{Evidence, SOURCE_FIELD};
+use crate::domain::value_objects::effective_date::{EffectiveDate, EffectiveDateError};
+use crate::domain::value_objects::sample_size::{SampleSize, SampleSizeError};
+use crate::domain::values::{Body, OptionalFields, trim_ascii_edges};
+
+pub(crate) const SAMPLE_SIZE_FIELD: &str = "sample_size";
+pub(crate) const OBSERVED_AT_FIELD: &str = "observed_at";
+const STATUS_FIELD: &str = "status";
+
+const OBSERVATION_INVALID_STATUS_HELP: &str = "The only valid observation status is: observed.";
+const OBSERVATION_MISSING_BODY_HELP: &str =
+    "Observations require non-empty body text describing what was seen.";
+
+/// A recorded finding (PRD §13.9, V6.5.2).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Observation {
+    id: ObjectId,
+    status: ObservationStatus,
+    body: Body,
+    sample_size: Option<SampleSize>,
+    observed_at: Option<EffectiveDate>,
+    fields: OptionalFields,
+    /// Inline `source:` evidence (ADR-0027 free-string form).
+    source_evidence: Option<Evidence>,
+    /// `evidence_ref:` entries naming `source` Knowledge Objects.
+    evidence_refs: Vec<Evidence>,
+    relations: Relations,
+    span: SourceSpan,
+}
+
+/// Why an `observation` failed to build from parsed input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ObservationError {
+    InvalidId(ObjectIdError),
+    MissingStatus,
+    InvalidStatus(String),
+    MissingBody,
+    InvalidSampleSize(String),
+    InvalidObservedAt(String),
+}
+
+impl Observation {
+    pub(crate) fn build_from_parsed(
+        mut parsed: ParsedTypedBlock,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Self> {
+        if super::reject_duplicate_fields(&parsed, "observation", diagnostics) {
+            return None;
+        }
+
+        let id = match ObjectId::new(&parsed.id_text) {
+            Ok(id) => Some(id),
+            Err(error) => {
+                emit_observation_error(&parsed, ObservationError::InvalidId(error), diagnostics);
+                None
+            }
+        };
+
+        let status = match parse_status(&mut parsed) {
+            Ok(status) => Some(status),
+            Err(error) => {
+                emit_observation_error(&parsed, error, diagnostics);
+                None
+            }
+        };
+
+        let mut invalid_optional_field = false;
+        let sample_size = match parse_sample_size(&mut parsed) {
+            Ok(sample_size) => sample_size,
+            Err(error) => {
+                emit_observation_error(&parsed, error, diagnostics);
+                invalid_optional_field = true;
+                None
+            }
+        };
+        let observed_at = match parse_observed_at(&mut parsed) {
+            Ok(observed_at) => observed_at,
+            Err(error) => {
+                emit_observation_error(&parsed, error, diagnostics);
+                invalid_optional_field = true;
+                None
+            }
+        };
+
+        let body = match super::body_from_parsed(&parsed) {
+            Some(body) => Some(body),
+            None => {
+                emit_observation_error(&parsed, ObservationError::MissingBody, diagnostics);
+                None
+            }
+        };
+
+        let evidence_refs = super::parse_evidence_refs(&mut parsed, diagnostics);
+        let source_evidence = parsed
+            .raw_fields
+            .remove(SOURCE_FIELD)
+            .and_then(|value| Evidence::from_field(SOURCE_FIELD, &value));
+
+        if id.is_none() || status.is_none() || body.is_none() || invalid_optional_field {
+            return None;
+        }
+
+        let relations = super::extract_relations(&mut parsed, diagnostics);
+        let optional_fields = std::mem::take(&mut parsed.raw_fields);
+
+        Some(Self {
+            id: id.expect("checked above"),
+            status: status.expect("checked above"),
+            body: body.expect("checked above"),
+            sample_size,
+            observed_at,
+            fields: OptionalFields::from_map(optional_fields),
+            source_evidence,
+            evidence_refs,
+            relations,
+            span: parsed.span.clone(),
+        })
+    }
+
+    /// Test-only constructor that bypasses the parsed-block pipeline.
+    #[cfg(test)]
+    pub(crate) fn try_new(
+        id_text: &str,
+        status_text: &str,
+        sample_size_text: Option<&str>,
+        observed_at_text: Option<&str>,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> Result<Self, ObservationError> {
+        let id = ObjectId::new(id_text).map_err(ObservationError::InvalidId)?;
+        let status = ObservationStatus::try_new(status_text)?;
+        let sample_size = sample_size_text
+            .map(|value| {
+                SampleSize::try_new(value).map_err(|error| match error {
+                    SampleSizeError::Missing => ObservationError::InvalidSampleSize(String::new()),
+                    SampleSizeError::Invalid(value) => ObservationError::InvalidSampleSize(value),
+                })
+            })
+            .transpose()?;
+        let observed_at = observed_at_text
+            .map(|value| {
+                EffectiveDate::try_new(value).map_err(|error| match error {
+                    EffectiveDateError::Missing => {
+                        ObservationError::InvalidObservedAt(String::new())
+                    }
+                    EffectiveDateError::Invalid(value) => {
+                        ObservationError::InvalidObservedAt(value)
+                    }
+                })
+            })
+            .transpose()?;
+        let body = Body::from_plain_text(body_text).ok_or(ObservationError::MissingBody)?;
+        Ok(Self {
+            id,
+            status,
+            body,
+            sample_size,
+            observed_at,
+            fields: OptionalFields::from_map(optional_fields),
+            source_evidence: None,
+            evidence_refs: Vec::new(),
+            relations: Relations::empty(),
+            span,
+        })
+    }
+
+    // ── Accessors ────────────────────────────────────────────────────────────
+
+    pub(crate) fn id(&self) -> &ObjectId {
+        &self.id
+    }
+
+    pub(crate) fn status(&self) -> &ObservationStatus {
+        &self.status
+    }
+
+    pub(crate) fn sample_size(&self) -> Option<&SampleSize> {
+        self.sample_size.as_ref()
+    }
+
+    pub(crate) fn observed_at(&self) -> Option<&EffectiveDate> {
+        self.observed_at.as_ref()
+    }
+
+    pub(crate) fn body(&self) -> &Body {
+        &self.body
+    }
+
+    pub(crate) fn body_mut(&mut self) -> &mut Body {
+        &mut self.body
+    }
+
+    pub(crate) fn fields(&self) -> &OptionalFields {
+        &self.fields
+    }
+
+    pub(crate) fn source_evidence(&self) -> Option<&Evidence> {
+        self.source_evidence.as_ref()
+    }
+
+    pub(crate) fn evidence_refs(&self) -> &[Evidence] {
+        &self.evidence_refs
+    }
+
+    pub(crate) fn relations(&self) -> &Relations {
+        &self.relations
+    }
+
+    pub(crate) fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+}
+
+/// Required closed status: `status:` absent or blank is
+/// [`ObservationError::MissingStatus`].
+fn parse_status(parsed: &mut ParsedTypedBlock) -> Result<ObservationStatus, ObservationError> {
+    let Some(raw) = parsed.raw_fields.remove(STATUS_FIELD) else {
+        return Err(ObservationError::MissingStatus);
+    };
+    let trimmed = trim_ascii_edges(&raw);
+    if trimmed.is_empty() {
+        return Err(ObservationError::MissingStatus);
+    }
+    ObservationStatus::try_new(trimmed)
+}
+
+/// Optional positive integer; present-but-blank is treated as absent.
+fn parse_sample_size(
+    parsed: &mut ParsedTypedBlock,
+) -> Result<Option<SampleSize>, ObservationError> {
+    let Some(raw) = parsed.raw_fields.remove(SAMPLE_SIZE_FIELD) else {
+        return Ok(None);
+    };
+    match SampleSize::try_new(&raw) {
+        Ok(sample_size) => Ok(Some(sample_size)),
+        Err(SampleSizeError::Missing) => Ok(None),
+        Err(SampleSizeError::Invalid(value)) => Err(ObservationError::InvalidSampleSize(value)),
+    }
+}
+
+/// Optional `YYYY-MM-DD` date; present-but-blank is treated as absent.
+fn parse_observed_at(
+    parsed: &mut ParsedTypedBlock,
+) -> Result<Option<EffectiveDate>, ObservationError> {
+    let Some(raw) = parsed.raw_fields.remove(OBSERVED_AT_FIELD) else {
+        return Ok(None);
+    };
+    match EffectiveDate::try_new(&raw) {
+        Ok(observed_at) => Ok(Some(observed_at)),
+        Err(EffectiveDateError::Missing) => Ok(None),
+        Err(EffectiveDateError::Invalid(value)) => Err(ObservationError::InvalidObservedAt(value)),
+    }
+}
+
+fn emit_observation_error(
+    parsed: &ParsedTypedBlock,
+    error: ObservationError,
+    diagnostics: &mut Vec<Diagnostic>,
+) {
+    let diagnostic = match error {
+        ObservationError::InvalidId(error) => Diagnostic::error(
+            DiagnosticCode::IdInvalid,
+            format!("invalid observation id `{}`: {error}", parsed.id_text),
+        )
+        .with_help(OBJECT_ID_GRAMMAR_HELP),
+        ObservationError::MissingStatus => Diagnostic::error(
+            DiagnosticCode::SchemaObservationMissingStatus,
+            format!(
+                "observation `{}` is missing required field `status`",
+                parsed.id_text
+            ),
+        )
+        .with_help(DiagnosticCode::SchemaObservationMissingStatus.default_help()),
+        ObservationError::InvalidStatus(status) => Diagnostic::error(
+            DiagnosticCode::SchemaObservationInvalidStatus,
+            format!(
+                "observation `{}` has invalid status `{status}`",
+                parsed.id_text
+            ),
+        )
+        .with_help(OBSERVATION_INVALID_STATUS_HELP),
+        ObservationError::MissingBody => Diagnostic::error(
+            DiagnosticCode::SchemaMissingField,
+            format!("observation `{}` is missing required body", parsed.id_text),
+        )
+        .with_help(OBSERVATION_MISSING_BODY_HELP),
+        ObservationError::InvalidSampleSize(value) => Diagnostic::error(
+            DiagnosticCode::SchemaObservationInvalidSampleSize,
+            format!(
+                "observation `{}` has invalid sample_size `{value}`",
+                parsed.id_text
+            ),
+        )
+        .with_help(DiagnosticCode::SchemaObservationInvalidSampleSize.default_help()),
+        ObservationError::InvalidObservedAt(value) => Diagnostic::error(
+            DiagnosticCode::SchemaObservationInvalidObservedAt,
+            format!(
+                "observation `{}` has invalid observed_at `{value}`",
+                parsed.id_text
+            ),
+        )
+        .with_help(DiagnosticCode::SchemaObservationInvalidObservedAt.default_help()),
+    };
+    diagnostics.push(
+        diagnostic
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text),
+    );
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ObservationStatus {
+    Observed,
+}
+
+impl ObservationStatus {
+    pub(crate) fn try_new(value: &str) -> Result<Self, ObservationError> {
+        match trim_ascii_edges(value) {
+            "observed" => Ok(Self::Observed),
+            other => Err(ObservationError::InvalidStatus(other.to_string())),
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        match self {
+            Self::Observed => "observed",
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+    use crate::domain::value_objects::evidence_kind::EvidenceKind;
+
+    fn span() -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from("test.adoc"),
+            start: SourcePosition {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line: 1,
+                column: 8,
+                offset: 7,
+            },
+        }
+    }
+
+    fn parsed_observation(fields: BTreeMap<String, String>) -> ParsedTypedBlock {
+        let body_text = "Users often misunderstand credit usage before their first generation.";
+        ParsedTypedBlock {
+            kind_word: "observation".to_string(),
+            kind_word_span: span(),
+            id_text: "onboarding.credit-confusion".to_string(),
+            raw_fields: fields,
+            raw_field_spans: BTreeMap::new(),
+            duplicate_keys: Vec::new(),
+            body_text: body_text.to_string(),
+            body_inlines: ParsedTypedBlock::test_body_inlines_from_text(body_text),
+            body_spans: Vec::new(),
+            content_spans: Vec::new(),
+            span: span(),
+            close_fence_span: span(),
+            body_separator_span: None,
+        }
+    }
+
+    #[test]
+    fn try_new_accepts_required_and_optional_fields() {
+        let observation = Observation::try_new(
+            "onboarding.credit-confusion",
+            "observed",
+            Some("37"),
+            Some("2026-04-30"),
+            "Users often misunderstand credit usage.",
+            BTreeMap::new(),
+            span(),
+        )
+        .expect("valid observation");
+
+        assert_eq!(observation.id().as_str(), "onboarding.credit-confusion");
+        assert_eq!(observation.status().as_str(), "observed");
+        assert_eq!(
+            observation.sample_size().map(SampleSize::as_str),
+            Some("37")
+        );
+        assert_eq!(
+            observation.observed_at().map(EffectiveDate::as_str),
+            Some("2026-04-30")
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_non_observed_status() {
+        let result = Observation::try_new(
+            "onboarding.credit-confusion",
+            "verified",
+            None,
+            None,
+            "Body.",
+            BTreeMap::new(),
+            span(),
+        );
+
+        assert_eq!(
+            result,
+            Err(ObservationError::InvalidStatus("verified".to_string()))
+        );
+    }
+
+    #[test]
+    fn try_new_rejects_invalid_sample_size() {
+        let result = Observation::try_new(
+            "onboarding.credit-confusion",
+            "observed",
+            Some("-3"),
+            None,
+            "Body.",
+            BTreeMap::new(),
+            span(),
+        );
+
+        assert_eq!(
+            result,
+            Err(ObservationError::InvalidSampleSize("-3".to_string()))
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_accepts_the_prd_example() {
+        // PRD §13.9 verbatim field set.
+        let parsed = parsed_observation(BTreeMap::from([
+            ("status".to_string(), "observed".to_string()),
+            ("source".to_string(), "support_tickets".to_string()),
+            ("sample_size".to_string(), "37".to_string()),
+            ("observed_at".to_string(), "2026-04-30".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let observation =
+            Observation::build_from_parsed(parsed, &mut diagnostics).expect("valid observation");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(observation.status().as_str(), "observed");
+        assert_eq!(
+            observation.sample_size().map(SampleSize::as_str),
+            Some("37")
+        );
+        assert_eq!(
+            observation.observed_at().map(EffectiveDate::as_str),
+            Some("2026-04-30")
+        );
+        let source = observation.source_evidence().expect("source evidence");
+        assert_eq!(source.kind(), Some(EvidenceKind::SourceCode));
+        assert_eq!(
+            source.value().expect("inline value").as_str(),
+            "support_tickets"
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_missing_status() {
+        let parsed = parsed_observation(BTreeMap::new());
+        let mut diagnostics = Vec::new();
+
+        let observation = Observation::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(observation.is_none());
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaObservationMissingStatus
+        );
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("onboarding.credit-confusion")
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_invalid_status() {
+        let parsed = parsed_observation(BTreeMap::from([(
+            "status".to_string(),
+            "verified".to_string(),
+        )]));
+        let mut diagnostics = Vec::new();
+
+        let observation = Observation::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(observation.is_none());
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaObservationInvalidStatus
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_invalid_sample_size() {
+        let parsed = parsed_observation(BTreeMap::from([
+            ("status".to_string(), "observed".to_string()),
+            ("sample_size".to_string(), "-3".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let observation = Observation::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(observation.is_none());
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaObservationInvalidSampleSize
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_invalid_observed_at() {
+        let parsed = parsed_observation(BTreeMap::from([
+            ("status".to_string(), "observed".to_string()),
+            ("observed_at".to_string(), "not-a-date".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let observation = Observation::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(observation.is_none());
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaObservationInvalidObservedAt
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_captures_evidence_refs_and_relations() {
+        let parsed = parsed_observation(BTreeMap::from([
+            ("status".to_string(), "observed".to_string()),
+            (
+                "evidence_ref".to_string(),
+                "support.tickets-export".to_string(),
+            ),
+            ("related_to".to_string(), "billing.credits".to_string()),
+        ]));
+        let mut diagnostics = Vec::new();
+
+        let observation =
+            Observation::build_from_parsed(parsed, &mut diagnostics).expect("valid observation");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(observation.evidence_refs().len(), 1);
+        assert_eq!(
+            observation.evidence_refs()[0]
+                .target_id()
+                .expect("object ref")
+                .as_str(),
+            "support.tickets-export"
+        );
+        let related_to: Vec<&str> = observation
+            .relations()
+            .targets(crate::domain::graph::GraphRelationKind::RelatedTo)
+            .iter()
+            .map(|target| target.id().as_str())
+            .collect();
+        assert_eq!(related_to, vec!["billing.credits"]);
+    }
+
+    #[test]
+    fn status_try_new_rejects_unknown_values() {
+        assert_eq!(
+            ObservationStatus::try_new("archived"),
+            Err(ObservationError::InvalidStatus("archived".to_string()))
+        );
+    }
+}

--- a/crates/adoc-core/src/domain/knowledge_object/observation.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/observation.rs
@@ -185,6 +185,31 @@ impl Observation {
         })
     }
 
+    /// Test-only constructor that also accepts evidence refs.
+    ///
+    /// Each `ObjectId` in `ref_ids` is wrapped in `Evidence::ObjectRef`.
+    #[cfg(test)]
+    pub(crate) fn try_new_with_refs(
+        id_text: &str,
+        status_text: &str,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        ref_ids: Vec<ObjectId>,
+        span: SourceSpan,
+    ) -> Result<Self, ObservationError> {
+        let mut observation = Self::try_new(
+            id_text,
+            status_text,
+            None,
+            None,
+            body_text,
+            optional_fields,
+            span,
+        )?;
+        observation.evidence_refs = ref_ids.into_iter().map(Evidence::object_ref).collect();
+        Ok(observation)
+    }
+
     // ── Accessors ────────────────────────────────────────────────────────────
 
     pub(crate) fn id(&self) -> &ObjectId {

--- a/crates/adoc-core/src/domain/knowledge_object/observation.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/observation.rs
@@ -264,11 +264,14 @@ fn parse_status(parsed: &mut ParsedTypedBlock) -> Result<ObservationStatus, Obse
     let Some(raw) = parsed.raw_fields.remove(STATUS_FIELD) else {
         return Err(ObservationError::MissingStatus);
     };
-    let trimmed = trim_ascii_edges(&raw);
-    if trimmed.is_empty() {
-        return Err(ObservationError::MissingStatus);
+    match ObservationStatus::try_new(&raw) {
+        // `try_new` trims, so an empty rejected value means the field was
+        // blank — report it as missing, not invalid.
+        Err(ObservationError::InvalidStatus(value)) if value.is_empty() => {
+            Err(ObservationError::MissingStatus)
+        }
+        result => result,
     }
-    ObservationStatus::try_new(trimmed)
 }
 
 /// Optional positive integer; present-but-blank is treated as absent.
@@ -546,6 +549,21 @@ mod tests {
         assert_eq!(
             diagnostics[0].object_id.as_deref(),
             Some("onboarding.credit-confusion")
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_blank_status_as_missing() {
+        let parsed =
+            parsed_observation(BTreeMap::from([("status".to_string(), "   ".to_string())]));
+        let mut diagnostics = Vec::new();
+
+        let observation = Observation::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(observation.is_none());
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaObservationMissingStatus
         );
     }
 

--- a/crates/adoc-core/src/domain/knowledge_object/projection.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/projection.rs
@@ -9,6 +9,7 @@ use crate::domain::knowledge_object::{
     },
     decision::{DECIDED_BY_FIELD, DecidedBy, DecisionStatus},
     example::{CHECKS_FIELD, ExampleStatus, FORMAT_FIELD, LANG_FIELD, SANDBOX_FIELD},
+    observation::{OBSERVED_AT_FIELD, ObservationStatus, SAMPLE_SIZE_FIELD},
     policy::PolicyStatus,
     procedure::ProcedureStatus,
 };
@@ -105,6 +106,8 @@ pub(crate) enum MetadataDiscriminant<'a> {
     ContradictionStatus(&'a ContradictionStatus),
     /// V6.5.1: lifecycle status for `api`.
     ApiStatus(&'a ApiStatus),
+    /// V6.5.2: lifecycle status for `observation`.
+    ObservationStatus(&'a ObservationStatus),
 }
 
 impl<'a> MetadataDiscriminant<'a> {
@@ -117,6 +120,7 @@ impl<'a> MetadataDiscriminant<'a> {
             Self::ExampleStatus(status) => status.as_str(),
             Self::ContradictionStatus(status) => status.as_str(),
             Self::ApiStatus(status) => status.as_str(),
+            Self::ObservationStatus(status) => status.as_str(),
         }
     }
 }
@@ -268,6 +272,28 @@ impl KnowledgeObject {
                 }
                 append_verification_fields(&mut fields, &mut evidence, api.verification());
                 api.status().map(MetadataDiscriminant::ApiStatus)
+            }
+            Self::Observation(observation) => {
+                // Typed optionals project as stored scalars so they enter the
+                // hashed graph `fields` map.
+                if let Some(sample_size) = observation.sample_size() {
+                    fields.push(MetadataField::Stored {
+                        key: SAMPLE_SIZE_FIELD,
+                        value: sample_size.as_str(),
+                    });
+                }
+                if let Some(observed_at) = observation.observed_at() {
+                    fields.push(MetadataField::Stored {
+                        key: OBSERVED_AT_FIELD,
+                        value: observed_at.as_str(),
+                    });
+                }
+                // Inline `source:` evidence joins the typed evidence vec, so
+                // derived evidence_quality applies unchanged (V5 model).
+                evidence.extend(observation.source_evidence());
+                Some(MetadataDiscriminant::ObservationStatus(
+                    observation.status(),
+                ))
             }
             Self::Source(source) => {
                 // Evidence kind projected as a stored scalar under key "kind".

--- a/crates/adoc-core/src/domain/review/object_diff.rs
+++ b/crates/adoc-core/src/domain/review/object_diff.rs
@@ -264,6 +264,45 @@ mod tests {
         );
     }
 
+    /// V6.5.2: observation has no typed `FieldChange` variants — an edit to a
+    /// fields-map scalar like `sample_size` flips the content hash and
+    /// surfaces as a `changed` entry whose base/head fields carry the delta.
+    #[test]
+    fn observation_sample_size_edit_produces_fields_map_delta() {
+        let mut base_node = test_node("onboarding.credit-confusion", "sha256:base-observation");
+        base_node.kind = "observation".to_string();
+        base_node.status = Some("observed".to_string());
+        base_node
+            .fields
+            .insert("sample_size".to_string(), "37".to_string());
+        let mut head_node = base_node.clone();
+        head_node.content_hash = "sha256:head-observation".to_string();
+        head_node
+            .fields
+            .insert("sample_size".to_string(), "52".to_string());
+
+        let diff = ObjectDiff::compute(&[base_node], &[head_node]);
+
+        assert_eq!(diff.changed().len(), 1);
+        let entry = &diff.changed()[0];
+        assert_eq!(entry.id, "onboarding.credit-confusion");
+        assert_eq!(
+            entry.base.fields.get("sample_size").map(String::as_str),
+            Some("37")
+        );
+        assert_eq!(
+            entry.head.fields.get("sample_size").map(String::as_str),
+            Some("52")
+        );
+        // No typed FieldChange variant claims the delta — the fields map is
+        // the carrier (unlike api's method/path).
+        assert!(
+            entry.field_changes.is_empty(),
+            "unexpected typed field changes: {:?}",
+            entry.field_changes
+        );
+    }
+
     #[test]
     fn diff_arrays_are_sorted_by_object_id_regardless_of_input_order() {
         let base = vec![

--- a/crates/adoc-core/src/domain/services/resolve_pending_block.rs
+++ b/crates/adoc-core/src/domain/services/resolve_pending_block.rs
@@ -10,7 +10,8 @@ use crate::domain::identity::ObjectId;
 use crate::domain::knowledge_object::{
     BlockKind, KnowledgeObject, agent_instruction::AgentInstruction, api::Api, claim::Claim,
     constraint::Constraint, contradiction::Contradiction, decision::Decision, example::Example,
-    glossary::Glossary, policy::Policy, procedure::Procedure, source::Source, warning::Warning,
+    glossary::Glossary, observation::Observation, policy::Policy, procedure::Procedure,
+    source::Source, warning::Warning,
 };
 
 type KnowledgeObjectBuilder = fn(ParsedTypedBlock, &mut Vec<Diagnostic>) -> Option<KnowledgeObject>;
@@ -70,6 +71,10 @@ const RESOLVERS: &[KnowledgeObjectResolver] = &[
     KnowledgeObjectResolver {
         kind: BlockKind::Api,
         build: build_api,
+    },
+    KnowledgeObjectResolver {
+        kind: BlockKind::Observation,
+        build: build_observation,
     },
 ];
 
@@ -188,6 +193,13 @@ fn build_api(
     diagnostics: &mut Vec<Diagnostic>,
 ) -> Option<KnowledgeObject> {
     Api::build_from_parsed(parsed, diagnostics).map(KnowledgeObject::Api)
+}
+
+fn build_observation(
+    parsed: ParsedTypedBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<KnowledgeObject> {
+    Observation::build_from_parsed(parsed, diagnostics).map(KnowledgeObject::Observation)
 }
 
 fn unknown_kind_diagnostic(parsed: &ParsedTypedBlock) -> Diagnostic {
@@ -314,7 +326,7 @@ mod tests {
 
         assert_eq!(
             help,
-            "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. \
+            "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation. \
             Custom schemas are deferred."
         );
         for kind in BlockKind::ALL {

--- a/crates/adoc-core/src/domain/value_objects/mod.rs
+++ b/crates/adoc-core/src/domain/value_objects/mod.rs
@@ -17,6 +17,7 @@ pub(crate) mod http_method;
 pub(crate) mod lang;
 pub(crate) mod rel_path;
 pub(crate) mod review_interval;
+pub(crate) mod sample_size;
 pub(crate) mod sandbox;
 pub(crate) mod scope;
 pub(crate) mod severity;

--- a/crates/adoc-core/src/domain/value_objects/sample_size.rs
+++ b/crates/adoc-core/src/domain/value_objects/sample_size.rs
@@ -1,0 +1,148 @@
+//! `sample_size` value object used by the `observation` Knowledge Object.
+//!
+//! Introduced in V6.5.2. Constructed only via [`SampleSize::try_new`]; the
+//! accepted grammar is one or more ASCII digits denoting a positive integer
+//! (e.g. `37`, `1200`). Zero (`0`, `000`), signs (`-3`, `+3`), and any
+//! non-digit characters are rejected. The token is stored in its
+//! ASCII-trimmed form.
+
+use std::fmt;
+
+use crate::domain::values::trim_ascii_edges;
+
+/// A positive sample size with constructor-asserted validity.
+///
+/// Once constructed the inner string satisfies the grammar `[0-9]+`, parses
+/// as a `u64`, and is greater than zero.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct SampleSize(String);
+
+/// Why a sample size string failed to parse.
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum SampleSizeError {
+    /// The value was empty or contained only ASCII whitespace.
+    Missing,
+    /// The value was non-empty but was not a positive integer.
+    Invalid(String),
+}
+
+impl SampleSize {
+    /// Parse a sample size from a string slice. ASCII-trims first; empty
+    /// input is [`SampleSizeError::Missing`]; any value that is not a run of
+    /// ASCII digits with a positive `u64` value is
+    /// [`SampleSizeError::Invalid`].
+    pub(crate) fn try_new(value: &str) -> Result<Self, SampleSizeError> {
+        let trimmed = trim_ascii_edges(value);
+        if trimmed.is_empty() {
+            return Err(SampleSizeError::Missing);
+        }
+        let is_positive_integer = trimmed.bytes().all(|b| b.is_ascii_digit())
+            && trimmed.parse::<u64>().is_ok_and(|n| n > 0);
+        if is_positive_integer {
+            Ok(Self(trimmed.to_string()))
+        } else {
+            Err(SampleSizeError::Invalid(trimmed.to_string()))
+        }
+    }
+
+    /// The validated sample size token string.
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+
+    /// The numeric sample size.
+    ///
+    /// The constructor guarantees the inner string is a run of ASCII digits
+    /// that parses as a positive `u64`, so the `.expect` documents the
+    /// invariant rather than silently propagating a logic error.
+    #[cfg(test)]
+    pub(crate) fn value(&self) -> u64 {
+        self.0
+            .parse::<u64>()
+            .expect("SampleSize inner string is always a positive u64")
+    }
+}
+
+impl fmt::Display for SampleSize {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sample_size_accepts_positive_integers() {
+        for value in ["1", "37", "1200"] {
+            let sample_size = SampleSize::try_new(value).expect("valid sample size");
+            assert_eq!(sample_size.as_str(), value);
+        }
+    }
+
+    #[test]
+    fn sample_size_trims_ascii_edges() {
+        let sample_size = SampleSize::try_new("  37  ").expect("valid sample size after trim");
+        assert_eq!(sample_size.as_str(), "37");
+    }
+
+    #[test]
+    fn sample_size_rejects_empty_and_whitespace_only() {
+        assert_eq!(SampleSize::try_new(""), Err(SampleSizeError::Missing));
+        assert_eq!(SampleSize::try_new("   "), Err(SampleSizeError::Missing));
+    }
+
+    #[test]
+    fn sample_size_rejects_zero() {
+        assert_eq!(
+            SampleSize::try_new("0"),
+            Err(SampleSizeError::Invalid("0".to_string()))
+        );
+        assert_eq!(
+            SampleSize::try_new("000"),
+            Err(SampleSizeError::Invalid("000".to_string()))
+        );
+    }
+
+    #[test]
+    fn sample_size_rejects_negative_numbers() {
+        assert_eq!(
+            SampleSize::try_new("-3"),
+            Err(SampleSizeError::Invalid("-3".to_string()))
+        );
+    }
+
+    #[test]
+    fn sample_size_rejects_non_digit_input() {
+        for value in ["+3", "3.5", "many", "3 7"] {
+            assert_eq!(
+                SampleSize::try_new(value),
+                Err(SampleSizeError::Invalid(value.to_string()))
+            );
+        }
+    }
+
+    #[test]
+    fn sample_size_rejects_values_beyond_u64() {
+        let value = "99999999999999999999999999";
+        assert_eq!(
+            SampleSize::try_new(value),
+            Err(SampleSizeError::Invalid(value.to_string()))
+        );
+    }
+
+    #[test]
+    fn sample_size_display_round_trips_through_try_new() {
+        let sample_size = SampleSize::try_new("37").expect("valid sample size");
+        let rendered = sample_size.to_string();
+        assert_eq!(SampleSize::try_new(&rendered), Ok(sample_size));
+    }
+
+    #[test]
+    fn value_returns_numeric_sample_size() {
+        assert_eq!(SampleSize::try_new("37").expect("valid").value(), 37);
+        assert_eq!(SampleSize::try_new("1").expect("valid").value(), 1);
+    }
+}

--- a/crates/adoc-core/src/domain/value_objects/sample_size.rs
+++ b/crates/adoc-core/src/domain/value_objects/sample_size.rs
@@ -3,8 +3,9 @@
 //! Introduced in V6.5.2. Constructed only via [`SampleSize::try_new`]; the
 //! accepted grammar is one or more ASCII digits denoting a positive integer
 //! (e.g. `37`, `1200`). Zero (`0`, `000`), signs (`-3`, `+3`), and any
-//! non-digit characters are rejected. The token is stored in its
-//! ASCII-trimmed form.
+//! non-digit characters are rejected. The value is stored in canonical
+//! decimal form (leading zeros dropped, e.g. `00037` → `37`) so that
+//! cosmetically different authored tokens hash identically.
 
 use std::fmt;
 
@@ -12,8 +13,8 @@ use crate::domain::values::trim_ascii_edges;
 
 /// A positive sample size with constructor-asserted validity.
 ///
-/// Once constructed the inner string satisfies the grammar `[0-9]+`, parses
-/// as a `u64`, and is greater than zero.
+/// Once constructed the inner string is the canonical decimal rendering of
+/// a positive `u64` (no leading zeros).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct SampleSize(String);
 
@@ -37,12 +38,16 @@ impl SampleSize {
         if trimmed.is_empty() {
             return Err(SampleSizeError::Missing);
         }
-        let is_positive_integer = trimmed.bytes().all(|b| b.is_ascii_digit())
-            && trimmed.parse::<u64>().is_ok_and(|n| n > 0);
-        if is_positive_integer {
-            Ok(Self(trimmed.to_string()))
-        } else {
-            Err(SampleSizeError::Invalid(trimmed.to_string()))
+        let parsed = trimmed
+            .bytes()
+            .all(|b| b.is_ascii_digit())
+            .then(|| trimmed.parse::<u64>().ok())
+            .flatten()
+            .filter(|&n| n > 0);
+        match parsed {
+            // Canonicalize so leading-zero variants hash identically.
+            Some(n) => Ok(Self(n.to_string())),
+            None => Err(SampleSizeError::Invalid(trimmed.to_string())),
         }
     }
 
@@ -92,6 +97,14 @@ mod tests {
     fn sample_size_rejects_empty_and_whitespace_only() {
         assert_eq!(SampleSize::try_new(""), Err(SampleSizeError::Missing));
         assert_eq!(SampleSize::try_new("   "), Err(SampleSizeError::Missing));
+    }
+
+    #[test]
+    fn sample_size_canonicalizes_leading_zeros() {
+        let sample_size = SampleSize::try_new("00037").expect("valid sample size");
+        assert_eq!(sample_size.as_str(), "37");
+        let sample_size = SampleSize::try_new("010").expect("valid sample size");
+        assert_eq!(sample_size.as_str(), "10");
     }
 
     #[test]

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -146,6 +146,7 @@ impl GraphJsonArtifact {
                     KnowledgeObject::Claim(claim) => claim.evidence_refs(),
                     KnowledgeObject::Decision(decision) => decision.evidence_refs(),
                     KnowledgeObject::Api(api) => api.evidence_refs(),
+                    KnowledgeObject::Observation(observation) => observation.evidence_refs(),
                     _ => return None,
                 };
                 if refs_slice.is_empty() {

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -353,6 +353,9 @@ fn render_knowledge_object(
         KnowledgeObject::Api(_) => {
             render_api(knowledge_object, &metadata, html);
         }
+        KnowledgeObject::Observation(_) => {
+            render_observation(knowledge_object, &metadata, html);
+        }
     }
 
     // V5.10: append effective_status badge after the section close tag if set.
@@ -528,6 +531,40 @@ fn render_api(
         html.push_str("</code>");
     }
     html.push_str("</div>\n");
+
+    render_object_body(knowledge_object, html);
+    render_object_metadata(knowledge_object, metadata, html);
+    html.push_str("</section>\n");
+}
+
+fn render_observation(
+    knowledge_object: &KnowledgeObject,
+    metadata: &KnowledgeObjectMetadata<'_>,
+    html: &mut String,
+) {
+    let KnowledgeObject::Observation(observation) = knowledge_object else {
+        unreachable!("render_observation called with non-observation object");
+    };
+
+    render_object_section_open(knowledge_object, "observation", html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
+
+    // Sample size and observed date as metadata chips above the prose body
+    // (PRD §13.9).
+    if observation.sample_size().is_some() || observation.observed_at().is_some() {
+        html.push_str("<div class=\"observation__chips\">");
+        if let Some(sample_size) = observation.sample_size() {
+            html.push_str("<span class=\"observation__sample-size\">n=");
+            html.push_str(&escape_html(sample_size.as_str()));
+            html.push_str("</span>");
+        }
+        if let Some(observed_at) = observation.observed_at() {
+            html.push_str("<span class=\"observation__observed-at\">");
+            html.push_str(&escape_html(observed_at.as_str()));
+            html.push_str("</span>");
+        }
+        html.push_str("</div>\n");
+    }
 
     render_object_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);

--- a/crates/adoc-core/src/infrastructure/validate/evidence_ref_resolves.rs
+++ b/crates/adoc-core/src/infrastructure/validate/evidence_ref_resolves.rs
@@ -28,7 +28,8 @@ impl WorkspaceRule for EvidenceRefResolves {
             }
         }
 
-        // For every claim, decision, and api, check each evidence_ref id.
+        // For every claim, decision, api, and observation, check each
+        // evidence_ref id.
         for page in &workspace.pages {
             for block in &page.blocks {
                 let BlockAst::KnowledgeObject(ko) = block else {
@@ -42,6 +43,7 @@ impl WorkspaceRule for EvidenceRefResolves {
                         (decision.id(), decision.span(), decision.evidence_refs())
                     }
                     KnowledgeObject::Api(api) => (api.id(), api.span(), api.evidence_refs()),
+                    KnowledgeObject::Observation(o) => (o.id(), o.span(), o.evidence_refs()),
                     _ => continue,
                 };
                 for ev in refs {
@@ -97,6 +99,7 @@ mod tests {
         claim::Claim,
         constraint::Constraint,
         decision::{AcceptedVerdict, DecidedBy, Decision},
+        observation::Observation,
         source::Source,
     };
 
@@ -203,6 +206,20 @@ mod tests {
         )
         .expect("valid accepted decision");
         BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Decision(decision)))
+    }
+
+    fn observation_block_with_refs(observation_id: &str, refs: Vec<&str>) -> BlockAst {
+        let ref_ids: Vec<ObjectId> = refs.into_iter().map(id).collect();
+        let observation = Observation::try_new_with_refs(
+            observation_id,
+            "observed",
+            "Observation body.",
+            BTreeMap::new(),
+            ref_ids,
+            span("observations.adoc", 1, 1),
+        )
+        .expect("valid observation");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Observation(observation)))
     }
 
     fn check(workspace: WorkspaceAst) -> Vec<Diagnostic> {
@@ -487,5 +504,75 @@ mod tests {
         let diagnostics = check(workspace);
 
         assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    // ── V6.5.2: observation evidence_ref validation ───────────────────────────
+
+    #[test]
+    fn observation_evidence_ref_missing_target_emits_not_found() {
+        let workspace = WorkspaceAst {
+            pages: vec![page(
+                "one.adoc",
+                vec![observation_block_with_refs(
+                    "onboarding.credit-confusion",
+                    vec!["billing.missing-source"],
+                )],
+            )],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaEvidenceTargetNotFound
+        );
+        assert!(
+            diagnostics[0].message.contains("billing.missing-source"),
+            "message must name the missing id: {:?}",
+            diagnostics[0]
+        );
+        assert!(
+            diagnostics[0].message.contains("no object with that id"),
+            "message must say no such object: {:?}",
+            diagnostics[0]
+        );
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("onboarding.credit-confusion")
+        );
+    }
+
+    #[test]
+    fn observation_evidence_ref_wrong_kind_emits_not_a_source() {
+        let workspace = WorkspaceAst {
+            pages: vec![page(
+                "one.adoc",
+                vec![
+                    constraint_block("billing.constraint"),
+                    observation_block_with_refs(
+                        "onboarding.credit-confusion",
+                        vec!["billing.constraint"],
+                    ),
+                ],
+            )],
+        };
+
+        let diagnostics = check(workspace);
+
+        assert_eq!(diagnostics.len(), 1);
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::SchemaEvidenceTargetNotASource
+        );
+        assert!(
+            diagnostics[0].message.contains("constraint"),
+            "message must mention the actual kind: {:?}",
+            diagnostics[0]
+        );
+        assert_eq!(
+            diagnostics[0].object_id.as_deref(),
+            Some("onboarding.credit-confusion")
+        );
     }
 }

--- a/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
@@ -17,6 +17,6 @@
       }
     },
     "object_id": "billing.unknown",
-    "help": "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api. Custom schemas are deferred."
+    "help": "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation. Custom schemas are deferred."
   }
 ]

--- a/crates/adoc-core/tests/graph.rs
+++ b/crates/adoc-core/tests/graph.rs
@@ -555,3 +555,50 @@ fn built_api_node_is_lifecycle_only_with_method_and_path_fields() {
             .starts_with("sha256:")
     );
 }
+
+/// V6.5.2: the PRD §13.9 observation example emits a v4 node with the
+/// `observed` lifecycle status, sample_size/observed_at in the hashed
+/// `fields` map, inline `source:` as typed evidence, and no `severity`/`trust`
+/// carriers — observation is born under the ADR-0039 lifecycle-only rule.
+#[test]
+fn built_observation_node_is_lifecycle_only_with_sample_size_and_observed_at_fields() {
+    let graph = build_graph_value(
+        "# Onboarding findings @doc(team.onboarding-findings)\n\
+         \n\
+         ::observation onboarding.credit-confusion\n\
+         status: observed\n\
+         source: support_tickets\n\
+         sample_size: 37\n\
+         observed_at: 2026-04-30\n\
+         --\n\
+         Users often misunderstand credit usage before their first generation.\n\
+         ::\n",
+    );
+
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+
+    let observation = graph["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .find(|node| node["kind"] == "observation")
+        .expect("graph contains the observation node");
+
+    assert_eq!(observation["id"], "onboarding.credit-confusion");
+    assert_eq!(observation["status"], "observed");
+    assert_eq!(observation["fields"]["sample_size"], "37");
+    assert_eq!(observation["fields"]["observed_at"], "2026-04-30");
+    assert!(
+        observation.get("severity").is_none() && observation.get("trust").is_none(),
+        "observation nodes carry no severity/trust: {observation}"
+    );
+    // Inline `source:` evidence lands in the typed evidence array.
+    assert_eq!(observation["evidence"][0]["kind"], "source_code");
+    assert_eq!(observation["evidence"][0]["value"], "support_tickets");
+    assert!(
+        observation["content_hash"]
+            .as_str()
+            .expect("content_hash")
+            .starts_with("sha256:")
+    );
+}

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -2079,3 +2079,44 @@ fn api_object_is_lexically_findable_with_method_and_path_fields() {
         Some("/api/billing/credits/consume")
     );
 }
+
+// ── V6.5.2: observation Knowledge Object retrieval coverage ─────────────────
+
+/// An `observation` node's body is BM25-findable and its record echoes kind,
+/// the `observed` lifecycle status, and the sample_size/observed_at scalars
+/// riding the fields map. The numbers themselves are metadata, not meaning —
+/// they are echoed on the record but not indexed.
+#[test]
+fn observation_object_is_lexically_findable_with_metadata_fields() {
+    let mut observation = retrieval_search_object(
+        "onboarding.credit-confusion",
+        "observation",
+        Some("observed"),
+        None,
+        "docs/onboarding.adoc",
+        "Users often misunderstand credit usage before their first generation.",
+    );
+    observation["fields"]["sample_size"] = json!("37");
+    observation["fields"]["observed_at"] = json!("2026-04-30");
+
+    let session = load_session_from_objects(vec![observation]);
+
+    let result = search(
+        &session,
+        lexical_query("misunderstand credit usage", 3, SearchFilters::default()),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), vec!["onboarding.credit-confusion"]);
+    let record = &result.records[0];
+    assert_eq!(record.kind, "observation");
+    assert_eq!(record.status.as_deref(), Some("observed"));
+    assert_eq!(
+        record.fields.get("sample_size").map(String::as_str),
+        Some("37")
+    );
+    assert_eq!(
+        record.fields.get("observed_at").map(String::as_str),
+        Some("2026-04-30")
+    );
+}

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -71,6 +71,14 @@ const RESOURCES: &[AgentResource] = &[
         contents: include_str!("../../../docs/agent/v0/api-guide.md"),
     },
     AgentResource {
+        uri: "adoc://agent/v0/observation-guide",
+        name: "agent-observation-guide",
+        title: "Observation Guide",
+        description: "V6.5.2 observation objects record findings from support, analytics, research, and ops.",
+        mime_type: MARKDOWN,
+        contents: include_str!("../../../docs/agent/v0/observation-guide.md"),
+    },
+    AgentResource {
         uri: "adoc://agent/v0/patch-contract",
         name: "agent-patch-contract",
         title: "Agent Patch Contract",

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -266,6 +266,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/contradiction-guide",
         "adoc://agent/v0/source-guide",
         "adoc://agent/v0/api-guide",
+        "adoc://agent/v0/observation-guide",
         "adoc://agent/v0/patch-contract",
         "adoc://agent/v0/patch-apply-guide",
         "adoc://agent/v0/project-status-guide",

--- a/docs/ROADMAP-V7.md
+++ b/docs/ROADMAP-V7.md
@@ -131,7 +131,7 @@ Scope:
 - Observations plug into the V5 evidence model rather than inventing a parallel one; derived `evidence_quality` applies unchanged when evidence is present — no new validate rule, the existing `evidence_quality.rs` covers it by construction.
 - `sample_size` and `observed_at` ride the hashed `fields` map; extending `embedding_input` for them is **not** warranted — kind, body, id, status suffice, and the numbers are metadata, not meaning.
 - HTML renders an observation card with sample size and observed date as metadata chips (`render_observation`).
-- Diagnostics: `schema.observation_missing_status`, `schema.observation_invalid_status`, `schema.observation_invalid_sample_size`.
+- Diagnostics: `schema.observation_missing_status`, `schema.observation_invalid_status`, `schema.observation_invalid_sample_size`, `schema.observation_invalid_observed_at` (the optional `observed_at` date implies an invalid-date case; follows the `schema.policy_invalid_effective_at` precedent).
 
 The acceptance fixture is the PRD §13.9 example, verbatim:
 

--- a/docs/agent/v0/observation-guide.md
+++ b/docs/agent/v0/observation-guide.md
@@ -1,0 +1,57 @@
+# AgentDoc Observation Guide
+
+`observation` Knowledge Objects record findings from support, analytics, research, and ops (PRD §13.9, V6.5.2). Each one captures what was seen — not what is claimed to be true.
+
+## What an observation object is
+
+An `observation` records a finding as data: what was observed, where it came from (`source`), how much data backs it (`sample_size`), and when (`observed_at`). Observations are never `verified` — their authority comes from the data itself, so the status set is the closed single value `observed`. Knowledge distilled from observations belongs in `claim` objects.
+
+## Required fields
+
+| Field | Notes |
+|-------|-------|
+| `id` | Object ID — dot-separated lowercase identifier, e.g. `onboarding.credit-confusion` |
+| `status` | Closed set with a single value: `observed`. Any other value emits `schema.observation_invalid_status` |
+| `body` | Non-empty prose describing what was seen |
+
+A missing status emits `schema.observation_missing_status`.
+
+## Optional fields
+
+| Field | Notes |
+|-------|-------|
+| `source` | Free-string inline evidence naming where the finding came from (e.g. `support_tickets`) |
+| `sample_size` | Positive integer — the number of data points behind the finding. Anything else emits `schema.observation_invalid_sample_size` |
+| `observed_at` | ISO 8601 date (`YYYY-MM-DD`). Anything else emits `schema.observation_invalid_observed_at` |
+| `evidence_ref` | Object IDs of `source` objects backing the finding — coexists with inline `source:` per ADR-0027 |
+
+## Authoring syntax
+
+```
+::observation onboarding.credit-confusion
+status: observed
+source: support_tickets
+sample_size: 37
+observed_at: 2026-04-30
+--
+Users often misunderstand credit usage before their first generation.
+::
+```
+
+## Wire surface
+
+`observation` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+
+- `kind: "observation"` — the node-level kind discriminant
+- `status: "observed"` — the lifecycle status (lifecycle-only per ADR-0039)
+- `fields["sample_size"]` / `fields["observed_at"]` — the typed optionals, hashed as authored fields
+- `evidence` — the inline `source:` entry and any resolved `evidence_ref` targets, feeding the derived `evidence_quality` unchanged (V5 evidence model)
+- `body` — the prose finding
+
+They fold into the retrieval surface (`adoc.retrieval.v0`) like any other Knowledge Object; the body is searchable, while `sample_size`/`observed_at` are echoed on records as metadata, not indexed as meaning.
+
+## How to cite observation objects in answers
+
+- **Reference by Object ID.** Cite the observation's ID when reporting user-facing findings.
+- **Report the numbers as stored.** Surface `fields["sample_size"]` and `fields["observed_at"]` exactly as recorded; do not extrapolate.
+- **Keep observations and claims apart.** An observation is evidence of what was seen, not verified knowledge — prefer `verified` claims for authoritative answers and cite observations as supporting context.


### PR DESCRIPTION
## Summary

Adds the `observation` Knowledge Object (PRD §13.9) — support/analytics/research/ops findings — as the twelfth kind, following the established V5 per-kind vertical pattern verbatim (ROADMAP-V7.md §V6.5.2).

- **Aggregate**: `domain/knowledge_object/observation.rs` — fallible constructor owning required-field invariants (`id`, `status`, `body`); closed single-value status enum `observed`; optional `source` (free string or `evidence_ref`, ADR-0027 coexistence), `sample_size` (new positive-integer value object `SampleSize`), `observed_at` (date)
- **Pipeline**: `BlockKind`/`RESOLVERS`/draft wiring, graph emission under `adoc.graph.v4` (lifecycle-only status slot), distinct HTML card with sample-size/date metadata chips, diff/review + BM25 retrieval coverage
- **Evidence**: plugs into the V5 evidence model — `evidence_ref` targets are resolution-checked (existence + source kind) and derived `evidence_quality` applies unchanged
- **Diagnostics**: `schema.observation_missing_status`, `schema.observation_invalid_status`, `schema.observation_invalid_sample_size`, `schema.observation_invalid_observed_at` (invalid-date code follows the `schema.policy_invalid_effective_at` precedent)
- **Agent docs**: `docs/agent/v0/observation-guide.md`, published via MCP resources

The last two commits fix findings from a local multi-agent review against the roadmap/PRD: the `evidence_ref_resolves` rule now covers observations (a dangling ref previously passed `adoc check` while emitting a dangling graph edge), plus a help-text dedup and the roadmap diagnostics-list true-up.

## Acceptance (asserted in `crates/adoc-cli/tests/observation_cli.rs`)

- PRD §13.9 example (verbatim fixture) exits 0
- `sample_size: -3` → `error[schema.observation_invalid_sample_size]`
- `status: verified` → `error[schema.observation_invalid_status]`
- `evidence_ref: no.such.source` → `error[schema.evidence_target_not_found]`
- `FieldChange` fields-map delta on `sample_size` edit; observation body BM25-findable

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — all green (55 suites, 0 failures)

Part of the V6.5 Vocabulary Completion milestone; sibling slices `question` (V6.5.3) and `task` (V6.5.4) follow and stack on this branch.