### PR TITLE
feat(core): task Knowledge Object (V6.5.4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -420,6 +420,7 @@ Supported object kinds:
 - `api`
 - `observation`
 - `question`
+- `task`
 <!-- /adoc:kinds -->
 
 Supported relation fields:

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_flags.snap
@@ -6,6 +6,6 @@ exit-success: false
 ---stdout---
 unknown_kind.adoc:5:3: error[schema.unknown_kind] unknown typed-block kind `fact`
   object_id: billing.policy
-  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question. Custom schemas are deferred.
+  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question, task. Custom schemas are deferred.
 1 errors, 0 warnings
 ---stderr---

--- a/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_freeform_flags.snap
+++ b/crates/adoc-cli/tests/snapshots/snapshots_cli__check_unknown_kind_freeform_flags.snap
@@ -6,6 +6,6 @@ exit-success: false
 ---stdout---
 unknown_kind_freeform.adoc:5:3: error[schema.unknown_kind] unknown typed-block kind `fact`
   object_id: billing.policy
-  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question. Custom schemas are deferred.
+  help: supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question, task. Custom schemas are deferred.
 1 errors, 0 warnings
 ---stderr---

--- a/crates/adoc-cli/tests/task_cli.rs
+++ b/crates/adoc-cli/tests/task_cli.rs
@@ -296,6 +296,43 @@ Update the support runbook to mention refund behavior after persistence failure.
 }
 
 #[test]
+fn check_rejects_task_with_malformed_due_date() {
+    let workspace = TestWorkspace::new("task-invalid-due");
+    workspace.write(
+        "tasks.adoc",
+        "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::task billing.update-support-runbook
+owner: support-ops
+status: open
+due: someday
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for a malformed due date"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.task_invalid_due]"),
+        "expected invalid-due diagnostic, got:\n{combined}"
+    );
+}
+
+#[test]
 fn check_emits_exactly_one_overdue_warning_for_wide_margin_past_due() {
     let workspace = TestWorkspace::new("task-past-due");
     workspace.write("tasks.adoc", WIDE_MARGIN_PAST_DUE_TASK);

--- a/crates/adoc-cli/tests/task_cli.rs
+++ b/crates/adoc-cli/tests/task_cli.rs
@@ -1,0 +1,321 @@
+//! V6.5.4 `task` Knowledge Object CLI acceptance (PRD §13.11).
+//!
+//! `task.overdue` is clock-dependent by design and the CLI compile path runs
+//! on the real clock, so every fixture uses fixed wide-margin dates: past
+//! dates fire the warning deterministically, 2120-style far-future dates stay
+//! quiet. Never dates relative to now.
+
+mod support;
+
+use std::fs;
+
+use serde_json::Value;
+
+use support::{TestWorkspace, adoc_command, stderr, stdout};
+
+/// The PRD §13.11 example, verbatim, plus the claim its `depends_on` names —
+/// relation targets must resolve in the workspace.
+const PRD_EXAMPLE_TASK: &str = "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::claim billing.credits.refund-on-failed-persistence
+status: plain
+--
+Credits are refunded when persistence fails after generation.
+::
+
+::task billing.update-support-runbook
+owner: support-ops
+status: open
+due: 2026-05-20
+depends_on: billing.credits.refund-on-failed-persistence
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+";
+
+/// Far-future `due` (the pilot's 2120/2125 `expires_at` precedent): quiet on
+/// any clock.
+const FAR_FUTURE_DUE_TASK: &str = "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::task billing.update-support-runbook
+owner: support-ops
+status: open
+due: 2126-05-20
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+";
+
+const MISSING_OWNER_TASK: &str = "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::task billing.update-support-runbook
+status: open
+due: 2126-05-20
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+";
+
+/// Wide-margin past `due` (2020–2024 range): overdue on any clock.
+const WIDE_MARGIN_PAST_DUE_TASK: &str = "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::task billing.update-support-runbook
+owner: support-ops
+status: open
+due: 2021-03-15
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+";
+
+#[test]
+fn check_accepts_prd_example_with_exactly_one_overdue_warning() {
+    let workspace = TestWorkspace::new("task-prd-check");
+    workspace.write("tasks.adoc", PRD_EXAMPLE_TASK);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    // The example's fixed `due: 2026-05-20` is already past, so exactly one
+    // `task.overdue` warning fires — warnings never fail the build.
+    assert!(
+        output.status.success(),
+        "expected the PRD §13.11 example to pass check despite the warning\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert_eq!(
+        combined.matches("warning[task.overdue]").count(),
+        1,
+        "expected exactly one task.overdue warning, got:\n{combined}"
+    );
+}
+
+#[test]
+fn build_emits_task_node_and_depends_on_edge_into_graph() {
+    let workspace = TestWorkspace::new("task-prd-build");
+    workspace.write("tasks.adoc", PRD_EXAMPLE_TASK);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", "tasks.adoc", "--out", "dist", "--no-embeddings"])
+        .output()
+        .expect("adoc build runs");
+
+    assert!(
+        output.status.success(),
+        "expected the PRD §13.11 example to build\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+
+    let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
+        .expect("graph artifact is written");
+    let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
+
+    // Node: kind task, lifecycle-only status, owner and due in the fields map.
+    let task = graph["nodes"]
+        .as_array()
+        .expect("nodes is an array")
+        .iter()
+        .find(|node| node["kind"] == "task")
+        .expect("graph contains a task node");
+    assert_eq!(task["id"], "billing.update-support-runbook");
+    assert_eq!(task["status"], "open");
+    assert_eq!(task["fields"]["owner"], "support-ops");
+    assert_eq!(task["fields"]["due"], "2026-05-20");
+    assert!(task.get("severity").is_none());
+    assert!(task.get("trust").is_none());
+
+    // Edge: the PRD example's depends_on relation appears in graph JSON.
+    let has_depends_on_edge = graph["edges"]
+        .as_array()
+        .expect("edges is an array")
+        .iter()
+        .any(|edge| {
+            edge["kind"] == "relation"
+                && edge["relation"] == "depends_on"
+                && edge["source"] == "billing.update-support-runbook"
+                && edge["target"] == "billing.credits.refund-on-failed-persistence"
+        });
+    assert!(
+        has_depends_on_edge,
+        "expected the task depends_on edge in graph JSON:\n{graph_text}"
+    );
+
+    // HTML: the task card carries owner, due date, and open/done state.
+    let html = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
+        .expect("html artifact is written");
+    assert!(
+        html.contains("<section class=\"task task--open\""),
+        "html must carry the open state on the task card\n{html}"
+    );
+    assert!(
+        html.contains("<div class=\"task__field-item\"><dt>owner</dt><dd>support-ops</dd></div>"),
+        "html must contain the owner field\n{html}"
+    );
+    assert!(
+        html.contains("<div class=\"task__field-item\"><dt>due</dt><dd>2026-05-20</dd></div>"),
+        "html must contain the due date\n{html}"
+    );
+}
+
+#[test]
+fn check_accepts_far_future_due_task_warning_free() {
+    let workspace = TestWorkspace::new("task-far-future");
+    workspace.write("tasks.adoc", FAR_FUTURE_DUE_TASK);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "expected a far-future due task to pass check\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        !combined.contains("task.overdue"),
+        "a far-future due must stay quiet on any clock, got:\n{combined}"
+    );
+}
+
+#[test]
+fn check_rejects_task_without_owner() {
+    let workspace = TestWorkspace::new("task-missing-owner");
+    workspace.write("tasks.adoc", MISSING_OWNER_TASK);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for a task without owner"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.task_missing_owner]"),
+        "expected missing-owner diagnostic, got:\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+}
+
+#[test]
+fn check_rejects_task_without_status() {
+    let workspace = TestWorkspace::new("task-missing-status");
+    workspace.write(
+        "tasks.adoc",
+        "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::task billing.update-support-runbook
+owner: support-ops
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for a task without status"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.task_missing_status]"),
+        "expected missing-status diagnostic, got:\n{combined}"
+    );
+}
+
+#[test]
+fn check_rejects_task_with_status_outside_closed_set() {
+    let workspace = TestWorkspace::new("task-invalid-status");
+    workspace.write(
+        "tasks.adoc",
+        "\
+# Billing Tasks @doc(team.billing-tasks)
+
+Billing documentation action items.
+
+::task billing.update-support-runbook
+owner: support-ops
+status: in-progress
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        !output.status.success(),
+        "expected check to fail for a status outside open|done"
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert!(
+        combined.contains("error[schema.task_invalid_status]"),
+        "expected invalid-status diagnostic, got:\n{combined}"
+    );
+}
+
+#[test]
+fn check_emits_exactly_one_overdue_warning_for_wide_margin_past_due() {
+    let workspace = TestWorkspace::new("task-past-due");
+    workspace.write("tasks.adoc", WIDE_MARGIN_PAST_DUE_TASK);
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "tasks.adoc"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "task.overdue is a warning; warnings never fail the build\nstdout:\n{}\nstderr:\n{}",
+        stdout(&output),
+        stderr(&output)
+    );
+    let combined = format!("{}{}", stdout(&output), stderr(&output));
+    assert_eq!(
+        combined.matches("warning[task.overdue]").count(),
+        1,
+        "expected exactly one task.overdue warning, got:\n{combined}"
+    );
+}

--- a/crates/adoc-cli/tests/task_cli.rs
+++ b/crates/adoc-cli/tests/task_cli.rs
@@ -159,12 +159,15 @@ fn build_emits_task_node_and_depends_on_edge_into_graph() {
         "expected the task depends_on edge in graph JSON:\n{graph_text}"
     );
 
-    // HTML: the task card carries owner, due date, and open/done state.
+    // HTML: the task card carries owner, due date, and open/done state. The
+    // PRD example's fixed due is already past (the same clock assumption as
+    // the task.overdue warning asserted above), so the card also carries the
+    // overdue modifier.
     let html = fs::read_to_string(workspace.root.join("dist").join("docs.html"))
         .expect("html artifact is written");
     assert!(
-        html.contains("<section class=\"task task--open\""),
-        "html must carry the open state on the task card\n{html}"
+        html.contains("<section class=\"task task--open task--overdue\""),
+        "html must carry the open + overdue state on the task card\n{html}"
     );
     assert!(
         html.contains("<div class=\"task__field-item\"><dt>owner</dt><dd>support-ops</dd></div>"),

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -156,6 +156,7 @@ pub enum DiagnosticCode {
     SchemaTaskMissingOwner,
     SchemaTaskMissingStatus,
     SchemaTaskInvalidStatus,
+    SchemaTaskInvalidDue,
     /// V6.5.4: an `open` task's `due` date is strictly before today. WARNING
     /// severity — clock-dependent, so fixture dates use the wide-margin
     /// discipline (the `schema.policy_review_overdue` precedent).
@@ -308,6 +309,7 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaTaskMissingOwner,
             DiagnosticCode::SchemaTaskMissingStatus,
             DiagnosticCode::SchemaTaskInvalidStatus,
+            DiagnosticCode::SchemaTaskInvalidDue,
             DiagnosticCode::TaskOverdue,
             DiagnosticCode::SchemaEvidenceTargetNotFound,
             DiagnosticCode::SchemaEvidenceTargetNotASource,
@@ -499,6 +501,7 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaTaskMissingOwner => "schema.task_missing_owner",
             DiagnosticCode::SchemaTaskMissingStatus => "schema.task_missing_status",
             DiagnosticCode::SchemaTaskInvalidStatus => "schema.task_invalid_status",
+            DiagnosticCode::SchemaTaskInvalidDue => "schema.task_invalid_due",
             DiagnosticCode::TaskOverdue => "task.overdue",
             DiagnosticCode::SchemaEvidenceTargetNotFound => "schema.evidence_target_not_found",
             DiagnosticCode::SchemaEvidenceTargetNotASource => "schema.evidence_target_not_a_source",
@@ -858,6 +861,7 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaTaskInvalidStatus => {
                 "Use a valid task status: one of open, done."
             }
+            DiagnosticCode::SchemaTaskInvalidDue => "Use a valid `YYYY-MM-DD` date for `due`.",
             DiagnosticCode::TaskOverdue => {
                 "Complete the task and set `status: done`, or move its `due` date."
             }
@@ -1030,6 +1034,7 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "schema.task_missing_owner",
     "schema.task_missing_status",
     "schema.task_invalid_status",
+    "schema.task_invalid_due",
     "task.overdue",
     "schema.evidence_target_not_found",
     "schema.evidence_target_not_a_source",

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -853,14 +853,12 @@ impl DiagnosticCode {
                 "Remove `resolved_by` or set `status: answered`."
             }
             DiagnosticCode::SchemaTaskMissingOwner => {
-                "Add a non-empty `owner` field to the task; a task without an owner is a wish."
+                "Tasks require a non-empty `owner` field; a task without an owner is a wish."
             }
             DiagnosticCode::SchemaTaskMissingStatus => {
-                "Add a `status` field to the task: one of open, done."
+                "Tasks require non-empty `status`. Valid task statuses are: open, done."
             }
-            DiagnosticCode::SchemaTaskInvalidStatus => {
-                "Use a valid task status: one of open, done."
-            }
+            DiagnosticCode::SchemaTaskInvalidStatus => "Valid task statuses are: open, done.",
             DiagnosticCode::SchemaTaskInvalidDue => "Use a valid `YYYY-MM-DD` date for `due`.",
             DiagnosticCode::TaskOverdue => {
                 "Complete the task and set `status: done`, or move its `due` date."

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -152,6 +152,14 @@ pub enum DiagnosticCode {
     /// V6.5.3: a non-`answered` question carries a `resolved_by:` field —
     /// only answered questions name the object that answered them.
     SchemaQuestionUnexpectedResolvedBy,
+    /// V6.5.4: `task` Knowledge Object (PRD §13.11).
+    SchemaTaskMissingOwner,
+    SchemaTaskMissingStatus,
+    SchemaTaskInvalidStatus,
+    /// V6.5.4: an `open` task's `due` date is strictly before today. WARNING
+    /// severity — clock-dependent, so fixture dates use the wide-margin
+    /// discipline (the `schema.policy_review_overdue` precedent).
+    TaskOverdue,
     /// V5.8 TB2: the `evidence_ref:` on a claim names an Object ID that does
     /// not exist anywhere in the workspace.
     SchemaEvidenceTargetNotFound,
@@ -297,6 +305,10 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaQuestionResolvedByNotFound,
             DiagnosticCode::SchemaQuestionResolvedByWrongKind,
             DiagnosticCode::SchemaQuestionUnexpectedResolvedBy,
+            DiagnosticCode::SchemaTaskMissingOwner,
+            DiagnosticCode::SchemaTaskMissingStatus,
+            DiagnosticCode::SchemaTaskInvalidStatus,
+            DiagnosticCode::TaskOverdue,
             DiagnosticCode::SchemaEvidenceTargetNotFound,
             DiagnosticCode::SchemaEvidenceTargetNotASource,
             DiagnosticCode::ClaimEvidenceQualityLow,
@@ -484,6 +496,10 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaQuestionUnexpectedResolvedBy => {
                 "schema.question_unexpected_resolved_by"
             }
+            DiagnosticCode::SchemaTaskMissingOwner => "schema.task_missing_owner",
+            DiagnosticCode::SchemaTaskMissingStatus => "schema.task_missing_status",
+            DiagnosticCode::SchemaTaskInvalidStatus => "schema.task_invalid_status",
+            DiagnosticCode::TaskOverdue => "task.overdue",
             DiagnosticCode::SchemaEvidenceTargetNotFound => "schema.evidence_target_not_found",
             DiagnosticCode::SchemaEvidenceTargetNotASource => "schema.evidence_target_not_a_source",
             DiagnosticCode::ClaimEvidenceQualityLow => "claim.evidence_quality_low",
@@ -833,6 +849,18 @@ impl DiagnosticCode {
             DiagnosticCode::SchemaQuestionUnexpectedResolvedBy => {
                 "Remove `resolved_by` or set `status: answered`."
             }
+            DiagnosticCode::SchemaTaskMissingOwner => {
+                "Add a non-empty `owner` field to the task; a task without an owner is a wish."
+            }
+            DiagnosticCode::SchemaTaskMissingStatus => {
+                "Add a `status` field to the task: one of open, done."
+            }
+            DiagnosticCode::SchemaTaskInvalidStatus => {
+                "Use a valid task status: one of open, done."
+            }
+            DiagnosticCode::TaskOverdue => {
+                "Complete the task and set `status: done`, or move its `due` date."
+            }
             DiagnosticCode::SchemaEvidenceTargetNotFound => {
                 "Ensure every `evidence_ref` ID refers to an existing `source` object in the workspace."
             }
@@ -999,6 +1027,10 @@ const DIAGNOSTIC_CODE_VARIANTS: &[&str] = &[
     "schema.question_resolved_by_not_found",
     "schema.question_resolved_by_wrong_kind",
     "schema.question_unexpected_resolved_by",
+    "schema.task_missing_owner",
+    "schema.task_missing_status",
+    "schema.task_invalid_status",
+    "task.overdue",
     "schema.evidence_target_not_found",
     "schema.evidence_target_not_a_source",
     "claim.evidence_quality_low",

--- a/crates/adoc-core/src/domain/knowledge_object/draft.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/draft.rs
@@ -20,6 +20,7 @@ use crate::domain::knowledge_object::observation::{
 use crate::domain::knowledge_object::question::{
     ANSWERED_STATUS, QuestionStatus, RESOLVED_BY_FIELD,
 };
+use crate::domain::knowledge_object::task::{DUE_FIELD, TaskStatus};
 use crate::domain::value_objects::effective_date::EffectiveDate;
 use crate::domain::value_objects::http_method::HttpMethod;
 use crate::domain::value_objects::sample_size::SampleSize;
@@ -76,6 +77,7 @@ impl DraftValidator<'_> {
             "api" => self.validate_api(),
             "observation" => self.validate_observation(),
             "question" => self.validate_question(),
+            "task" => self.validate_task(),
             kind => self.error(format!("unknown Knowledge Object kind `{kind}`")),
         }
     }
@@ -213,6 +215,31 @@ impl DraftValidator<'_> {
             && self.draft.fields.contains_key(RESOLVED_BY_FIELD)
         {
             self.error("question with fields.resolved_by requires `status: answered`");
+        }
+    }
+
+    fn validate_task(&mut self) {
+        if TaskStatus::try_new(self.draft.status.unwrap_or("")).is_err() {
+            match self.draft.status {
+                Some(status) => self.error(format!("task has invalid status `{status}`")),
+                None => self.error("task requires status"),
+            }
+        }
+
+        if self
+            .draft
+            .fields
+            .get(OWNER_FIELD)
+            .and_then(|value| Owner::try_new(value))
+            .is_none()
+        {
+            self.error("task requires non-empty fields.owner");
+        }
+
+        if let Some(due) = self.draft.fields.get(DUE_FIELD)
+            && EffectiveDate::try_new(due).is_err()
+        {
+            self.error(format!("task has invalid due `{due}`"));
         }
     }
 
@@ -542,6 +569,64 @@ mod tests {
                 .contains("requires review evidence before approval"),
             "unexpected obligation reason: {}",
             validation.proof_obligations[0].reason
+        );
+    }
+
+    // ── V6.5.4: task drafts ──────────────────────────────────────────────────
+
+    #[test]
+    fn open_task_with_owner_is_valid() {
+        let validation = validate(
+            "task",
+            Some("open"),
+            "Update the support runbook.",
+            BTreeMap::from([(OWNER_FIELD.to_string(), "support-ops".to_string())]),
+        );
+
+        assert!(validation.diagnostics.is_empty());
+        assert!(validation.proof_obligations.is_empty());
+    }
+
+    #[test]
+    fn task_without_owner_is_invalid() {
+        let validation = validate(
+            "task",
+            Some("open"),
+            "Update the support runbook.",
+            BTreeMap::new(),
+        );
+
+        assert_eq!(validation.diagnostics.len(), 1);
+        assert!(validation.diagnostics[0].message.contains("fields.owner"));
+    }
+
+    #[test]
+    fn task_with_invalid_status_or_due_is_invalid() {
+        let bad_status = validate(
+            "task",
+            Some("blocked"),
+            "Update the support runbook.",
+            BTreeMap::from([(OWNER_FIELD.to_string(), "support-ops".to_string())]),
+        );
+        assert!(
+            bad_status.diagnostics[0]
+                .message
+                .contains("invalid status `blocked`")
+        );
+
+        let bad_due = validate(
+            "task",
+            Some("open"),
+            "Update the support runbook.",
+            BTreeMap::from([
+                (OWNER_FIELD.to_string(), "support-ops".to_string()),
+                (DUE_FIELD.to_string(), "someday".to_string()),
+            ]),
+        );
+        assert!(
+            bad_due.diagnostics[0]
+                .message
+                .contains("invalid due `someday`")
         );
     }
 

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -1314,6 +1314,7 @@ mod tests {
         assert_eq!(BlockKind::Source.as_str(), "source");
         assert_eq!(BlockKind::Api.as_str(), "api");
         assert_eq!(BlockKind::Observation.as_str(), "observation");
+        assert_eq!(BlockKind::Question.as_str(), "question");
         assert_eq!(BlockKind::Task.as_str(), "task");
     }
 

--- a/crates/adoc-core/src/domain/knowledge_object/mod.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/mod.rs
@@ -30,6 +30,7 @@ pub(crate) mod procedure;
 pub(crate) mod projection;
 pub(crate) mod question;
 pub(crate) mod source;
+pub(crate) mod task;
 pub(crate) mod warning;
 
 use agent_instruction::AgentInstruction;
@@ -45,6 +46,7 @@ use policy::Policy;
 use procedure::Procedure;
 use question::Question;
 use source::Source;
+use task::Task;
 use warning::Warning;
 
 pub(super) fn reject_duplicate_fields(
@@ -824,6 +826,7 @@ pub(crate) enum BlockKind {
     Api,
     Observation,
     Question,
+    Task,
 }
 
 impl BlockKind {
@@ -842,6 +845,7 @@ impl BlockKind {
         Self::Api,
         Self::Observation,
         Self::Question,
+        Self::Task,
     ];
 
     pub(crate) const fn as_str(self) -> &'static str {
@@ -860,6 +864,7 @@ impl BlockKind {
             Self::Api => "api",
             Self::Observation => "observation",
             Self::Question => "question",
+            Self::Task => "task",
         }
     }
 
@@ -895,6 +900,7 @@ pub(crate) enum KnowledgeObject {
     Api(Api),
     Observation(Observation),
     Question(Question),
+    Task(Task),
 }
 
 impl KnowledgeObject {
@@ -914,6 +920,7 @@ impl KnowledgeObject {
             Self::Api(_) => BlockKind::Api,
             Self::Observation(_) => BlockKind::Observation,
             Self::Question(_) => BlockKind::Question,
+            Self::Task(_) => BlockKind::Task,
         }
     }
 
@@ -933,6 +940,7 @@ impl KnowledgeObject {
             Self::Api(api) => api.id(),
             Self::Observation(observation) => observation.id(),
             Self::Question(question) => question.id(),
+            Self::Task(task) => task.id(),
         }
     }
 
@@ -952,6 +960,7 @@ impl KnowledgeObject {
             Self::Api(api) => api.span(),
             Self::Observation(observation) => observation.span(),
             Self::Question(question) => question.span(),
+            Self::Task(task) => task.span(),
         }
     }
 
@@ -971,6 +980,7 @@ impl KnowledgeObject {
             Self::Api(api) => api.body(),
             Self::Observation(observation) => observation.body(),
             Self::Question(question) => question.body(),
+            Self::Task(task) => task.body(),
         }
     }
 
@@ -990,6 +1000,7 @@ impl KnowledgeObject {
             Self::Api(api) => api.body_mut(),
             Self::Observation(observation) => observation.body_mut(),
             Self::Question(question) => question.body_mut(),
+            Self::Task(task) => task.body_mut(),
         }
     }
 
@@ -1009,6 +1020,7 @@ impl KnowledgeObject {
             Self::Api(api) => api.relations(),
             Self::Observation(observation) => observation.relations(),
             Self::Question(question) => question.relations(),
+            Self::Task(task) => task.relations(),
         }
     }
 
@@ -1031,6 +1043,7 @@ impl KnowledgeObject {
             | Self::Source(_)
             | Self::Observation(_) => &[],
             Self::Question(_) => &[],
+            Self::Task(_) => &[],
         }
     }
 
@@ -1050,6 +1063,7 @@ impl KnowledgeObject {
             Self::Api(api) => api.fields(),
             Self::Observation(observation) => observation.fields(),
             Self::Question(question) => question.fields(),
+            Self::Task(task) => task.fields(),
         }
     }
 }
@@ -1073,6 +1087,7 @@ mod tests {
     use crate::domain::knowledge_object::policy::Policy;
     use crate::domain::knowledge_object::procedure::Procedure;
     use crate::domain::knowledge_object::source::Source;
+    use crate::domain::knowledge_object::task::Task;
     use crate::domain::knowledge_object::warning::Warning;
 
     fn span(file: &str, line: u32, column: u32) -> SourceSpan {
@@ -1239,6 +1254,21 @@ mod tests {
         )
     }
 
+    fn task_object() -> KnowledgeObject {
+        KnowledgeObject::Task(
+            Task::try_new(
+                "billing.update-support-runbook",
+                "open",
+                "support-ops",
+                Some("2026-05-20"),
+                "Update the support runbook.",
+                BTreeMap::from([("audience".to_string(), "support".to_string())]),
+                span("task.adoc", 27, 1),
+            )
+            .expect("valid task"),
+        )
+    }
+
     fn source_object() -> KnowledgeObject {
         KnowledgeObject::Source(
             Source::try_new(
@@ -1284,6 +1314,7 @@ mod tests {
         assert_eq!(BlockKind::Source.as_str(), "source");
         assert_eq!(BlockKind::Api.as_str(), "api");
         assert_eq!(BlockKind::Observation.as_str(), "observation");
+        assert_eq!(BlockKind::Task.as_str(), "task");
     }
 
     #[test]
@@ -1334,6 +1365,7 @@ mod tests {
             BlockKind::from_fence_word("observation"),
             Some(BlockKind::Observation)
         );
+        assert_eq!(BlockKind::from_fence_word("task"), Some(BlockKind::Task));
         assert_eq!(BlockKind::from_fence_word("fact"), None);
         assert_eq!(BlockKind::from_fence_word("Claim"), None);
     }
@@ -1357,6 +1389,7 @@ mod tests {
                 BlockKind::Api,
                 BlockKind::Observation,
                 BlockKind::Question,
+                BlockKind::Task,
             ]
         );
     }
@@ -1488,6 +1521,15 @@ mod tests {
                 "observation.adoc",
                 27,
                 "owner",
+            ),
+            (
+                task_object(),
+                BlockKind::Task,
+                "billing.update-support-runbook",
+                "Update the support runbook.",
+                "task.adoc",
+                27,
+                "audience",
             ),
         ];
 

--- a/crates/adoc-core/src/domain/knowledge_object/projection.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/projection.rs
@@ -13,6 +13,7 @@ use crate::domain::knowledge_object::{
     policy::PolicyStatus,
     procedure::ProcedureStatus,
     question::{QuestionStatus, RESOLVED_BY_FIELD},
+    task::{DUE_FIELD, TaskStatus},
 };
 use crate::domain::value_objects::contradiction_status::ContradictionStatus;
 use crate::domain::value_objects::effective_date::EffectiveDate;
@@ -111,6 +112,8 @@ pub(crate) enum MetadataDiscriminant<'a> {
     ObservationStatus(&'a ObservationStatus),
     /// V6.5.3: lifecycle status for `question`.
     QuestionStatus(&'a QuestionStatus),
+    /// V6.5.4: lifecycle status for `task`.
+    TaskStatus(&'a TaskStatus),
 }
 
 impl<'a> MetadataDiscriminant<'a> {
@@ -125,6 +128,7 @@ impl<'a> MetadataDiscriminant<'a> {
             Self::ApiStatus(status) => status.as_str(),
             Self::ObservationStatus(status) => status.as_str(),
             Self::QuestionStatus(status) => status.as_str(),
+            Self::TaskStatus(status) => status.as_str(),
         }
     }
 }
@@ -313,6 +317,18 @@ impl KnowledgeObject {
                     });
                 }
                 Some(MetadataDiscriminant::QuestionStatus(question.status()))
+            }
+            Self::Task(task) => {
+                fields.push(MetadataField::Owner(task.owner()));
+                // `due` projects as a stored scalar so it enters the hashed
+                // graph `fields` map (the api method/path pattern).
+                if let Some(due) = task.due() {
+                    fields.push(MetadataField::Stored {
+                        key: DUE_FIELD,
+                        value: due.as_str(),
+                    });
+                }
+                Some(MetadataDiscriminant::TaskStatus(task.status()))
             }
             Self::Source(source) => {
                 // Evidence kind projected as a stored scalar under key "kind".
@@ -664,6 +680,43 @@ mod tests {
                 entry(LANG_FIELD, "ts"),
                 entry(CHECKS_FIELD, "npm test"),
                 entry(SANDBOX_FIELD, "node-test"),
+            ]
+        );
+    }
+
+    #[test]
+    fn task_projection_maps_status_discriminant_with_typed_owner_and_stored_due() {
+        use crate::domain::knowledge_object::task::Task;
+
+        let object = KnowledgeObject::Task(
+            Task::try_new(
+                "billing.update-support-runbook",
+                "open",
+                "support-ops",
+                Some("2026-05-20"),
+                "Update the support runbook.",
+                BTreeMap::from([("audience".to_string(), "support".to_string())]),
+                span(),
+            )
+            .expect("valid task"),
+        );
+
+        let projection = object.metadata_projection();
+
+        assert_eq!(
+            projection
+                .discriminant()
+                .map(MetadataDiscriminant::value_as_str),
+            Some("open")
+        );
+        assert_eq!(projection.severity(), None);
+        assert_eq!(projection.trust(), None);
+        assert_eq!(
+            field_entries(&projection),
+            vec![
+                entry("audience", "support"),
+                entry("owner", "support-ops"),
+                entry("due", "2026-05-20"),
             ]
         );
     }

--- a/crates/adoc-core/src/domain/knowledge_object/task.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/task.rs
@@ -1,0 +1,521 @@
+//! `task` Knowledge Object aggregate (V6.5.4, PRD §13.11).
+//!
+//! A documentation action item. Required fields: `id`, `status`, `owner`,
+//! `body` — task is the only kind beyond `policy` requiring `owner`
+//! unconditionally (a task without an owner is a wish). Statuses are the
+//! closed `open | done` set. Optional: `due` (a `YYYY-MM-DD` date reusing the
+//! [`EffectiveDate`] value object). The clock-dependent `task.overdue`
+//! lifecycle warning lives in `infrastructure/validate/task_overdue.rs`.
+
+#[cfg(test)]
+use std::collections::BTreeMap;
+
+use crate::domain::ast::ParsedTypedBlock;
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
+use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId, ObjectIdError};
+use crate::domain::knowledge_object::Relations;
+use crate::domain::knowledge_object::claim::{OWNER_FIELD, Owner};
+use crate::domain::value_objects::effective_date::{EffectiveDate, EffectiveDateError};
+use crate::domain::values::{Body, OptionalFields, trim_ascii_edges};
+
+const STATUS_FIELD: &str = "status";
+pub(crate) const DUE_FIELD: &str = "due";
+
+const TASK_MISSING_STATUS_HELP: &str =
+    "Tasks require non-empty `status`. Valid task statuses are: open, done.";
+const TASK_INVALID_STATUS_HELP: &str = "Valid task statuses are: open, done.";
+const TASK_MISSING_OWNER_HELP: &str =
+    "Tasks require a non-empty `owner` field; a task without an owner is a wish.";
+const TASK_INVALID_DUE_HELP: &str = "Use a valid `YYYY-MM-DD` date for `due`.";
+const TASK_MISSING_BODY_HELP: &str = "Tasks require non-empty body text describing the action.";
+
+/// A documentation action item (PRD §13.11, V6.5.4).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct Task {
+    id: ObjectId,
+    status: TaskStatus,
+    owner: Owner,
+    due: Option<EffectiveDate>,
+    body: Body,
+    fields: OptionalFields,
+    relations: Relations,
+    span: SourceSpan,
+}
+
+/// Why a `task` failed to build from parsed input.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum TaskError {
+    InvalidId(ObjectIdError),
+    MissingStatus,
+    InvalidStatus(String),
+    MissingOwner,
+    InvalidDue(String),
+    MissingBody,
+}
+
+impl Task {
+    pub(crate) fn build_from_parsed(
+        mut parsed: ParsedTypedBlock,
+        diagnostics: &mut Vec<Diagnostic>,
+    ) -> Option<Self> {
+        if super::reject_duplicate_fields(&parsed, "task", diagnostics) {
+            return None;
+        }
+
+        let id = match ObjectId::new(&parsed.id_text) {
+            Ok(id) => Some(id),
+            Err(error) => {
+                emit_task_error(&parsed, TaskError::InvalidId(error), diagnostics);
+                None
+            }
+        };
+
+        let status_raw = parsed.raw_fields.remove(STATUS_FIELD);
+        let status = match TaskStatus::try_new(status_raw.as_deref().unwrap_or("")) {
+            Ok(status) => Some(status),
+            Err(error) => {
+                emit_task_error(&parsed, error, diagnostics);
+                None
+            }
+        };
+
+        let owner_raw = parsed.raw_fields.remove(OWNER_FIELD);
+        let owner = match owner_raw.as_deref().and_then(Owner::try_new) {
+            Some(owner) => Some(owner),
+            None => {
+                emit_task_error(&parsed, TaskError::MissingOwner, diagnostics);
+                None
+            }
+        };
+
+        // Parse due (optional; blank value → treat as absent).
+        let due_raw = parsed.raw_fields.remove(DUE_FIELD);
+        let due = match due_raw.as_deref() {
+            Some(raw) => match EffectiveDate::try_new(raw) {
+                Ok(date) => Some(Some(date)),
+                Err(EffectiveDateError::Missing) => Some(None),
+                Err(EffectiveDateError::Invalid(value)) => {
+                    emit_task_error(&parsed, TaskError::InvalidDue(value), diagnostics);
+                    None
+                }
+            },
+            None => Some(None),
+        };
+
+        let body = match super::body_from_parsed(&parsed) {
+            Some(body) => Some(body),
+            None => {
+                emit_task_error(&parsed, TaskError::MissingBody, diagnostics);
+                None
+            }
+        };
+
+        if id.is_none() || status.is_none() || owner.is_none() || due.is_none() || body.is_none() {
+            return None;
+        }
+
+        let relations = super::extract_relations(&mut parsed, diagnostics);
+        let optional_fields = std::mem::take(&mut parsed.raw_fields);
+
+        Some(Self {
+            id: id.expect("checked above"),
+            status: status.expect("checked above"),
+            owner: owner.expect("checked above"),
+            due: due.expect("checked above"),
+            body: body.expect("checked above"),
+            fields: OptionalFields::from_map(optional_fields),
+            relations,
+            span: parsed.span.clone(),
+        })
+    }
+
+    // ── Accessors ────────────────────────────────────────────────────────────
+
+    pub(crate) fn id(&self) -> &ObjectId {
+        &self.id
+    }
+
+    pub(crate) fn status(&self) -> &TaskStatus {
+        &self.status
+    }
+
+    pub(crate) fn owner(&self) -> &Owner {
+        &self.owner
+    }
+
+    pub(crate) fn due(&self) -> Option<&EffectiveDate> {
+        self.due.as_ref()
+    }
+
+    pub(crate) fn body(&self) -> &Body {
+        &self.body
+    }
+
+    pub(crate) fn body_mut(&mut self) -> &mut Body {
+        &mut self.body
+    }
+
+    pub(crate) fn fields(&self) -> &OptionalFields {
+        &self.fields
+    }
+
+    pub(crate) fn relations(&self) -> &Relations {
+        &self.relations
+    }
+
+    pub(crate) fn span(&self) -> &SourceSpan {
+        &self.span
+    }
+
+    /// Test-only constructor that bypasses the parsed-block pipeline.
+    #[cfg(test)]
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) fn try_new(
+        id_text: &str,
+        status_text: &str,
+        owner_text: &str,
+        due_text: Option<&str>,
+        body_text: &str,
+        optional_fields: BTreeMap<String, String>,
+        span: SourceSpan,
+    ) -> Result<Self, TaskError> {
+        let id = ObjectId::new(id_text).map_err(TaskError::InvalidId)?;
+        let status = TaskStatus::try_new(status_text)?;
+        let owner = Owner::try_new(owner_text).ok_or(TaskError::MissingOwner)?;
+        let due = due_text
+            .map(|raw| {
+                EffectiveDate::try_new(raw).map_err(|error| match error {
+                    EffectiveDateError::Missing => TaskError::InvalidDue(String::new()),
+                    EffectiveDateError::Invalid(value) => TaskError::InvalidDue(value),
+                })
+            })
+            .transpose()?;
+        let body = Body::from_plain_text(body_text).ok_or(TaskError::MissingBody)?;
+        Ok(Self {
+            id,
+            status,
+            owner,
+            due,
+            body,
+            fields: OptionalFields::from_map(optional_fields),
+            relations: Relations::empty(),
+            span,
+        })
+    }
+}
+
+fn emit_task_error(parsed: &ParsedTypedBlock, error: TaskError, diagnostics: &mut Vec<Diagnostic>) {
+    let diagnostic = match error {
+        TaskError::InvalidId(error) => Diagnostic::error(
+            DiagnosticCode::IdInvalid,
+            format!("invalid task id `{}`: {error}", parsed.id_text),
+        )
+        .with_help(OBJECT_ID_GRAMMAR_HELP),
+        TaskError::MissingStatus => Diagnostic::error(
+            DiagnosticCode::SchemaTaskMissingStatus,
+            format!(
+                "task `{}` is missing required field `status`",
+                parsed.id_text
+            ),
+        )
+        .with_help(TASK_MISSING_STATUS_HELP),
+        TaskError::InvalidStatus(status) => Diagnostic::error(
+            DiagnosticCode::SchemaTaskInvalidStatus,
+            format!("task `{}` has invalid status `{status}`", parsed.id_text),
+        )
+        .with_help(TASK_INVALID_STATUS_HELP),
+        TaskError::MissingOwner => Diagnostic::error(
+            DiagnosticCode::SchemaTaskMissingOwner,
+            format!(
+                "task `{}` is missing required field `owner`",
+                parsed.id_text
+            ),
+        )
+        .with_help(TASK_MISSING_OWNER_HELP),
+        // Reuses the generic field code — the roadmap's task vocabulary is the
+        // closed four-code set; `due` misuse is an ordinary field-value error.
+        TaskError::InvalidDue(value) => Diagnostic::error(
+            DiagnosticCode::SchemaMissingField,
+            format!(
+                "task `{}` has invalid `due` value `{value}`",
+                parsed.id_text
+            ),
+        )
+        .with_help(TASK_INVALID_DUE_HELP),
+        TaskError::MissingBody => Diagnostic::error(
+            DiagnosticCode::SchemaMissingField,
+            format!("task `{}` is missing required body", parsed.id_text),
+        )
+        .with_help(TASK_MISSING_BODY_HELP),
+    };
+    diagnostics.push(
+        diagnostic
+            .with_span(parsed.span.clone())
+            .with_object_id(&parsed.id_text),
+    );
+}
+
+/// Task lifecycle status.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TaskStatus {
+    Open,
+    Done,
+}
+
+impl TaskStatus {
+    pub(crate) fn try_new(value: &str) -> Result<Self, TaskError> {
+        let trimmed = trim_ascii_edges(value);
+        if trimmed.is_empty() {
+            return Err(TaskError::MissingStatus);
+        }
+        match trimmed {
+            "open" => Ok(Self::Open),
+            "done" => Ok(Self::Done),
+            _ => Err(TaskError::InvalidStatus(trimmed.to_string())),
+        }
+    }
+
+    pub(crate) fn as_str(self) -> &'static str {
+        match self {
+            Self::Open => "open",
+            Self::Done => "done",
+        }
+    }
+
+    pub(crate) fn is_open(self) -> bool {
+        matches!(self, Self::Open)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::path::PathBuf;
+
+    use super::*;
+    use crate::domain::diagnostic::{SourcePosition, SourceSpan};
+
+    fn span() -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from("test.adoc"),
+            start: SourcePosition {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line: 1,
+                column: 8,
+                offset: 7,
+            },
+        }
+    }
+
+    const BODY: &str =
+        "Update the support runbook to mention refund behavior after persistence failure.";
+
+    fn parsed_task(fields: BTreeMap<String, String>, body_text: &str) -> ParsedTypedBlock {
+        ParsedTypedBlock {
+            kind_word: "task".to_string(),
+            kind_word_span: span(),
+            id_text: "billing.update-support-runbook".to_string(),
+            raw_fields: fields,
+            raw_field_spans: BTreeMap::new(),
+            duplicate_keys: Vec::new(),
+            body_text: body_text.to_string(),
+            body_inlines: ParsedTypedBlock::test_body_inlines_from_text(body_text),
+            body_spans: Vec::new(),
+            content_spans: Vec::new(),
+            span: span(),
+            close_fence_span: span(),
+            body_separator_span: None,
+        }
+    }
+
+    fn valid_fields() -> BTreeMap<String, String> {
+        BTreeMap::from([
+            (STATUS_FIELD.to_string(), "open".to_string()),
+            (OWNER_FIELD.to_string(), "support-ops".to_string()),
+            (DUE_FIELD.to_string(), "2026-05-20".to_string()),
+        ])
+    }
+
+    // ── TaskStatus tests ────────────────────────────────────────────────────
+
+    #[test]
+    fn status_try_new_rejects_empty() {
+        assert_eq!(TaskStatus::try_new("  "), Err(TaskError::MissingStatus));
+    }
+
+    #[test]
+    fn status_try_new_rejects_unknown_values() {
+        assert_eq!(
+            TaskStatus::try_new("closed"),
+            Err(TaskError::InvalidStatus("closed".to_string()))
+        );
+    }
+
+    #[test]
+    fn status_try_new_accepts_closed_set_and_trims() {
+        assert!(TaskStatus::try_new("  open  ").expect("open").is_open());
+        assert_eq!(TaskStatus::try_new("done").expect("done"), TaskStatus::Done);
+        assert!(!TaskStatus::Done.is_open());
+    }
+
+    // ── build_from_parsed — the PRD §13.11 example ──────────────────────────
+
+    #[test]
+    fn build_from_parsed_accepts_the_prd_example() {
+        let mut fields = valid_fields();
+        fields.insert(
+            "depends_on".to_string(),
+            "billing.credits.refund-on-failed-persistence".to_string(),
+        );
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics).expect("valid task");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(task.id().as_str(), "billing.update-support-runbook");
+        assert!(task.status().is_open());
+        assert_eq!(task.owner().as_str(), "support-ops");
+        assert_eq!(task.due().map(EffectiveDate::as_str), Some("2026-05-20"));
+        assert_eq!(task.body().to_source(), BODY);
+        let depends_on: Vec<&str> = task
+            .relations()
+            .targets(crate::domain::graph::GraphRelationKind::DependsOn)
+            .iter()
+            .map(|target| target.id().as_str())
+            .collect();
+        assert_eq!(
+            depends_on,
+            vec!["billing.credits.refund-on-failed-persistence"]
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_accepts_done_task_without_due() {
+        let mut fields = valid_fields();
+        fields.insert(STATUS_FIELD.to_string(), "done".to_string());
+        fields.remove(DUE_FIELD);
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics).expect("valid task");
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(task.status(), &TaskStatus::Done);
+        assert!(task.due().is_none());
+    }
+
+    // ── build_from_parsed — missing/invalid required fields ─────────────────
+
+    #[test]
+    fn build_from_parsed_reports_missing_status() {
+        let mut fields = valid_fields();
+        fields.remove(STATUS_FIELD);
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(task.is_none());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == DiagnosticCode::SchemaTaskMissingStatus),
+            "expected SchemaTaskMissingStatus, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_invalid_status() {
+        let mut fields = valid_fields();
+        fields.insert(STATUS_FIELD.to_string(), "blocked".to_string());
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(task.is_none());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == DiagnosticCode::SchemaTaskInvalidStatus),
+            "expected SchemaTaskInvalidStatus, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_missing_owner() {
+        let mut fields = valid_fields();
+        fields.remove(OWNER_FIELD);
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(task.is_none());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == DiagnosticCode::SchemaTaskMissingOwner),
+            "expected SchemaTaskMissingOwner, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_invalid_due() {
+        let mut fields = valid_fields();
+        fields.insert(DUE_FIELD.to_string(), "not-a-date".to_string());
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(task.is_none());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == DiagnosticCode::SchemaMissingField
+                    && d.message.contains("invalid `due` value")),
+            "expected invalid-due diagnostic, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_reports_missing_body() {
+        let parsed = parsed_task(valid_fields(), "   ");
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(task.is_none());
+        assert!(
+            diagnostics
+                .iter()
+                .any(|d| d.code == DiagnosticCode::SchemaMissingField
+                    && d.message.contains("missing required body")),
+            "expected missing-body diagnostic, got: {diagnostics:?}"
+        );
+    }
+
+    #[test]
+    fn build_from_parsed_collects_multiple_errors() {
+        let parsed = parsed_task(BTreeMap::new(), BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        assert!(task.is_none());
+        let codes: Vec<_> = diagnostics.iter().map(|d| d.code).collect();
+        assert!(
+            codes.contains(&DiagnosticCode::SchemaTaskMissingStatus),
+            "expected missing status, got: {codes:?}"
+        );
+        assert!(
+            codes.contains(&DiagnosticCode::SchemaTaskMissingOwner),
+            "expected missing owner, got: {codes:?}"
+        );
+    }
+}

--- a/crates/adoc-core/src/domain/knowledge_object/task.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/task.rs
@@ -176,14 +176,18 @@ impl Task {
         let id = ObjectId::new(id_text).map_err(TaskError::InvalidId)?;
         let status = TaskStatus::try_new(status_text)?;
         let owner = Owner::try_new(owner_text).ok_or(TaskError::MissingOwner)?;
-        let due = due_text
-            .map(|raw| {
-                EffectiveDate::try_new(raw).map_err(|error| match error {
-                    EffectiveDateError::Missing => TaskError::InvalidDue(String::new()),
-                    EffectiveDateError::Invalid(value) => TaskError::InvalidDue(value),
-                })
-            })
-            .transpose()?;
+        // Present-but-blank `due` is absent, matching the parser path
+        // (`parse_due`).
+        let due = match due_text {
+            Some(raw) => match EffectiveDate::try_new(raw) {
+                Ok(date) => Some(date),
+                Err(EffectiveDateError::Missing) => None,
+                Err(EffectiveDateError::Invalid(value)) => {
+                    return Err(TaskError::InvalidDue(value));
+                }
+            },
+            None => None,
+        };
         let body = Body::from_plain_text(body_text).ok_or(TaskError::MissingBody)?;
         Ok(Self {
             id,
@@ -473,6 +477,41 @@ mod tests {
                     && d.message.contains("invalid `due` value")),
             "expected invalid-due diagnostic, got: {diagnostics:?}"
         );
+    }
+
+    #[test]
+    fn build_from_parsed_treats_blank_due_as_absent() {
+        let mut fields = valid_fields();
+        fields.insert(DUE_FIELD.to_string(), String::new());
+        let parsed = parsed_task(fields, BODY);
+        let mut diagnostics = Vec::new();
+
+        let task = Task::build_from_parsed(parsed, &mut diagnostics);
+
+        let task = task.expect("blank `due:` builds like an absent field");
+        assert!(
+            diagnostics.is_empty(),
+            "expected no diagnostics, got: {diagnostics:?}"
+        );
+        assert!(task.due().is_none());
+    }
+
+    #[test]
+    fn try_new_treats_blank_due_as_absent() {
+        // Mirrors the parser path (`parse_due`): present-but-blank `due`
+        // behaves like an absent field.
+        let task = Task::try_new(
+            "billing.update-support-runbook",
+            "open",
+            "support-ops",
+            Some("   "),
+            BODY,
+            BTreeMap::new(),
+            span(),
+        )
+        .expect("blank due is absent, not invalid");
+
+        assert!(task.due().is_none());
     }
 
     #[test]

--- a/crates/adoc-core/src/domain/knowledge_object/task.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/task.rs
@@ -26,7 +26,6 @@ const TASK_MISSING_STATUS_HELP: &str =
 const TASK_INVALID_STATUS_HELP: &str = "Valid task statuses are: open, done.";
 const TASK_MISSING_OWNER_HELP: &str =
     "Tasks require a non-empty `owner` field; a task without an owner is a wish.";
-const TASK_INVALID_DUE_HELP: &str = "Use a valid `YYYY-MM-DD` date for `due`.";
 const TASK_MISSING_BODY_HELP: &str = "Tasks require non-empty body text describing the action.";
 
 /// A documentation action item (PRD §13.11, V6.5.4).
@@ -232,16 +231,14 @@ fn emit_task_error(parsed: &ParsedTypedBlock, error: TaskError, diagnostics: &mu
             ),
         )
         .with_help(TASK_MISSING_OWNER_HELP),
-        // Reuses the generic field code — the roadmap's task vocabulary is the
-        // closed four-code set; `due` misuse is an ordinary field-value error.
         TaskError::InvalidDue(value) => Diagnostic::error(
-            DiagnosticCode::SchemaMissingField,
+            DiagnosticCode::SchemaTaskInvalidDue,
             format!(
                 "task `{}` has invalid `due` value `{value}`",
                 parsed.id_text
             ),
         )
-        .with_help(TASK_INVALID_DUE_HELP),
+        .with_help(DiagnosticCode::SchemaTaskInvalidDue.default_help()),
         TaskError::MissingBody => Diagnostic::error(
             DiagnosticCode::SchemaMissingField,
             format!("task `{}` is missing required body", parsed.id_text),
@@ -477,7 +474,7 @@ mod tests {
         assert!(
             diagnostics
                 .iter()
-                .any(|d| d.code == DiagnosticCode::SchemaMissingField
+                .any(|d| d.code == DiagnosticCode::SchemaTaskInvalidDue
                     && d.message.contains("invalid `due` value")),
             "expected invalid-due diagnostic, got: {diagnostics:?}"
         );

--- a/crates/adoc-core/src/domain/knowledge_object/task.rs
+++ b/crates/adoc-core/src/domain/knowledge_object/task.rs
@@ -21,11 +21,6 @@ use crate::domain::values::{Body, OptionalFields, trim_ascii_edges};
 const STATUS_FIELD: &str = "status";
 pub(crate) const DUE_FIELD: &str = "due";
 
-const TASK_MISSING_STATUS_HELP: &str =
-    "Tasks require non-empty `status`. Valid task statuses are: open, done.";
-const TASK_INVALID_STATUS_HELP: &str = "Valid task statuses are: open, done.";
-const TASK_MISSING_OWNER_HELP: &str =
-    "Tasks require a non-empty `owner` field; a task without an owner is a wish.";
 const TASK_MISSING_BODY_HELP: &str = "Tasks require non-empty body text describing the action.";
 
 /// A documentation action item (PRD §13.11, V6.5.4).
@@ -217,12 +212,12 @@ fn emit_task_error(parsed: &ParsedTypedBlock, error: TaskError, diagnostics: &mu
                 parsed.id_text
             ),
         )
-        .with_help(TASK_MISSING_STATUS_HELP),
+        .with_help(DiagnosticCode::SchemaTaskMissingStatus.default_help()),
         TaskError::InvalidStatus(status) => Diagnostic::error(
             DiagnosticCode::SchemaTaskInvalidStatus,
             format!("task `{}` has invalid status `{status}`", parsed.id_text),
         )
-        .with_help(TASK_INVALID_STATUS_HELP),
+        .with_help(DiagnosticCode::SchemaTaskInvalidStatus.default_help()),
         TaskError::MissingOwner => Diagnostic::error(
             DiagnosticCode::SchemaTaskMissingOwner,
             format!(
@@ -230,7 +225,7 @@ fn emit_task_error(parsed: &ParsedTypedBlock, error: TaskError, diagnostics: &mu
                 parsed.id_text
             ),
         )
-        .with_help(TASK_MISSING_OWNER_HELP),
+        .with_help(DiagnosticCode::SchemaTaskMissingOwner.default_help()),
         TaskError::InvalidDue(value) => Diagnostic::error(
             DiagnosticCode::SchemaTaskInvalidDue,
             format!(

--- a/crates/adoc-core/src/domain/review/field_change.rs
+++ b/crates/adoc-core/src/domain/review/field_change.rs
@@ -135,6 +135,11 @@ pub enum FieldChange {
         before: Option<String>,
         after: Option<String>,
     },
+    /// V6.5.4: the `due` date on a `task` object changed.
+    Due {
+        before: Option<String>,
+        after: Option<String>,
+    },
 }
 
 impl FieldChange {
@@ -175,6 +180,7 @@ impl FieldChange {
             FieldChange::ApiMethod { .. } => "method changed",
             FieldChange::ApiPath { .. } => "path changed",
             FieldChange::QuestionResolvedBy { .. } => "resolved_by changed",
+            FieldChange::Due { .. } => "due changed",
         }
     }
 }
@@ -276,6 +282,12 @@ impl fmt::Display for FieldChange {
             FieldChange::QuestionResolvedBy { before, after } => write!(
                 f,
                 "resolved_by: {} → {}",
+                optional(before.as_deref()),
+                optional(after.as_deref())
+            ),
+            FieldChange::Due { before, after } => write!(
+                f,
+                "due: {} → {}",
                 optional(before.as_deref()),
                 optional(after.as_deref())
             ),
@@ -1036,6 +1048,42 @@ mod tests {
             }
             .to_string(),
             "path: /a → /b"
+        );
+    }
+
+    // ── V6.5.4 task variants ───────────────────────────────────────────────
+
+    #[test]
+    fn due_variant_serializes_with_snake_case_tag() {
+        let change = FieldChange::Due {
+            before: Some("2026-05-20".to_string()),
+            after: Some("2026-06-30".to_string()),
+        };
+
+        let value = serde_json::to_value(&change).expect("FieldChange serializes");
+
+        assert_eq!(value["type"], "due");
+        assert_eq!(value["before"], "2026-05-20");
+        assert_eq!(value["after"], "2026-06-30");
+    }
+
+    #[test]
+    fn summary_label_and_display_cover_v6_5_task_due_variant() {
+        assert_eq!(
+            FieldChange::Due {
+                before: None,
+                after: None,
+            }
+            .summary_label(),
+            "due changed"
+        );
+        assert_eq!(
+            FieldChange::Due {
+                before: Some("2026-05-20".to_string()),
+                after: None,
+            }
+            .to_string(),
+            "due: 2026-05-20 → (none)"
         );
     }
 

--- a/crates/adoc-core/src/domain/review/projection.rs
+++ b/crates/adoc-core/src/domain/review/projection.rs
@@ -21,6 +21,7 @@ use crate::domain::knowledge_object::api::{
 };
 use crate::domain::knowledge_object::metadata::KnowledgeObjectMetadata;
 use crate::domain::knowledge_object::question::RESOLVED_BY_FIELD;
+use crate::domain::knowledge_object::task::DUE_FIELD;
 
 const EFFECTIVE_AT_FIELD: &str = "effective_at";
 const SCOPE_FIELD: &str = "scope";
@@ -186,6 +187,20 @@ pub(crate) fn project_changed(c: &ChangedObject) -> Vec<FieldChange> {
             out.push(FieldChange::QuestionResolvedBy {
                 before: base_resolved.map(str::to_string),
                 after: head_resolved.map(str::to_string),
+            });
+        }
+    }
+
+    // V6.5.4: task due scalar diff off the graph fields map, gated on kind so
+    // an unrelated `due` optional field on another kind never projects as the
+    // typed task vocabulary.
+    if head.kind == BlockKind::Task.as_str() {
+        let base_due = base.fields.get(DUE_FIELD).map(String::as_str);
+        let head_due = head.fields.get(DUE_FIELD).map(String::as_str);
+        if base_due != head_due {
+            out.push(FieldChange::Due {
+                before: base_due.map(str::to_string),
+                after: head_due.map(str::to_string),
             });
         }
     }
@@ -1028,6 +1043,25 @@ mod tests {
         n
     }
 
+    // ── V6.5.4 task due diffs ──────────────────────────────────────────────
+
+    fn task_node(content_hash: &str, due: Option<&str>) -> GraphKnowledgeObjectNode {
+        let mut fields = BTreeMap::from([("owner".to_string(), "support-ops".to_string())]);
+        if let Some(due) = due {
+            fields.insert("due".to_string(), due.to_string());
+        }
+        let mut n = node(
+            "billing.update-support-runbook",
+            content_hash,
+            "Update the support runbook.",
+            Some("open"),
+            fields,
+            GraphRelations::default(),
+        );
+        n.kind = "task".to_string();
+        n
+    }
+
     #[test]
     fn question_open_to_answered_emits_status_and_resolved_by_field_changes() {
         let base = question_node("sha256:a", "open", None);
@@ -1053,6 +1087,63 @@ mod tests {
                     after: Some("billing.trial-credit-decision".to_string()),
                 },
             ]
+        );
+    }
+
+    #[test]
+    fn task_due_change_emits_due_field_change() {
+        let base = task_node("sha256:a", Some("2026-05-20"));
+        let head = task_node("sha256:b", Some("2026-06-30"));
+
+        assert_eq!(
+            project_changed(&ChangedObject::new(
+                "billing.update-support-runbook".to_string(),
+                base,
+                head,
+            )),
+            vec![FieldChange::Due {
+                before: Some("2026-05-20".to_string()),
+                after: Some("2026-06-30".to_string()),
+            }]
+        );
+    }
+
+    #[test]
+    fn task_due_removal_emits_due_field_change_with_none_after() {
+        let base = task_node("sha256:a", Some("2026-05-20"));
+        let head = task_node("sha256:b", None);
+
+        assert_eq!(
+            project_changed(&ChangedObject::new(
+                "billing.update-support-runbook".to_string(),
+                base,
+                head,
+            )),
+            vec![FieldChange::Due {
+                before: Some("2026-05-20".to_string()),
+                after: None,
+            }]
+        );
+    }
+
+    #[test]
+    fn non_task_due_field_edit_does_not_emit_due_field_change() {
+        // The due diff is kind-gated: a free-form `due` optional field on a
+        // claim must not project as the typed task vocabulary.
+        let mut base = baseline("x");
+        base.fields
+            .insert("due".to_string(), "2026-05-20".to_string());
+        let mut head = baseline("x");
+        head.fields
+            .insert("due".to_string(), "2026-06-30".to_string());
+
+        let changes = project_changed(&changed_from(base, head));
+
+        assert!(
+            !changes
+                .iter()
+                .any(|change| matches!(change, FieldChange::Due { .. })),
+            "claim due edits must not project as the task due variant: {changes:?}"
         );
     }
 

--- a/crates/adoc-core/src/domain/services/resolve_pending_block.rs
+++ b/crates/adoc-core/src/domain/services/resolve_pending_block.rs
@@ -11,7 +11,7 @@ use crate::domain::knowledge_object::{
     BlockKind, KnowledgeObject, agent_instruction::AgentInstruction, api::Api, claim::Claim,
     constraint::Constraint, contradiction::Contradiction, decision::Decision, example::Example,
     glossary::Glossary, observation::Observation, policy::Policy, procedure::Procedure,
-    question::Question, source::Source, warning::Warning,
+    question::Question, source::Source, task::Task, warning::Warning,
 };
 
 type KnowledgeObjectBuilder = fn(ParsedTypedBlock, &mut Vec<Diagnostic>) -> Option<KnowledgeObject>;
@@ -79,6 +79,10 @@ const RESOLVERS: &[KnowledgeObjectResolver] = &[
     KnowledgeObjectResolver {
         kind: BlockKind::Question,
         build: build_question,
+    },
+    KnowledgeObjectResolver {
+        kind: BlockKind::Task,
+        build: build_task,
     },
 ];
 
@@ -213,6 +217,13 @@ fn build_question(
     Question::build_from_parsed(parsed, diagnostics).map(KnowledgeObject::Question)
 }
 
+fn build_task(
+    parsed: ParsedTypedBlock,
+    diagnostics: &mut Vec<Diagnostic>,
+) -> Option<KnowledgeObject> {
+    Task::build_from_parsed(parsed, diagnostics).map(KnowledgeObject::Task)
+}
+
 fn unknown_kind_diagnostic(parsed: &ParsedTypedBlock) -> Diagnostic {
     let mut diagnostic = Diagnostic::error(
         DiagnosticCode::SchemaUnknownKind,
@@ -337,7 +348,7 @@ mod tests {
 
         assert_eq!(
             help,
-            "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question. \
+            "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question, task. \
             Custom schemas are deferred."
         );
         for kind in BlockKind::ALL {

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -360,7 +360,7 @@ fn render_knowledge_object(
             render_question(knowledge_object, &metadata, html);
         }
         KnowledgeObject::Task(_) => {
-            render_task(knowledge_object, &metadata, html);
+            render_task(knowledge_object, &metadata, today, html);
         }
     }
 
@@ -607,6 +607,7 @@ fn render_question(
 fn render_task(
     knowledge_object: &KnowledgeObject,
     metadata: &KnowledgeObjectMetadata<'_>,
+    today: Option<NaiveDate>,
     html: &mut String,
 ) {
     let KnowledgeObject::Task(task) = knowledge_object else {
@@ -615,8 +616,19 @@ fn render_task(
 
     // Task card: open/done state on the section class and the status badge,
     // owner and due date as a definition list above the body (PRD §13.11).
+    // The overdue modifier mirrors the `task.overdue` rule (task_overdue.rs):
+    // open + due strictly before the injected date; undated renders unchanged.
     let status_str = task.status().as_str();
-    let class = format!("task task--{status_str}");
+    let overdue = task.status().is_open()
+        && task
+            .due()
+            .zip(today)
+            .is_some_and(|(due, today)| due.date() < today);
+    let class = if overdue {
+        format!("task task--{status_str} task--overdue")
+    } else {
+        format!("task task--{status_str}")
+    };
 
     render_object_section_open(knowledge_object, &class, html);
     render_object_header(knowledge_object, status_badge(metadata), html);
@@ -2303,6 +2315,63 @@ mod tests {
                 "<span class=\"ko__effective-status ko__effective-status--stale\">stale</span>"
             ),
             "verified expired claim must render stale badge; html: {html}"
+        );
+    }
+
+    /// An `open` task whose `due` is strictly before the injected date renders
+    /// the `task--overdue` section modifier, mirroring the `task.overdue`
+    /// lifecycle rule; `done` tasks, future dues, and undated renders do not.
+    #[test]
+    fn open_past_due_task_renders_overdue_modifier() {
+        use crate::domain::ast::PageAst;
+        use crate::domain::identity::PageId;
+        use crate::domain::knowledge_object::{KnowledgeObject, task::Task};
+
+        let span = dummy_span();
+        // Wide-margin fixed dates, per the task_cli.rs discipline.
+        let make_page = |id: &str, status: &str, due: &str| PageAst {
+            id: PageId::from_string(format!("docs.{id}")).expect("page id"),
+            title: None,
+            source_path: std::path::PathBuf::from(format!("docs/{id}.adoc")),
+            blocks: vec![BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Task(
+                Task::try_new(
+                    &format!("billing.{id}"),
+                    status,
+                    "support-ops",
+                    Some(due),
+                    "Update the support runbook.",
+                    std::collections::BTreeMap::new(),
+                    span.clone(),
+                )
+                .expect("valid task"),
+            )))],
+        };
+
+        let workspace = crate::domain::ast::WorkspaceAst {
+            pages: vec![
+                make_page("past-open", "open", "2021-05-20"),
+                make_page("future-open", "open", "2126-01-01"),
+                make_page("past-done", "done", "2021-05-20"),
+            ],
+        };
+        let today = chrono::NaiveDate::from_ymd_opt(2026, 6, 1).expect("valid date");
+
+        let html = HtmlRenderer.render_workspace_for_date(&workspace, Some(today));
+        assert!(
+            html.contains("task task--open task--overdue"),
+            "open past-due task must carry the overdue modifier; html: {html}"
+        );
+        assert_eq!(
+            html.matches("task--overdue").count(),
+            1,
+            "future-due and done tasks must not carry the modifier; html: {html}"
+        );
+
+        // Undated renders stay modifier-free.
+        let undated = HtmlRenderer.render_workspace_for_date(&workspace, None);
+        assert!(
+            !undated.contains("task--overdue"),
+            "renders without an injected date must not derive overdue; html: {undated}"
         );
     }
 

--- a/crates/adoc-core/src/infrastructure/render/html.rs
+++ b/crates/adoc-core/src/infrastructure/render/html.rs
@@ -359,6 +359,9 @@ fn render_knowledge_object(
         KnowledgeObject::Question(_) => {
             render_question(knowledge_object, &metadata, html);
         }
+        KnowledgeObject::Task(_) => {
+            render_task(knowledge_object, &metadata, html);
+        }
     }
 
     // V5.10: append effective_status badge after the section close tag if set.
@@ -595,6 +598,39 @@ fn render_question(
     } else {
         html.push_str("<div class=\"question__open-badge\">Open</div>\n");
     }
+
+    render_object_body(knowledge_object, html);
+    render_object_metadata(knowledge_object, metadata, html);
+    html.push_str("</section>\n");
+}
+
+fn render_task(
+    knowledge_object: &KnowledgeObject,
+    metadata: &KnowledgeObjectMetadata<'_>,
+    html: &mut String,
+) {
+    let KnowledgeObject::Task(task) = knowledge_object else {
+        unreachable!("render_task called with non-task object");
+    };
+
+    // Task card: open/done state on the section class and the status badge,
+    // owner and due date as a definition list above the body (PRD §13.11).
+    let status_str = task.status().as_str();
+    let class = format!("task task--{status_str}");
+
+    render_object_section_open(knowledge_object, &class, html);
+    render_object_header(knowledge_object, status_badge(metadata), html);
+
+    html.push_str("<div class=\"task__fields\">\n<dl>\n");
+    html.push_str("<div class=\"task__field-item\"><dt>owner</dt><dd>");
+    html.push_str(&escape_html(task.owner().as_str()));
+    html.push_str("</dd></div>\n");
+    if let Some(due) = task.due() {
+        html.push_str("<div class=\"task__field-item\"><dt>due</dt><dd>");
+        html.push_str(&escape_html(due.as_str()));
+        html.push_str("</dd></div>\n");
+    }
+    html.push_str("</dl>\n</div>\n");
 
     render_object_body(knowledge_object, html);
     render_object_metadata(knowledge_object, metadata, html);

--- a/crates/adoc-core/src/infrastructure/validate/mod.rs
+++ b/crates/adoc-core/src/infrastructure/validate/mod.rs
@@ -27,6 +27,7 @@ mod policy_active_approval;
 mod policy_review_drift;
 mod question_resolved_by;
 mod raw_html_forbidden;
+mod task_overdue;
 mod unsafe_link_forbidden;
 pub(crate) mod url_walker;
 
@@ -43,6 +44,7 @@ use policy_active_approval::PolicyActiveApproval;
 use policy_review_drift::PolicyReviewDrift;
 use question_resolved_by::QuestionResolvedBy;
 use raw_html_forbidden::RawHtmlForbidden;
+use task_overdue::TaskOverdue;
 use unsafe_link_forbidden::UnsafeLinkForbidden;
 
 use crate::domain::ast::{PageAst, WorkspaceAst};
@@ -81,11 +83,13 @@ pub(crate) fn validate_resolved_page(
     let lifecycle = KnowledgeObjectLifecycle::new(today);
     let policy_active_approval = PolicyActiveApproval::new(today);
     let drift = PolicyReviewDrift::new(today);
-    let rules: [&dyn ValidationRule; 5] = [
+    let task_overdue = TaskOverdue::new(today);
+    let rules: [&dyn ValidationRule; 6] = [
         &KnowledgeObjectBodyUnsafeLinksForbidden,
         &lifecycle,
         &policy_active_approval,
         &drift,
+        &task_overdue,
         &ClaimEvidenceQualityLowRule,
     ];
     validate_page_with_rules(page, source, &rules)

--- a/crates/adoc-core/src/infrastructure/validate/task_overdue.rs
+++ b/crates/adoc-core/src/infrastructure/validate/task_overdue.rs
@@ -1,0 +1,189 @@
+use chrono::NaiveDate;
+
+use crate::domain::ast::{BlockAst, PageAst};
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::domain::knowledge_object::KnowledgeObject;
+use crate::domain::rules::ValidationRule;
+use crate::domain::source::SourceFile;
+
+/// Validates that an `open` task is not overdue.
+///
+/// An open task whose `due` date is strictly before `today` emits a WARNING
+/// diagnostic `task.overdue` — warnings never fail the build. Tasks without a
+/// `due` field are exempt; `done` tasks are also exempt. Same injected-`today`
+/// threading as `PolicyReviewDrift`; the CLI compile path runs on the real
+/// clock, so CLI fixtures use wide-margin fixed dates.
+pub(crate) struct TaskOverdue {
+    today: NaiveDate,
+}
+
+impl TaskOverdue {
+    pub(crate) fn new(today: NaiveDate) -> Self {
+        Self { today }
+    }
+}
+
+impl ValidationRule for TaskOverdue {
+    fn check(&self, page: &PageAst, _source: &SourceFile, sink: &mut Vec<Diagnostic>) {
+        for block in &page.blocks {
+            let BlockAst::KnowledgeObject(knowledge_object) = block else {
+                continue;
+            };
+            let KnowledgeObject::Task(task) = knowledge_object.as_ref() else {
+                continue;
+            };
+
+            if !task.status().is_open() {
+                continue;
+            }
+
+            let Some(due) = task.due() else {
+                continue;
+            };
+
+            if due.date() < self.today {
+                sink.push(
+                    Diagnostic::warning(
+                        DiagnosticCode::TaskOverdue,
+                        format!(
+                            "open task `{}` is overdue (due {})",
+                            task.id().as_str(),
+                            due,
+                        ),
+                    )
+                    .with_span(task.span().clone())
+                    .with_object_id(task.id().as_str()),
+                );
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::path::PathBuf;
+
+    use chrono::NaiveDate;
+
+    use super::*;
+    use crate::domain::ast::{BlockAst, PageAst};
+    use crate::domain::diagnostic::{DiagnosticCode, Severity, SourcePosition, SourceSpan};
+    use crate::domain::identity::PageId;
+    use crate::domain::knowledge_object::KnowledgeObject;
+    use crate::domain::knowledge_object::task::Task;
+    use crate::domain::source::SourceFile;
+
+    /// Fixed test date: 2026-06-03.
+    const TODAY: NaiveDate = match NaiveDate::from_ymd_opt(2026, 6, 3) {
+        Some(d) => d,
+        None => panic!("invalid test date"),
+    };
+
+    fn span() -> SourceSpan {
+        SourceSpan {
+            file: PathBuf::from("test.adoc"),
+            start: SourcePosition {
+                line: 1,
+                column: 1,
+                offset: 0,
+            },
+            end: SourcePosition {
+                line: 1,
+                column: 8,
+                offset: 7,
+            },
+        }
+    }
+
+    fn task_block(status: &str, due: Option<&str>) -> BlockAst {
+        let task = Task::try_new(
+            "billing.update-support-runbook",
+            status,
+            "support-ops",
+            due,
+            "Update the support runbook to mention refund behavior.",
+            BTreeMap::new(),
+            span(),
+        )
+        .expect("valid task");
+        BlockAst::KnowledgeObject(Box::new(KnowledgeObject::Task(task)))
+    }
+
+    fn page(blocks: Vec<BlockAst>) -> PageAst {
+        PageAst {
+            id: PageId::from_string("docs.test".to_string()).expect("valid page id"),
+            title: None,
+            source_path: PathBuf::from("test.adoc"),
+            blocks,
+        }
+    }
+
+    fn source() -> SourceFile {
+        SourceFile::new_with_identity_path(
+            PathBuf::from("test.adoc"),
+            String::new(),
+            PathBuf::from("test.adoc"),
+        )
+    }
+
+    fn check(page: &PageAst, today: NaiveDate) -> Vec<Diagnostic> {
+        let rule = TaskOverdue::new(today);
+        let mut sink = Vec::new();
+        rule.check(page, &source(), &mut sink);
+        sink
+    }
+
+    #[test]
+    fn open_task_past_due_emits_exactly_one_overdue_warning() {
+        // due = 2026-05-20 (the PRD §13.11 example date), today = 2026-06-03.
+        let page = page(vec![task_block("open", Some("2026-05-20"))]);
+
+        let diagnostics = check(&page, TODAY);
+
+        assert_eq!(diagnostics.len(), 1, "got: {diagnostics:?}");
+        assert_eq!(diagnostics[0].code, DiagnosticCode::TaskOverdue);
+        assert_eq!(diagnostics[0].severity, Severity::Warning);
+    }
+
+    /// The pre-due half of the PRD §13.11 acceptance: with an injected `today`
+    /// before the example's `due: 2026-05-20`, no warning fires. The CLI has
+    /// no clock seam, so this behavior is pinned here at unit level.
+    #[test]
+    fn open_task_due_in_future_emits_no_diagnostic() {
+        let page = page(vec![task_block("open", Some("2026-05-20"))]);
+
+        let before_due = NaiveDate::from_ymd_opt(2026, 5, 1).expect("valid date");
+        let diagnostics = check(&page, before_due);
+
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    #[test]
+    fn open_task_without_due_emits_no_diagnostic() {
+        let page = page(vec![task_block("open", None)]);
+
+        let diagnostics = check(&page, TODAY);
+
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    #[test]
+    fn done_task_past_due_emits_no_diagnostic() {
+        let page = page(vec![task_block("done", Some("2026-05-20"))]);
+
+        let diagnostics = check(&page, TODAY);
+
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+
+    #[test]
+    fn boundary_due_equal_to_today_emits_no_diagnostic() {
+        // Strict `<` means due today is NOT overdue.
+        let page = page(vec![task_block("open", Some("2026-06-03"))]);
+
+        let diagnostics = check(&page, TODAY);
+
+        assert!(diagnostics.is_empty(), "got: {diagnostics:?}");
+    }
+}

--- a/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
@@ -17,6 +17,6 @@
       }
     },
     "object_id": "billing.unknown",
-    "help": "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question. Custom schemas are deferred."
+    "help": "supported kinds: claim, decision, glossary, warning, constraint, policy, procedure, example, agent_instruction, contradiction, source, api, observation, question, task. Custom schemas are deferred."
   }
 ]

--- a/crates/adoc-core/tests/graph.rs
+++ b/crates/adoc-core/tests/graph.rs
@@ -650,3 +650,66 @@ fn built_answered_question_emits_resolved_by_edge_to_answering_claim() {
     assert_eq!(edge["source"], "billing.trial-credit-expiration");
     assert_eq!(edge["target"], "billing.trial-credit-decision");
 }
+
+// ── V6.5.4: v4 golden task node ──────────────────────────────────────────────
+
+/// Pins the `adoc.graph.v4` task node shape: lifecycle-only `status`, owner
+/// and due in the hashed `fields` map, and no `severity`/`trust` carriers —
+/// task is born under the ADR-0039 lifecycle-only rule. The PRD §13.11
+/// `depends_on` relation emits a graph edge.
+#[test]
+fn built_task_node_is_lifecycle_only_with_owner_and_due_fields() {
+    let graph = build_graph_value(
+        "# Billing Tasks @doc(team.billing-tasks)\n\
+         \n\
+         ::claim billing.credits.refund-on-failed-persistence\n\
+         status: plain\n\
+         --\n\
+         Credits are refunded when persistence fails after generation.\n\
+         ::\n\
+         \n\
+         ::task billing.update-support-runbook\n\
+         owner: support-ops\n\
+         status: open\n\
+         due: 2026-05-20\n\
+         depends_on: billing.credits.refund-on-failed-persistence\n\
+         --\n\
+         Update the support runbook to mention refund behavior after persistence failure.\n\
+         ::\n",
+    );
+
+    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+
+    let task = graph["nodes"]
+        .as_array()
+        .expect("nodes array")
+        .iter()
+        .find(|node| node["kind"] == "task")
+        .expect("graph contains the task node");
+
+    assert_eq!(task["id"], "billing.update-support-runbook");
+    assert_eq!(task["status"], "open");
+    assert_eq!(task["fields"]["owner"], "support-ops");
+    assert_eq!(task["fields"]["due"], "2026-05-20");
+    assert!(
+        task.get("severity").is_none() && task.get("trust").is_none(),
+        "task nodes carry no severity/trust: {task}"
+    );
+    assert!(
+        task["content_hash"]
+            .as_str()
+            .expect("content_hash")
+            .starts_with("sha256:")
+    );
+
+    let has_depends_on_edge = graph["edges"]
+        .as_array()
+        .expect("edges array")
+        .iter()
+        .any(|edge| {
+            edge["relation"] == "depends_on"
+                && edge["source"] == "billing.update-support-runbook"
+                && edge["target"] == "billing.credits.refund-on-failed-persistence"
+        });
+    assert!(has_depends_on_edge, "expected the task depends_on edge");
+}

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -2204,3 +2204,40 @@ fn question_object_body_is_lexically_findable() {
     assert_eq!(record.kind, "question");
     assert_eq!(record.status.as_deref(), Some("open"));
 }
+
+// ── V6.5.4: task Knowledge Object retrieval coverage ────────────────────────
+
+/// The retrieval pipeline is kind-generic by construction: a `task` node's
+/// body is BM25-findable and its record echoes kind, lifecycle status, and
+/// the owner/due riding the fields map.
+#[test]
+fn task_object_is_lexically_findable_with_owner_and_due_fields() {
+    let mut task = retrieval_search_object(
+        "billing.update-support-runbook",
+        "task",
+        Some("open"),
+        Some("support-ops"),
+        "docs/billing-tasks.adoc",
+        "Update the support runbook to mention refund behavior after persistence failure.",
+    );
+    task["fields"]["due"] = json!("2026-05-20");
+
+    let session = load_session_from_objects(vec![task]);
+
+    let result = search(
+        &session,
+        lexical_query("support runbook refund", 3, SearchFilters::default()),
+    );
+
+    assert!(result.diagnostics.is_empty());
+    assert_eq!(search_ids(&result), vec!["billing.update-support-runbook"]);
+    let record = &result.records[0];
+    assert_eq!(record.kind, "task");
+    assert_eq!(record.status.as_deref(), Some("open"));
+    // `owner` is a typed record slot, not a generic fields entry.
+    assert_eq!(record.owner.as_deref(), Some("support-ops"));
+    assert_eq!(
+        record.fields.get("due").map(String::as_str),
+        Some("2026-05-20")
+    );
+}

--- a/crates/adoc-core/tests/support/mod.rs
+++ b/crates/adoc-core/tests/support/mod.rs
@@ -1,5 +1,6 @@
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{SystemTime, UNIX_EPOCH};
 
 pub(crate) struct TestWorkspace {
@@ -8,11 +9,20 @@ pub(crate) struct TestWorkspace {
 
 impl TestWorkspace {
     pub(crate) fn new(name: &str) -> Self {
+        // The timestamp alone is not unique: parallel tests sharing a `name`
+        // can observe the same clock reading (coarse resolution), collide on
+        // the root, and delete each other's files on Drop. Match the
+        // adoc-cli/adoc-mcp support pattern: pid + per-process counter.
+        static WORKSPACE_COUNTER: AtomicU64 = AtomicU64::new(0);
         let nonce = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .expect("clock is after epoch")
             .as_nanos();
-        let root = std::env::temp_dir().join(format!("adoc-{name}-{nonce}"));
+        let counter = WORKSPACE_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let root = std::env::temp_dir().join(format!(
+            "adoc-{name}-{}-{counter}-{nonce}",
+            std::process::id()
+        ));
         fs::create_dir_all(&root).expect("test workspace can be created");
         Self { root }
     }

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -87,6 +87,14 @@ const RESOURCES: &[AgentResource] = &[
         contents: include_str!("../../../docs/agent/v0/question-guide.md"),
     },
     AgentResource {
+        uri: "adoc://agent/v0/task-guide",
+        name: "agent-task-guide",
+        title: "Task Guide",
+        description: "V6.5.4 task objects are documentation action items; open tasks with a past due date warn task.overdue.",
+        mime_type: MARKDOWN,
+        contents: include_str!("../../../docs/agent/v0/task-guide.md"),
+    },
+    AgentResource {
         uri: "adoc://agent/v0/patch-contract",
         name: "agent-patch-contract",
         title: "Agent Patch Contract",

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -268,6 +268,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/api-guide",
         "adoc://agent/v0/observation-guide",
         "adoc://agent/v0/question-guide",
+        "adoc://agent/v0/task-guide",
         "adoc://agent/v0/patch-contract",
         "adoc://agent/v0/patch-apply-guide",
         "adoc://agent/v0/project-status-guide",

--- a/docs/ROADMAP-V7.md
+++ b/docs/ROADMAP-V7.md
@@ -187,7 +187,7 @@ Scope:
 - Required: `id`, `status`, `owner`, `body` — task is the only kind beyond policy requiring `owner` unconditionally (a task without an owner is a wish). Statuses: closed `open | done`. Optional: `due` (date). Existing relation fields (`depends_on`, ...) work unchanged, matching the PRD example.
 - New clock-dependent lifecycle warning `task.overdue` (WARNING) when an `open` task's `due` is before today — same `today` threading as the policy review rule (`policy_review_drift.rs` is the pattern; the task rule is its sibling in `infrastructure/validate/`), same wide-margin fixture-date discipline. Because `task.overdue` is clock-dependent by design, the wide-margin fixed past date (2020–2024 range) is the stability mechanism, exactly as it is for `schema.policy_review_overdue`. Note the seam: only the unit-level rule takes an injected `today`; the CLI compile path runs on the real clock with no injection point, so CLI fixtures use fixed past dates to fire the warning and far-future dates (the pilot's 2120/2125 `expires_at` precedent) to stay quiet.
 - HTML renders a task card with owner, due date, and open/done state (`render_task`).
-- `FieldChange::Due`; diagnostics `schema.task_missing_owner`, `schema.task_missing_status`, `schema.task_invalid_status`, `task.overdue`.
+- `FieldChange::Due`; diagnostics `schema.task_missing_owner`, `schema.task_missing_status`, `schema.task_invalid_status`, `schema.task_invalid_due`, `task.overdue`.
 
 The acceptance fixture is the PRD §13.11 example, verbatim:
 

--- a/docs/agent/v0/task-guide.md
+++ b/docs/agent/v0/task-guide.md
@@ -1,0 +1,60 @@
+# AgentDoc Task Guide
+
+`task` Knowledge Objects are documentation action items (PRD §13.11, V6.5.4). Each one names a piece of documentation work — what needs doing, who owns it, and optionally by when.
+
+## What a task object is
+
+A `task` object records tracked documentation work: the action in prose (the body), the accountable party (`owner`), the lifecycle state (`open` or `done`), and an optional `due` date. A task without an owner is a wish — `owner` is required unconditionally, the only kind beyond `policy` where that holds.
+
+## Required fields
+
+| Field | Notes |
+|-------|-------|
+| `id` | Object ID — dot-separated lowercase identifier, e.g. `billing.update-support-runbook` |
+| `status` | Closed set: `open`, `done` |
+| `owner` | Non-empty accountable party |
+| `body` | Non-empty prose describing the action |
+
+Missing or invalid values emit `schema.task_missing_status` / `schema.task_invalid_status` / `schema.task_missing_owner`.
+
+## Optional fields
+
+| Field | Notes |
+|-------|-------|
+| `due` | `YYYY-MM-DD` date the task is due |
+| `depends_on`, `supersedes`, `related_to` | Standard relation fields, unchanged |
+
+## The overdue warning
+
+An `open` task whose `due` date is strictly before today emits the `task.overdue` WARNING at check/build time. Warnings never fail the build — the task stays valid; the warning is a nudge to complete the work and set `status: done`, or move the `due` date. `done` tasks and tasks without `due` are exempt. The check is clock-dependent: it runs against the local calendar date.
+
+## Authoring syntax
+
+```
+::task billing.update-support-runbook
+owner: support-ops
+status: open
+due: 2026-05-20
+depends_on: billing.credits.refund-on-failed-persistence
+--
+Update the support runbook to mention refund behavior after persistence failure.
+::
+```
+
+## Wire surface
+
+`task` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+
+- `kind: "task"` — the node-level kind discriminant
+- `status` — the lifecycle status (`open` / `done`, lifecycle-only per ADR-0039)
+- `fields["owner"]` — the accountable party
+- `fields["due"]` — the due date, when authored
+- `body` — the prose action description
+
+Relation fields emit graph edges as usual (`depends_on` and friends). Tasks fold into the retrieval surface (`adoc.retrieval.v0`) like any other Knowledge Object.
+
+## How to cite task objects in answers
+
+- **Reference by Object ID.** Cite the task object's ID when reporting documentation work status.
+- **Report the state as stored.** Surface `status`, `owner`, and `due` exactly as recorded; do not infer completion.
+- **Respect the lifecycle.** An `open` task is pending work, not a statement of fact — never cite a task body as verified knowledge.

--- a/docs/agent/v0/task-guide.md
+++ b/docs/agent/v0/task-guide.md
@@ -15,7 +15,7 @@ A `task` object records tracked documentation work: the action in prose (the bod
 | `owner` | Non-empty accountable party |
 | `body` | Non-empty prose describing the action |
 
-Missing or invalid values emit `schema.task_missing_status` / `schema.task_invalid_status` / `schema.task_missing_owner`.
+Missing or invalid values emit `schema.task_missing_status` / `schema.task_invalid_status` / `schema.task_missing_owner` / `schema.task_invalid_due`.
 
 ## Optional fields
 

--- a/docs/agent/v0/task-guide.md
+++ b/docs/agent/v0/task-guide.md
@@ -26,7 +26,7 @@ Missing or invalid values emit `schema.task_missing_status` / `schema.task_inval
 
 ## The overdue warning
 
-An `open` task whose `due` date is strictly before today emits the `task.overdue` WARNING at check/build time. Warnings never fail the build — the task stays valid; the warning is a nudge to complete the work and set `status: done`, or move the `due` date. `done` tasks and tasks without `due` are exempt. The check is clock-dependent: it runs against the local calendar date.
+An `open` task whose `due` date is strictly before today emits the `task.overdue` WARNING at check/build time. Warnings never fail the build — the task stays valid; the warning is a nudge to complete the work and set `status: done`, or move the `due` date. `done` tasks and tasks without `due` are exempt. The check is clock-dependent: it runs against the local calendar date. The rendered HTML mirrors the same rule: an open past-due task's card carries a `task--overdue` class alongside `task--open`.
 
 ## Authoring syntax
 


### PR DESCRIPTION
## Summary

Adds the `task` kind (PRD §13.11) — documentation action items — completing the four V6.5 kind slices and, with them, the fifteen-kind PRD §13 vocabulary. Follows the established per-kind vertical pattern (ROADMAP-V7.md §V6.5.4).

- **Aggregate**: `domain/knowledge_object/task.rs` — required `id`, `status`, `owner`, `body` (the only kind besides policy requiring `owner` unconditionally — "a task without an owner is a wish"); closed status enum `open | done`; optional `due` date; existing relation fields (`depends_on`, …) work unchanged
- **Lifecycle**: new clock-dependent warning `task.overdue` (WARNING) when an `open` task's `due` is past — `infrastructure/validate/task_overdue.rs`, sibling of `policy_review_drift.rs`, with the injected-`today` seam at unit level and wide-margin fixed fixture dates (2020–2024 past / 2126 future) on the CLI path, which has no clock seam
- **Pipeline**: `BlockKind`/`RESOLVERS`/draft wiring, `adoc.graph.v4` emission (lifecycle-only status; owner/due in the hashed fields map), task card HTML (owner, due, open/done), `FieldChange::Due` diff/review coverage, BM25 retrieval
- **Agent docs**: `docs/agent/v0/task-guide.md`, published via MCP resources

## Diagnostics

`schema.task_missing_owner`, `schema.task_missing_status`, `schema.task_invalid_status`, `schema.task_invalid_due`, `task.overdue`

## Review fixes included

- **Dedicated `schema.task_invalid_due` wire code** for present-but-malformed `due:` values — previously mapped to the generic `schema.missing_field`, semantically wrong on the machine contract; siblings all mint dedicated invalid-value codes (`schema.observation_invalid_observed_at`, `schema.policy_invalid_effective_at`, `schema.api_invalid_method`)
- **Help text single-sourced** into the `default_help()` arms — the emit-site consts had silently diverged from the `default_help` wording added in the same slice

## Acceptance (asserted in `crates/adoc-cli/tests/task_cli.rs` + core tests)

- PRD §13.11 example (verbatim fixture) exits 0 with exactly one `task.overdue` warning (its fixed `due:` is past; warnings never fail the build) and the `depends_on` edge in graph JSON
- Far-future `due` (2126) → exit 0, warning-free on any clock
- Missing `owner:` → `error[schema.task_missing_owner]`; missing/invalid status covered
- Wide-margin past `due` (2021) → exactly one `task.overdue` warning
- `due: someday` → `error[schema.task_invalid_due]`
- Pre-due behavior pinned at unit level with injected `today`; v4 golden task node in `graph.rs`; standard diff (`FieldChange::Due`) and retrieval assertions

## Test plan

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` — all green (57 suites, 0 failures)

Completes the four V6.5 kind slices (with #92 observation and #93 question) — V6.5.5 (full-vocabulary pilot) follows on main.