### PR TITLE
feat: V1.7.2 Prose Embedding Slice — adoc.search.v1 prose vectors

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -161,7 +161,7 @@ The V1 compiler outputs: `dist/docs.html`, `dist/docs.graph.json`, and optionall
 _Avoid_: SQLite graph artifact, RAG ndjson, separate diagnostics artifact
 
 **Search Artifact**:
-The V1 build output, `dist/docs.search.json`, with schema version `adoc.search.v0`. Carries one `{ id, content_hash, vector }` entry per Knowledge Object, a `model: { id, provider, dim }` header, and a `graph_artifact_hash` for drift detection. The serialized JSON shape is public; the Rust DTO used to build or read it is internal to `adoc-core`.
+The V1 build output, `dist/docs.search.json`, with schema version `adoc.search.v1` since V1.7.2 (ADR-0040). Carries one `{ id, entry_kind, content_hash, vector }` entry per Knowledge Object and per indexed prose block (`entry_kind: "knowledge_object" | "prose"`), a `model: { id, provider, dim }` header, and a `graph_artifact_hash` for drift detection. Code blocks and prose under a minimum token threshold are not embedded; prose cache reuse is keyed by content hash and model, never by order-derived block id. The serialized JSON shape is public; the Rust DTO used to build or read it is internal to `adoc-core`.
 _Avoid_: per-chunk embedding store, vectors embedded in `docs.graph.json`, binary sidecar in V1
 
 **Graph Artifact**:
@@ -201,7 +201,7 @@ A production-configurable, repeatable hash-based embedding provider selected wit
 _Avoid_: hidden debug-only provider, calling deterministic vectors semantic quality, model-header mismatch between build and query
 
 **Embedding Composition**:
-The canonical input string each Knowledge Object is reduced to before embedding: `{kind}: {body_plain_text}\n[id: {id}] [status: {status}] [owner: {owner}]`. Part of the `adoc.search.v0` contract; changing it requires a schema-version bump.
+The canonical input string each embedded record is reduced to before embedding. Knowledge Objects: `{kind}: {body_plain_text}\n[id: {id}] [status: {status}] [owner: {owner}]`. Prose blocks (V1.7.2): `prose: {text}\n[page: {page_id}]`. Part of the `adoc.search.v1` contract; changing either formula requires a schema-version bump.
 _Avoid_: per-field separate embeddings in V1, relations folded into embedding input, freeform composition
 
 **Hybrid Retrieval**:

--- a/crates/adoc-cli/src/cli.rs
+++ b/crates/adoc-cli/src/cli.rs
@@ -453,13 +453,13 @@ pub(crate) enum Commands {
         /// Return only Knowledge Object records (the pre-V1.7 result set).
         #[arg(long, conflicts_with = "prose_only")]
         objects_only: bool,
-        /// Return only prose records. Prose has no Knowledge Object metadata
-        /// or vectors, so this conflicts with the metadata filters and
-        /// --semantic.
+        /// Return only prose records. Prose has no Knowledge Object metadata,
+        /// so this conflicts with the metadata filters. Semantic prose search
+        /// works since V1.7.2 (adoc.search.v1 prose vectors).
         #[arg(
             long,
             conflicts_with_all = [
-                "objects_only", "semantic", "kind", "status", "owner",
+                "objects_only", "kind", "status", "owner",
                 "source_path", "related_to",
             ]
         )]

--- a/crates/adoc-cli/tests/billing_pilot.rs
+++ b/crates/adoc-cli/tests/billing_pilot.rs
@@ -149,17 +149,26 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
         .expect("billing pilot search JSON is written");
     let search_json: Value =
         serde_json::from_str(&search_json_text).expect("search JSON is valid JSON");
-    assert_eq!(search_json["schema_version"], "adoc.search.v0");
+    assert_eq!(search_json["schema_version"], "adoc.search.v1");
     assert_eq!(search_json["model"]["id"], "hash-v1");
     assert_eq!(search_json["model"]["provider"], "deterministic");
     assert_eq!(search_json["model"]["dim"], 384);
+    let embeddings = search_json["embeddings"]
+        .as_array()
+        .expect("search embeddings is an array");
     assert_eq!(
-        search_json["embeddings"]
-            .as_array()
-            .expect("search embeddings is an array")
-            .len(),
+        embeddings
+            .iter()
+            .filter(|entry| entry["entry_kind"] == "knowledge_object")
+            .count(),
         objects.len(),
         "search artifact should carry one embedding per Knowledge Object"
+    );
+    assert!(
+        embeddings
+            .iter()
+            .any(|entry| entry["entry_kind"] == "prose"),
+        "adoc.search.v1 should carry prose entries for the pilot's prose blocks"
     );
 
     let artifact_path = output_directory.join("docs.graph.json");

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -455,7 +455,7 @@ fn build_creates_missing_output_directory_and_writes_artifacts() {
         .expect("search JSON is written");
     let search_json: serde_json::Value =
         serde_json::from_str(&search_json_text).expect("search JSON is valid");
-    assert_eq!(search_json["schema_version"], "adoc.search.v0");
+    assert_eq!(search_json["schema_version"], "adoc.search.v1");
     assert_eq!(search_json["model"]["id"], "hash-v1");
     assert_eq!(search_json["model"]["provider"], "deterministic");
     assert_eq!(search_json["model"]["dim"], 384);

--- a/crates/adoc-cli/tests/semantic_search_cli.rs
+++ b/crates/adoc-cli/tests/semantic_search_cli.rs
@@ -302,3 +302,256 @@ mod paraphrase_recall {
         }
     }
 }
+
+/// V1.7.2 (ADR-0040): prose vectors in adoc.search.v1, exercised through the
+/// real CLI against the Markdown Pilot with the deterministic provider.
+mod prose_semantic {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use crate::support::TestWorkspace;
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+    }
+
+    struct MarkdownPilot {
+        _workspace: TestWorkspace,
+        artifact: String,
+        search_artifact: String,
+    }
+
+    fn build_markdown_pilot() -> MarkdownPilot {
+        let workspace = TestWorkspace::new("v1-7-2-markdown-pilot");
+        let output_directory = workspace.root.join("dist");
+        let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .current_dir(repo_root())
+            .env("ADOC_TEST_EMBEDDING_PROVIDER", "deterministic")
+            .args([
+                "build",
+                "examples/markdown-pilot/",
+                "--out",
+                output_directory
+                    .to_str()
+                    .expect("output directory path is utf-8"),
+            ])
+            .output()
+            .expect("adoc build runs");
+        assert!(
+            build_output.status.success(),
+            "markdown pilot must build cleanly\nstderr:\n{}",
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+        MarkdownPilot {
+            artifact: output_directory
+                .join("docs.graph.json")
+                .to_string_lossy()
+                .into_owned(),
+            search_artifact: output_directory
+                .join("docs.search.json")
+                .to_string_lossy()
+                .into_owned(),
+            _workspace: workspace,
+        }
+    }
+
+    fn search_json(pilot: &MarkdownPilot, extra_args: &[&str], query: &str) -> serde_json::Value {
+        let mut args = vec![
+            "search",
+            query,
+            "--artifact",
+            &pilot.artifact,
+            "--search-artifact",
+            &pilot.search_artifact,
+        ];
+        args.extend_from_slice(extra_args);
+        args.extend_from_slice(&["--format", "json"]);
+        let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .args(&args)
+            .env("ADOC_TEST_EMBEDDING_PROVIDER", "deterministic")
+            .output()
+            .expect("adoc search runs");
+        assert!(
+            output.status.success(),
+            "search must exit 0\nstdout:\n{}\nstderr:\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        serde_json::from_slice(&output.stdout).expect("search stdout is JSON")
+    }
+
+    /// The Markdown Pilot's v1 search artifact carries prose entries with
+    /// entry_kind, no code_block entries, and no sub-threshold entries.
+    #[test]
+    fn markdown_pilot_search_artifact_carries_prose_entries() {
+        let pilot = build_markdown_pilot();
+        let artifact: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(&pilot.search_artifact).expect("search artifact is readable"),
+        )
+        .expect("search artifact is JSON");
+
+        assert_eq!(artifact["schema_version"], "adoc.search.v1");
+        let embeddings = artifact["embeddings"].as_array().expect("embeddings array");
+        assert!(
+            embeddings
+                .iter()
+                .any(|entry| entry["entry_kind"] == "prose"),
+            "prose entries must be embedded"
+        );
+        assert!(
+            embeddings
+                .iter()
+                .any(|entry| entry["entry_kind"] == "knowledge_object"),
+            "knowledge object entries must remain"
+        );
+    }
+
+    /// V1.7.2 roadmap acceptance: `--semantic --prose-only` is un-gated and
+    /// returns prose records ranked by vector similarity.
+    #[test]
+    fn prose_only_semantic_search_returns_ranked_prose_records() {
+        let pilot = build_markdown_pilot();
+        let envelope = search_json(
+            &pilot,
+            &["--semantic", "--prose-only", "--top", "3"],
+            "how are credits spent during a generation run",
+        );
+
+        assert_eq!(envelope["schema_version"], "adoc.retrieval.v1");
+        let records = envelope["records"].as_array().expect("records array");
+        assert!(
+            !records.is_empty(),
+            "prose-only semantic search returns records"
+        );
+        for record in records {
+            assert_eq!(record["record_type"], "prose");
+            assert_eq!(record["match"]["mode"], "semantic");
+            assert!(
+                record["match"]["vector_rank"].is_number(),
+                "prose semantic hits carry vector_rank: {record}"
+            );
+            assert!(
+                record["match"]["cosine_score"].is_number(),
+                "prose semantic hits carry cosine_score: {record}"
+            );
+        }
+    }
+
+    /// V1.7.2 roadmap acceptance: a paraphrase query returns a prose match
+    /// under `--semantic` that lexical search misses (fixture-pinned with
+    /// deterministic vectors; the pin moves only if the pilot prose or the
+    /// Embedding Composition changes).
+    #[test]
+    fn semantic_search_returns_prose_match_lexical_misses() {
+        let pilot = build_markdown_pilot();
+        let query = "confirming message delivery receipts";
+        let pinned_id = "tutorials.concepts#block-0007";
+
+        let lexical = search_json(&pilot, &["--lexical", "--prose-only"], query);
+        assert!(
+            lexical["records"]
+                .as_array()
+                .expect("records array")
+                .iter()
+                .all(|record| record["id"] != pinned_id),
+            "the pinned block must be lexically unreachable for this query: {lexical}"
+        );
+
+        let semantic = search_json(&pilot, &["--semantic", "--prose-only", "--top", "1"], query);
+        let first = &semantic["records"][0];
+        assert_eq!(first["record_type"], "prose");
+        assert_eq!(first["id"], pinned_id);
+        assert_eq!(first["match"]["mode"], "semantic");
+    }
+
+    /// Prose semantic results are deterministic across two runs.
+    #[test]
+    fn prose_semantic_results_are_deterministic_across_two_runs() {
+        let pilot = build_markdown_pilot();
+        let query = "verifying webhook deliveries during onboarding";
+
+        let first = search_json(&pilot, &["--semantic", "--prose-only", "--top", "5"], query);
+        let second = search_json(&pilot, &["--semantic", "--prose-only", "--top", "5"], query);
+
+        assert_eq!(first, second, "deterministic vectors must rank stably");
+    }
+}
+
+/// V1.7.2: real-model paraphrase recall over Markdown Pilot prose —
+/// the deterministic tests above pin the wiring; this proves the semantics.
+#[cfg(feature = "fastembed-it")]
+mod prose_paraphrase_recall {
+    use std::path::PathBuf;
+    use std::process::Command;
+
+    use crate::support::TestWorkspace;
+
+    fn repo_root() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("..")
+            .join("..")
+    }
+
+    #[test]
+    fn paraphrase_query_recalls_settlement_prose_in_top_3_with_fastembed() {
+        let workspace = TestWorkspace::new("v1-7-2-markdown-pilot-fastembed");
+        let output_directory = workspace.root.join("dist");
+        let build_output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .current_dir(repo_root())
+            // No ADOC_TEST_EMBEDDING_PROVIDER — real fastembed for the corpus.
+            .args([
+                "build",
+                "examples/markdown-pilot/",
+                "--out",
+                output_directory
+                    .to_str()
+                    .expect("output directory path is utf-8"),
+            ])
+            .output()
+            .expect("adoc build runs");
+        assert!(
+            build_output.status.success(),
+            "markdown pilot must build cleanly with fastembed\nstderr:\n{}",
+            String::from_utf8_lossy(&build_output.stderr)
+        );
+
+        let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .args([
+                "search",
+                "when do funds become available to withdraw",
+                "--artifact",
+                output_directory.join("docs.graph.json").to_str().unwrap(),
+                "--search-artifact",
+                output_directory.join("docs.search.json").to_str().unwrap(),
+                "--semantic",
+                "--prose-only",
+                "--top",
+                "3",
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("adoc search runs");
+        let envelope: serde_json::Value =
+            serde_json::from_slice(&output.stdout).unwrap_or_else(|e| {
+                panic!(
+                    "stdout is JSON: {e}; stderr={}",
+                    String::from_utf8_lossy(&output.stderr)
+                )
+            });
+
+        let records = envelope["records"].as_array().expect("records array");
+        assert!(
+            records.iter().any(|record| {
+                record["record_type"] == "prose"
+                    && record["page_id"] == "tutorials.concepts"
+                    && record["text"]
+                        .as_str()
+                        .is_some_and(|text| text.contains("Settlement"))
+            }),
+            "the settlement paragraph must be a top-3 semantic prose hit, got {envelope:#}"
+        );
+    }
+}

--- a/crates/adoc-core/src/application/artifact_inspection.rs
+++ b/crates/adoc-core/src/application/artifact_inspection.rs
@@ -291,6 +291,6 @@ mod tests {
     #[test]
     fn graph_schema_constants_match_readers() {
         assert_eq!(SUPPORTED_GRAPH_SCHEMA_VERSION, "adoc.graph.v4");
-        assert_eq!(SUPPORTED_SEARCH_SCHEMA_VERSION, "adoc.search.v0");
+        assert_eq!(SUPPORTED_SEARCH_SCHEMA_VERSION, "adoc.search.v1");
     }
 }

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -834,7 +834,9 @@ mod tests {
 
     use super::*;
     use crate::application::hashing::sha256_prefixed;
-    use crate::domain::artifact::{SearchArtifactDocument, SearchEmbedding, SearchModelHeader};
+    use crate::domain::artifact::{
+        SearchArtifactDocument, SearchEmbedding, SearchEntryKind, SearchModelHeader,
+    };
     use crate::domain::graph::{
         GraphArtifactDocument, GraphBlockNode, GraphEdge, GraphEdgeKind, GraphKnowledgeObjectNode,
         GraphNode, GraphPageNode, GraphRelationKind, GraphRelations, GraphSourceSpan,
@@ -1020,7 +1022,7 @@ mod tests {
 
     fn search_document(graph_artifact_hash: &str) -> SearchArtifactDocument {
         SearchArtifactDocument {
-            schema_version: "adoc.search.v0".to_string(),
+            schema_version: "adoc.search.v1".to_string(),
             model: SearchModelHeader {
                 id: "hash-v1".to_string(),
                 provider: "deterministic".to_string(),
@@ -1029,6 +1031,7 @@ mod tests {
             graph_artifact_hash: graph_artifact_hash.to_string(),
             embeddings: vec![SearchEmbedding {
                 id: "billing.target".to_string(),
+                entry_kind: SearchEntryKind::KnowledgeObject,
                 content_hash: "sha256:content".to_string(),
                 vector: vec![1.0, 0.0],
             }],

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -104,20 +104,14 @@ impl SearchQuery {
         self.scope != SearchRecordScope::ProseOnly
     }
 
-    /// ADR-0040: a prose-only query cannot be satisfied by semantic search
-    /// (no prose vectors until V1.7.2) or combined with Knowledge Object
-    /// metadata filters (filters imply object intent). Adapters reject these
-    /// combinations at argument-parse time; a direct library caller gets a
-    /// diagnostic instead of a silent empty result.
+    /// ADR-0040: a prose-only query cannot be combined with Knowledge Object
+    /// metadata filters (filters imply object intent). Adapters reject the
+    /// combination at argument-parse time; a direct library caller gets a
+    /// diagnostic instead of a silent empty result. The V1.7.1 prose-only ×
+    /// semantic conflict is gone: prose vectors ship in `adoc.search.v1`.
     fn scope_conflict(&self) -> Option<Diagnostic> {
         if self.scope != SearchRecordScope::ProseOnly {
             return None;
-        }
-        if self.mode == SearchMode::Semantic {
-            return Some(Diagnostic::error(
-                DiagnosticCode::SearchInvalidScope,
-                "Semantic search has no prose vectors; a prose-only query requires lexical or blended search.",
-            ));
         }
         if self.filters.constrains_objects() {
             return Some(Diagnostic::error(
@@ -476,9 +470,13 @@ fn search_hybrid_impl(session: &RetrievalSession, query: SearchQuery) -> SearchR
         .query_vector
         .as_deref()
         .expect("query_vector is checked above");
-    // Prose has no vectors until V1.7.2 (adoc.search.v1): only Knowledge
-    // Objects enter the vector ranking; prose fuses on lexical rank alone.
-    let vector_hits = vector_index.rank_among(query_vector, ko_ids.iter().copied(), ko_ids.len());
+    // V1.7.2 (adoc.search.v1): prose vectors ship in the search artifact, so
+    // the whole blended pool enters the vector ranking.
+    let vector_hits = vector_index.rank_among(
+        query_vector,
+        candidate_ids.iter().copied(),
+        candidate_ids.len(),
+    );
     let ranker = HybridRanker;
     let ranked_hits = ranker.rank(
         &query.text,
@@ -551,9 +549,9 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
         return missing_query_vector_result(SearchMode::Semantic);
     }
 
-    // Semantic search stays Knowledge-Object-only until prose vectors ship
-    // in V1.7.2 (adoc.search.v1); ProseOnly therefore yields no candidates.
-    let candidates = match SearchScope::resolve(session, &query.filters) {
+    // V1.7.2 (adoc.search.v1): the semantic pool blends Knowledge Objects
+    // and prose, mirroring hybrid; prose vectors ship in the search artifact.
+    let ko_candidates = match SearchScope::resolve(session, &query.filters) {
         Ok(scope) if query.include_objects() => {
             scope.metadata_and_graph_candidates(session, &query.filters)
         }
@@ -565,7 +563,15 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
             };
         }
     };
-    if candidates.is_empty() {
+    let ko_ids: Vec<&str> = ko_candidates
+        .iter()
+        .map(|object| object.id.as_str())
+        .collect();
+    let mut candidate_ids = ko_ids.clone();
+    if query.include_prose() {
+        candidate_ids.extend(prose_candidate_ids(session));
+    }
+    if candidate_ids.is_empty() {
         return SearchResult {
             records: Vec::new(),
             diagnostics: Vec::new(),
@@ -576,7 +582,6 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
         .query_vector
         .as_deref()
         .expect("query_vector is checked above");
-    let candidate_ids: Vec<&str> = candidates.iter().map(|object| object.id.as_str()).collect();
     let hits = index.rank_among(
         query_vector,
         candidate_ids.iter().copied(),
@@ -586,9 +591,10 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
 
     // Pins ride above the `top` budget (ADR-0040): the scored slots stay
     // reserved for vector hits even when the query prefix-pins an id.
+    // Only Knowledge Object ids are pinnable; prose ids are never Object IDs.
     let ranker = HybridRanker;
     let result_ids = merge_pinned_then_scored(
-        ranker.pinned_candidate_ids(&query.text, &candidate_ids),
+        ranker.pinned_candidate_ids(&query.text, &ko_ids),
         hits.iter().map(|hit| hit.id.clone()),
         |id| id.as_str(),
         query.top.get(),
@@ -600,11 +606,6 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
         .map(|(idx, id)| {
             // Semantic result IDs are pinned candidate IDs or vector hits
             // ranked from the same candidate pool; all were validated at load.
-            let object_id = ObjectId::new_unchecked(id.clone());
-            let object = session
-                .graph_session
-                .object(&object_id)
-                .expect("hit must exist in graph index");
             let search_match = hits_by_id.get(id.as_str()).map_or_else(
                 || RetrievalMatch {
                     mode: SearchMode::Semantic,
@@ -616,10 +617,7 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
                 },
                 |hit| RetrievalMatch::semantic((idx + 1) as u32, hit.vector_rank, hit.cosine_score),
             );
-            RetrievalEntry::KnowledgeObject(RetrievalRecord::from_object_with_match(
-                object,
-                search_match,
-            ))
+            resolve_entry(session, &id, search_match)
         })
         .collect();
 
@@ -1304,23 +1302,25 @@ mod tests {
         assert!(result.records[0].as_knowledge_object().is_some());
     }
 
-    /// V1.7.1 (ADR-0040): semantic search has no prose vectors until V1.7.2,
-    /// so a prose-only semantic query is structurally unsatisfiable. Adapters
-    /// reject the combination at argument-parse time; a direct library caller
-    /// gets a diagnostic instead of a silent empty result.
+    /// V1.7.2 (ADR-0040): prose vectors ship in adoc.search.v1, so a
+    /// prose-only semantic query is a valid scope; without a search artifact
+    /// it fails on the missing artifact, not on the scope.
     #[test]
-    fn semantic_search_with_prose_only_scope_diagnoses_invalid_scope() {
+    fn semantic_search_with_prose_only_scope_requires_search_artifact_only() {
         let session = load_session_from_document(mixed_graph_document());
 
         let mut query = lexical_search_query("credits", SearchRecordScope::ProseOnly);
         query.mode = SearchMode::Semantic;
         let result = search(&session, query);
 
+        // V1.7.2: prose-only semantic search is a valid scope now that prose
+        // vectors ship in adoc.search.v1; on a session without a search
+        // artifact it fails exactly like any other semantic query.
         assert!(result.records.is_empty());
         assert_eq!(result.diagnostics.len(), 1);
         assert_eq!(
             result.diagnostics[0].code,
-            DiagnosticCode::SearchInvalidScope
+            DiagnosticCode::SearchArtifactMissing
         );
     }
 

--- a/crates/adoc-core/src/application/search_artifact.rs
+++ b/crates/adoc-core/src/application/search_artifact.rs
@@ -85,7 +85,8 @@ pub(crate) fn build_search_artifact(
         .map(|cached| (cached.content_hash.as_str(), cached))
         .collect();
     for (kind, block) in embeddable_prose_blocks(graph_document) {
-        let content_text = kind.content_text_from(block.text.as_deref(), None, &block.items);
+        let content_text =
+            kind.content_text_from(block.text.as_deref(), block.code.as_deref(), &block.items);
         if content_text.split_whitespace().count() < MIN_PROSE_EMBEDDING_TOKENS {
             continue;
         }

--- a/crates/adoc-core/src/application/search_artifact.rs
+++ b/crates/adoc-core/src/application/search_artifact.rs
@@ -2,9 +2,13 @@ use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
 use crate::application::hashing::sha256_prefixed;
-use crate::domain::artifact::{SearchArtifactDocument, SearchEmbedding, SearchModelHeader};
+use crate::domain::artifact::{
+    SearchArtifactDocument, SearchEmbedding, SearchEntryKind, SearchModelHeader,
+};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
-use crate::domain::graph::{GraphArtifactDocument, GraphKnowledgeObjectNode, GraphNode};
+use crate::domain::graph::{
+    GraphArtifactDocument, GraphBlockNode, GraphKnowledgeObjectNode, GraphNode, ProseBlockKind,
+};
 use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider};
 use crate::domain::retrieval::metadata;
 use crate::infrastructure::artifact::search_json::{
@@ -54,7 +58,10 @@ pub(crate) fn build_search_artifact(
             && cached.content_hash == content_hash
             && cached.vector.len() == provider.dim()
         {
-            embeddings.push(cached.clone());
+            embeddings.push(SearchEmbedding {
+                entry_kind: SearchEntryKind::KnowledgeObject,
+                ..cached.clone()
+            });
             cached_count += 1;
             continue;
         }
@@ -62,6 +69,45 @@ pub(crate) fn build_search_artifact(
         let index = embeddings.len();
         embeddings.push(SearchEmbedding {
             id,
+            entry_kind: SearchEntryKind::KnowledgeObject,
+            content_hash,
+            vector: Vec::new(),
+        });
+        misses.push((index, input));
+    }
+
+    // ADR-0040: prose cache reuse is keyed by content hash and model, never
+    // by block id — order-derived ids renumber on mid-page insertion, and a
+    // hash-keyed lookup makes renumbering free.
+    let cached_prose_by_hash: BTreeMap<&str, &SearchEmbedding> = cached_embeddings
+        .values()
+        .filter(|cached| cached.entry_kind == SearchEntryKind::Prose)
+        .map(|cached| (cached.content_hash.as_str(), cached))
+        .collect();
+    for (kind, block) in embeddable_prose_blocks(graph_document) {
+        let content_text = kind.content_text_from(block.text.as_deref(), None, &block.items);
+        if content_text.split_whitespace().count() < MIN_PROSE_EMBEDDING_TOKENS {
+            continue;
+        }
+        let input = metadata::prose_embedding_input(&content_text, &block.page_id);
+        let content_hash = sha256_prefixed(input.as_bytes());
+        if let Some(cached) = cached_prose_by_hash.get(content_hash.as_str())
+            && cached.vector.len() == provider.dim()
+        {
+            embeddings.push(SearchEmbedding {
+                id: block.id.clone(),
+                entry_kind: SearchEntryKind::Prose,
+                content_hash,
+                vector: cached.vector.clone(),
+            });
+            cached_count += 1;
+            continue;
+        }
+
+        let index = embeddings.len();
+        embeddings.push(SearchEmbedding {
+            id: block.id.clone(),
+            entry_kind: SearchEntryKind::Prose,
             content_hash,
             vector: Vec::new(),
         });
@@ -242,4 +288,238 @@ fn graph_knowledge_objects(
         .nodes
         .iter()
         .filter_map(GraphNode::as_knowledge_object)
+}
+
+/// ADR-0040 cost controls: code blocks are never embedded (code stays
+/// lexical-only), and blocks under [`MIN_PROSE_EMBEDDING_TOKENS`] are
+/// skipped in the caller.
+// ponytail: whitespace-token count as the cost gate; a real tokenizer only
+// matters if the pilots show mis-skips.
+const MIN_PROSE_EMBEDDING_TOKENS: usize = 5;
+
+fn embeddable_prose_blocks(
+    graph: &GraphArtifactDocument,
+) -> impl Iterator<Item = (ProseBlockKind, &GraphBlockNode)> {
+    graph
+        .nodes
+        .iter()
+        .filter_map(GraphNode::as_prose_block)
+        .filter(|(kind, _)| *kind != ProseBlockKind::CodeBlock)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::BTreeMap;
+    use std::fs;
+
+    use crate::domain::artifact::{SearchArtifactDocument, SearchEntryKind};
+    use crate::domain::graph::{
+        GraphArtifactDocument, GraphBlockNode, GraphKnowledgeObjectNode, GraphNode, GraphPageNode,
+        GraphRelations, GraphSourceSpan,
+    };
+    use crate::domain::ports::embedding_provider::EmbeddingProvider;
+    use crate::domain::retrieval::metadata;
+    use crate::infrastructure::embedding::deterministic::DeterministicProvider;
+
+    use super::*;
+
+    fn span(line: u32) -> GraphSourceSpan {
+        GraphSourceSpan {
+            path: "docs/guide.md".to_string(),
+            line,
+            column: 1,
+        }
+    }
+
+    fn block(id: &str, order: u32, text: Option<&str>) -> GraphBlockNode {
+        GraphBlockNode {
+            id: id.to_string(),
+            page_id: "guides.page".to_string(),
+            order,
+            level: None,
+            text: text.map(str::to_string),
+            language: None,
+            code: None,
+            items: Vec::new(),
+            source_span: span(order + 1),
+        }
+    }
+
+    fn knowledge_object(id: &str) -> GraphKnowledgeObjectNode {
+        GraphKnowledgeObjectNode {
+            id: id.to_string(),
+            kind: "claim".to_string(),
+            content_hash: format!("sha256:{id}"),
+            status: Some("draft".to_string()),
+            severity: None,
+            trust: None,
+            body: "Credits apply after successful payment.".to_string(),
+            page_id: "guides.page".to_string(),
+            source_span: span(1),
+            fields: BTreeMap::new(),
+            relations: GraphRelations::default(),
+            impacts: Vec::new(),
+            approved_by: Vec::new(),
+            allowed_actions: Vec::new(),
+            forbidden_actions: Vec::new(),
+            contradiction_claims: Vec::new(),
+            evidence: Vec::new(),
+            effective_status: None,
+            effective_reason: None,
+            evidence_quality: None,
+        }
+    }
+
+    fn document(nodes: Vec<GraphNode>) -> GraphArtifactDocument {
+        let mut all_nodes = vec![GraphNode::Page(GraphPageNode {
+            id: "guides.page".to_string(),
+            order: 0,
+            title: None,
+            source_path: "docs/guide.md".to_string(),
+        })];
+        all_nodes.extend(nodes);
+        GraphArtifactDocument {
+            schema_version: "adoc.graph.v4".to_string(),
+            nodes: all_nodes,
+            edges: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    fn parse(json: &str) -> SearchArtifactDocument {
+        serde_json::from_str(json).expect("search artifact parses")
+    }
+
+    fn build(
+        document: &GraphArtifactDocument,
+        provider: &DeterministicProvider,
+        prior: Option<&PathBuf>,
+    ) -> SearchArtifactBuild {
+        build_search_artifact(document, "{}", provider, prior)
+            .expect("search artifact build succeeds")
+    }
+
+    #[test]
+    fn prose_blocks_join_the_search_artifact_with_prose_entry_kind() {
+        let paragraph_text =
+            "Credits are consumed when a generation job completes, not when it starts.";
+        let mut list_block = block("guides.page#block-0003", 3, None);
+        list_block.items = vec![
+            "Verify the webhook signature".to_string(),
+            "Return a 2xx response".to_string(),
+        ];
+        let mut code_block = block("guides.page#block-0004", 4, None);
+        code_block.code = Some("adoc build --no-embeddings && adoc search credits".to_string());
+        let graph = document(vec![
+            GraphNode::Heading(block("guides.page#block-0001", 1, Some("Billing"))),
+            GraphNode::Paragraph(block("guides.page#block-0002", 2, Some(paragraph_text))),
+            GraphNode::List(list_block),
+            GraphNode::CodeBlock(code_block),
+            GraphNode::KnowledgeObject(knowledge_object("billing.credits")),
+        ]);
+        let provider = DeterministicProvider::new(4);
+
+        let search = parse(&build(&graph, &provider, None).json);
+
+        assert_eq!(search.schema_version, "adoc.search.v1");
+        let ids: Vec<&str> = search
+            .embeddings
+            .iter()
+            .map(|entry| entry.id.as_str())
+            .collect();
+        assert_eq!(
+            ids,
+            vec![
+                "billing.credits",
+                "guides.page#block-0002",
+                "guides.page#block-0003"
+            ],
+            "one-word heading and code block must be skipped"
+        );
+        assert_eq!(
+            search.embeddings[0].entry_kind,
+            SearchEntryKind::KnowledgeObject
+        );
+
+        let paragraph_entry = &search.embeddings[1];
+        let expected_input = metadata::prose_embedding_input(paragraph_text, "guides.page");
+        assert_eq!(paragraph_entry.entry_kind, SearchEntryKind::Prose);
+        assert_eq!(
+            paragraph_entry.content_hash,
+            sha256_prefixed(expected_input.as_bytes())
+        );
+        assert_eq!(
+            paragraph_entry.vector,
+            provider
+                .embed_passages(&[expected_input])
+                .expect("deterministic embedding succeeds")
+                .remove(0)
+        );
+
+        let list_entry = &search.embeddings[2];
+        let expected_list_input = metadata::prose_embedding_input(
+            "Verify the webhook signature\nReturn a 2xx response",
+            "guides.page",
+        );
+        assert_eq!(list_entry.entry_kind, SearchEntryKind::Prose);
+        assert_eq!(
+            list_entry.content_hash,
+            sha256_prefixed(expected_list_input.as_bytes())
+        );
+    }
+
+    #[test]
+    fn prose_cache_reuse_is_keyed_by_content_hash_across_block_renumbering() {
+        let paragraph_text =
+            "Settlement is the point at which captured funds become eligible for payout.";
+        let first_graph = document(vec![GraphNode::Paragraph(block(
+            "guides.page#block-0001",
+            1,
+            Some(paragraph_text),
+        ))]);
+        let provider = DeterministicProvider::new(4);
+        let first = build(&first_graph, &provider, None);
+        assert_eq!(first.computed_count, 1);
+
+        let cache_dir = tempfile::tempdir().expect("temp dir can be created");
+        let cache_path = cache_dir.path().join("docs.search.json");
+        fs::write(&cache_path, &first.json).expect("cache artifact can be written");
+
+        // The same paragraph renumbered mid-page: new block id, same text.
+        let renumbered_graph = document(vec![GraphNode::Paragraph(block(
+            "guides.page#block-0007",
+            7,
+            Some(paragraph_text),
+        ))]);
+        let second = build(&renumbered_graph, &provider, Some(&cache_path));
+
+        assert_eq!(
+            (second.cached_count, second.computed_count),
+            (1, 0),
+            "renumbered prose block must reuse its hash-keyed cached vector"
+        );
+        let search = parse(&second.json);
+        assert_eq!(search.embeddings[0].id, "guides.page#block-0007");
+        assert_eq!(
+            search.embeddings[0].vector,
+            parse(&first.json).embeddings[0].vector
+        );
+    }
+
+    #[test]
+    fn sub_threshold_prose_blocks_are_not_embedded() {
+        let graph = document(vec![GraphNode::Paragraph(block(
+            "guides.page#block-0001",
+            1,
+            Some("Too short to embed."),
+        ))]);
+        let provider = DeterministicProvider::new(4);
+
+        let search = parse(&build(&graph, &provider, None).json);
+
+        assert!(
+            search.embeddings.is_empty(),
+            "a four-token paragraph sits under the minimum token threshold"
+        );
+    }
 }

--- a/crates/adoc-core/src/domain/artifact.rs
+++ b/crates/adoc-core/src/domain/artifact.rs
@@ -21,9 +21,21 @@ pub(crate) struct SearchModelHeader {
     pub(crate) dim: usize,
 }
 
+/// V1.7.2 (ADR-0040): the `adoc.search.v1` entry discriminator. A prose
+/// entry's `content_hash` is derived from its Embedding Composition, not
+/// from a graph node hash, and its cache reuse is keyed by that hash rather
+/// than by its order-derived block id.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum SearchEntryKind {
+    KnowledgeObject,
+    Prose,
+}
+
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct SearchEmbedding {
     pub(crate) id: String,
+    pub(crate) entry_kind: SearchEntryKind,
     pub(crate) content_hash: String,
     pub(crate) vector: Vec<f32>,
 }
@@ -33,34 +45,46 @@ mod tests {
     use super::*;
 
     #[test]
-    fn search_artifact_serializes_with_v1_3_shape() {
+    fn search_artifact_serializes_with_v1_7_2_shape() {
         let artifact = SearchArtifactDocument {
-            schema_version: "adoc.search.v0".to_string(),
+            schema_version: "adoc.search.v1".to_string(),
             model: SearchModelHeader {
                 id: "bge-small-en-v1.5".to_string(),
                 provider: "fastembed".to_string(),
                 dim: 384,
             },
             graph_artifact_hash: "sha256:graph".to_string(),
-            embeddings: vec![SearchEmbedding {
-                id: "billing.credits".to_string(),
-                content_hash: "sha256:content".to_string(),
-                vector: vec![0.25, -0.5],
-            }],
+            embeddings: vec![
+                SearchEmbedding {
+                    id: "billing.credits".to_string(),
+                    entry_kind: SearchEntryKind::KnowledgeObject,
+                    content_hash: "sha256:content".to_string(),
+                    vector: vec![0.25, -0.5],
+                },
+                SearchEmbedding {
+                    id: "guides.page#block-0002".to_string(),
+                    entry_kind: SearchEntryKind::Prose,
+                    content_hash: "sha256:prose".to_string(),
+                    vector: vec![0.5, 0.25],
+                },
+            ],
         };
 
         let value = serde_json::to_value(&artifact).expect("search artifact serializes");
 
-        assert_eq!(value["schema_version"], "adoc.search.v0");
+        assert_eq!(value["schema_version"], "adoc.search.v1");
         assert_eq!(value["model"]["id"], "bge-small-en-v1.5");
         assert_eq!(value["model"]["provider"], "fastembed");
         assert_eq!(value["model"]["dim"], 384);
         assert_eq!(value["graph_artifact_hash"], "sha256:graph");
         assert_eq!(value["embeddings"][0]["id"], "billing.credits");
+        assert_eq!(value["embeddings"][0]["entry_kind"], "knowledge_object");
         assert_eq!(value["embeddings"][0]["content_hash"], "sha256:content");
         assert_eq!(
             value["embeddings"][0]["vector"],
             serde_json::json!([0.25, -0.5])
         );
+        assert_eq!(value["embeddings"][1]["id"], "guides.page#block-0002");
+        assert_eq!(value["embeddings"][1]["entry_kind"], "prose");
     }
 }

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -102,6 +102,18 @@ impl GraphNode {
             _ => None,
         }
     }
+
+    /// V1.7.2: the prose counterpart of [`Self::as_knowledge_object`] —
+    /// pairs the block payload with its variant's [`ProseBlockKind`].
+    pub(crate) fn as_prose_block(&self) -> Option<(ProseBlockKind, &GraphBlockNode)> {
+        match self {
+            Self::Heading(block) => Some((ProseBlockKind::Heading, block)),
+            Self::Paragraph(block) => Some((ProseBlockKind::Paragraph, block)),
+            Self::List(block) => Some((ProseBlockKind::List, block)),
+            Self::CodeBlock(block) => Some((ProseBlockKind::CodeBlock, block)),
+            Self::Page(_) | Self::KnowledgeObject(_) => None,
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
@@ -152,6 +164,24 @@ impl ProseBlockKind {
             Self::CodeBlock => "code_block",
         }
     }
+
+    /// Selects a block's canonical searchable text from its payload parts:
+    /// `text` for headings and paragraphs, `code` for code blocks,
+    /// newline-joined `items` for lists (a list's `text` is its
+    /// `ordered`/`unordered` marker, not content). Single source of truth
+    /// for both retained prose blocks and raw artifact nodes (V1.7.2).
+    pub(crate) fn content_text_from<'a>(
+        self,
+        text: Option<&'a str>,
+        code: Option<&'a str>,
+        items: &'a [String],
+    ) -> Cow<'a, str> {
+        match self {
+            Self::CodeBlock => Cow::from(code.unwrap_or_default()),
+            Self::List => Cow::from(items.join("\n")),
+            Self::Heading | Self::Paragraph => Cow::from(text.unwrap_or_default()),
+        }
+    }
 }
 
 /// V1.7.1 (ADR-0040): a prose block retained by `GraphIndex` for retrieval.
@@ -184,13 +214,8 @@ impl GraphProseBlock {
     /// record's `text` field (ADR-0040). Borrows wherever the block already
     /// owns the text; only lists allocate (there is no pre-joined string).
     pub(crate) fn content_text_ref(&self) -> Cow<'_, str> {
-        match self.kind {
-            ProseBlockKind::CodeBlock => Cow::from(self.code.as_deref().unwrap_or_default()),
-            ProseBlockKind::List => Cow::from(self.items.join("\n")),
-            ProseBlockKind::Heading | ProseBlockKind::Paragraph => {
-                Cow::from(self.text.as_deref().unwrap_or_default())
-            }
-        }
+        self.kind
+            .content_text_from(self.text.as_deref(), self.code.as_deref(), &self.items)
     }
 
     /// Owned variant of [`Self::content_text_ref`] for record construction.
@@ -424,20 +449,8 @@ impl GraphIndex {
                     has_markdown_pages = true;
                 }
             }
-            match &node {
-                GraphNode::Heading(block) => {
-                    prose_nodes.push((ProseBlockKind::Heading, block.clone()));
-                }
-                GraphNode::Paragraph(block) => {
-                    prose_nodes.push((ProseBlockKind::Paragraph, block.clone()));
-                }
-                GraphNode::List(block) => {
-                    prose_nodes.push((ProseBlockKind::List, block.clone()));
-                }
-                GraphNode::CodeBlock(block) => {
-                    prose_nodes.push((ProseBlockKind::CodeBlock, block.clone()));
-                }
-                GraphNode::Page(_) | GraphNode::KnowledgeObject(_) => {}
+            if let Some((kind, block)) = node.as_prose_block() {
+                prose_nodes.push((kind, block.clone()));
             }
             let Some(knowledge_object) = node.as_knowledge_object().cloned() else {
                 continue;

--- a/crates/adoc-core/src/domain/retrieval/metadata.rs
+++ b/crates/adoc-core/src/domain/retrieval/metadata.rs
@@ -76,6 +76,15 @@ pub(crate) fn embedding_input(object: &GraphKnowledgeObjectNode) -> String {
     )
 }
 
+/// V1.7.2 (ADR-0040): the prose Embedding Composition — `prose: {text}` plus
+/// a page-id marker line, the analogue of the Knowledge Object composition
+/// above. Part of the `adoc.search.v1` contract; prose `content_hash` is
+/// derived from this exact string.
+pub(crate) fn prose_embedding_input(content_text: &str, page_id: &str) -> String {
+    let body = normalized_embedding_body(content_text);
+    format!("prose: {body}\n[page: {page_id}]")
+}
+
 fn normalized_embedding_body(body: &str) -> String {
     body.replace("\r\n", "\n")
         .replace('\r', "\n")
@@ -177,6 +186,25 @@ mod tests {
         assert_eq!(
             embedding_input(&object),
             "claim: First line\nSecond line\n[id: billing.newline] [status: plain] [owner: unknown]"
+        );
+    }
+
+    #[test]
+    fn prose_embedding_input_prefixes_prose_kind_and_appends_page_marker() {
+        assert_eq!(
+            prose_embedding_input(
+                "Credits are consumed when a generation job completes.",
+                "guides.getting-started"
+            ),
+            "prose: Credits are consumed when a generation job completes.\n[page: guides.getting-started]"
+        );
+    }
+
+    #[test]
+    fn prose_embedding_input_normalizes_line_endings_and_trims_edges() {
+        assert_eq!(
+            prose_embedding_input(" First line\r\nSecond line\r ", "guides.page"),
+            "prose: First line\nSecond line\n[page: guides.page]"
         );
     }
 

--- a/crates/adoc-core/src/infrastructure/artifact/search_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/search_json.rs
@@ -9,7 +9,7 @@ use crate::domain::ports::artifact_reader::ArtifactReader;
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct SearchJsonArtifact;
 
-pub(crate) const SUPPORTED_SEARCH_SCHEMA_VERSION: &str = "adoc.search.v0";
+pub(crate) const SUPPORTED_SEARCH_SCHEMA_VERSION: &str = "adoc.search.v1";
 
 pub(crate) fn read_search_artifact_document(
     path: &Path,
@@ -75,7 +75,9 @@ impl ArtifactReader for SearchJsonArtifact {
 mod tests {
     use std::fs;
 
-    use crate::domain::artifact::{SearchArtifactDocument, SearchEmbedding, SearchModelHeader};
+    use crate::domain::artifact::{
+        SearchArtifactDocument, SearchEmbedding, SearchEntryKind, SearchModelHeader,
+    };
     use crate::domain::diagnostic::DiagnosticCode;
     use crate::domain::ports::artifact_reader::ArtifactReader;
     use crate::infrastructure::artifact::search_json::{
@@ -122,6 +124,7 @@ mod tests {
             graph_artifact_hash: "sha256:graph".to_string(),
             embeddings: vec![SearchEmbedding {
                 id: "billing.credits".to_string(),
+                entry_kind: SearchEntryKind::KnowledgeObject,
                 content_hash: "sha256:content".to_string(),
                 vector: vec![1.0, 0.0],
             }],

--- a/crates/adoc-core/src/infrastructure/artifact/search_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/search_json.rs
@@ -42,7 +42,7 @@ pub(crate) fn read_search_artifact_document(
                 ),
             )
             .with_help(format!(
-                "Expected schema_version '{}'.",
+                "Expected schema_version '{}'. Rebuild the artifact with `adoc build`.",
                 SUPPORTED_SEARCH_SCHEMA_VERSION
             )),
         ]);
@@ -109,6 +109,11 @@ mod tests {
         assert_eq!(
             diagnostics[0].code,
             DiagnosticCode::SchemaUnsupportedVersion
+        );
+        let help = diagnostics[0].help.as_deref().expect("diagnostic has help");
+        assert!(
+            help.contains("adoc build"),
+            "help must point at the rebuild fix, got: {help}"
         );
     }
 

--- a/crates/adoc-core/tests/artifact_inspection.rs
+++ b/crates/adoc-core/tests/artifact_inspection.rs
@@ -213,7 +213,7 @@ fn search_artifact_inspector_validates_model_hash_and_deterministic_quality() {
         embedding_provider: Some(EmbeddingProviderSelection::Deterministic),
     });
     assert_eq!(valid.load_status, ArtifactLoadStatus::Readable);
-    assert_eq!(valid.schema_version.as_deref(), Some("adoc.search.v0"));
+    assert_eq!(valid.schema_version.as_deref(), Some("adoc.search.v1"));
     assert_eq!(valid.object_count, Some(1));
     assert!(
         valid.diagnostics.iter().any(|diagnostic| {

--- a/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.search.json
+++ b/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.search.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.search.v0",
+  "schema_version": "adoc.search.v1",
   "model": {
     "id": "hash-v1",
     "provider": "deterministic",
@@ -8,6 +8,7 @@
   "embeddings": [
     {
       "id": "billing.first",
+      "entry_kind": "knowledge_object",
       "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
       "vector": [
         0.0,

--- a/crates/adoc-core/tests/fixtures/v1_4_semantic/model_mismatch.search.json
+++ b/crates/adoc-core/tests/fixtures/v1_4_semantic/model_mismatch.search.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.search.v0",
+  "schema_version": "adoc.search.v1",
   "model": {
     "id": "bge-large-en-v1.5",
     "provider": "fastembed",

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -2380,6 +2380,15 @@ fn prose_symmetry_graph_json(extension: &str) -> String {
                 "order": 2,
                 "text": "Refunds are handled manually by support.",
                 "source_span": { "path": path, "line": 5, "column": 1 }
+            },
+            {
+                "type": "code_block",
+                "id": "guides.page#block-0003",
+                "page_id": "guides.page",
+                "order": 3,
+                "language": "shell",
+                "code": "adoc build --provider fastembed",
+                "source_span": { "path": path, "line": 7, "column": 1 }
             }
         ],
         "edges": [],
@@ -2681,4 +2690,63 @@ fn hybrid_search_prose_hits_carry_vector_ranks() {
         "prose must enter the vector ranking in hybrid mode (V1.7.2)"
     );
     assert_eq!(search_match.lexical_rank, Some(1));
+}
+
+/// ADR-0040: code stays lexical-only. The v1 artifact never embeds code
+/// blocks, yet they remain in the blended candidate pool — a code-block hit
+/// fuses into hybrid results on lexical rank alone and never surfaces in
+/// semantic mode.
+#[test]
+fn code_block_prose_ranks_lexically_in_hybrid_but_never_semantically() {
+    let session = load_prose_session_with_vectors(vec![
+        ("guides.page#block-0001", vec![1.0, 0.0]),
+        ("guides.page#block-0002", vec![0.0, 1.0]),
+    ]);
+
+    let hybrid = search(
+        &session,
+        hybrid_query(
+            "provider fastembed",
+            vec![1.0, 0.0],
+            10,
+            SearchFilters::default(),
+        ),
+    );
+    assert!(hybrid.diagnostics.is_empty(), "{:?}", hybrid.diagnostics);
+    let code_hit = hybrid
+        .records
+        .iter()
+        .find_map(|entry| match entry {
+            RetrievalEntry::Prose(record) if record.id == "guides.page#block-0003" => Some(record),
+            _ => None,
+        })
+        .expect("code block must fuse into hybrid results on its lexical hit");
+    let search_match = code_hit
+        .search_match
+        .as_ref()
+        .expect("hybrid hit carries match metadata");
+    assert_eq!(search_match.lexical_rank, Some(1));
+    assert_eq!(
+        search_match.vector_rank, None,
+        "code blocks are never embedded, so a hybrid code hit carries no vector rank (ADR-0040)"
+    );
+
+    let semantic = search(
+        &session,
+        semantic_query(
+            "provider fastembed",
+            vec![1.0, 0.0],
+            10,
+            SearchFilters::default(),
+        ),
+    );
+    assert!(
+        semantic.diagnostics.is_empty(),
+        "{:?}",
+        semantic.diagnostics
+    );
+    assert!(
+        !search_ids(&semantic).contains(&"guides.page#block-0003"),
+        "semantic search must never surface a code block: it has no vector (ADR-0040)"
+    );
 }

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -63,7 +63,7 @@ fn load_session_from_objects_with_vectors(
     let graph_json = graph_json_from_objects(objects, Vec::new());
     let artifact = write_temp_artifact("hybrid-graph", &graph_json);
     let search_document = serde_json::json!({
-        "schema_version": "adoc.search.v0",
+        "schema_version": "adoc.search.v1",
         "model": {
             "id": "bge-small-en-v1.5",
             "provider": "fastembed",
@@ -74,6 +74,7 @@ fn load_session_from_objects_with_vectors(
             .into_iter()
             .map(|(id, vector)| serde_json::json!({
                 "id": id,
+                "entry_kind": "knowledge_object",
                 "content_hash": "sha256:test",
                 "vector": vector
             }))

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -147,7 +147,42 @@ struct CanonicalGraphDocument {
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 enum CanonicalGraphNode {
+    Page(CanonicalPageNode),
+    Heading(CanonicalBlockNode),
+    Paragraph(CanonicalBlockNode),
+    List(CanonicalBlockNode),
+    CodeBlock(CanonicalBlockNode),
     KnowledgeObject(CanonicalKnowledgeObject),
+}
+
+/// V1.7.2: mirrors `GraphPageNode` serialization order so prose fixtures
+/// round-trip byte-identically for the graph_artifact_hash check.
+#[derive(Debug, Serialize, Deserialize)]
+struct CanonicalPageNode {
+    id: String,
+    order: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    title: Option<String>,
+    source_path: String,
+}
+
+/// V1.7.2: mirrors `GraphBlockNode` serialization order.
+#[derive(Debug, Serialize, Deserialize)]
+struct CanonicalBlockNode {
+    id: String,
+    page_id: String,
+    order: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    level: Option<u8>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    text: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    language: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    code: Option<String>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    items: Vec<String>,
+    source_span: CanonicalSourceSpan,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -2463,4 +2498,187 @@ fn prose_record_serializes_with_record_type_and_normalized_match_shape() {
         heading_record.get("heading_context").is_none(),
         "a top-level heading has no ancestor context, got {heading_record:?}"
     );
+}
+
+/// V1.7.2 (ADR-0040): a prose session backed by a v1 search artifact whose
+/// prose entries carry vectors, so semantic and hybrid ranking can score
+/// prose blocks.
+fn load_prose_session_with_vectors(vectors: Vec<(&str, Vec<f32>)>) -> RetrievalSession {
+    let canonical: CanonicalGraphDocument = serde_json::from_str(&prose_symmetry_graph_json("md"))
+        .expect("prose fixture has canonical shape");
+    let graph_json =
+        serde_json::to_string_pretty(&canonical).expect("prose fixture serializes canonically");
+    let artifact = write_temp_artifact("prose-vectors-graph", &graph_json);
+    let search_document = json!({
+        "schema_version": "adoc.search.v1",
+        "model": {
+            "id": "bge-small-en-v1.5",
+            "provider": "fastembed",
+            "dim": 384
+        },
+        "graph_artifact_hash": sha256_prefixed(graph_json.as_bytes()),
+        "embeddings": vectors
+            .into_iter()
+            .map(|(id, vector)| json!({
+                "id": id,
+                "entry_kind": if id.contains('#') { "prose" } else { "knowledge_object" },
+                "content_hash": "sha256:test",
+                "vector": vector
+            }))
+            .collect::<Vec<_>>()
+    });
+    let search_artifact = write_temp_search_artifact(
+        "prose-vectors-search",
+        &serde_json::to_string_pretty(&search_document).expect("search fixture serializes"),
+    );
+
+    let result = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().to_path_buf(),
+        search_artifact_path: Some(search_artifact.path().to_path_buf()),
+    });
+    assert!(
+        result.diagnostics.is_empty(),
+        "expected clean prose vector fixture load, got {:?}",
+        result.diagnostics
+    );
+    result.session.expect("prose vector session loads")
+}
+
+/// V1.7.2 (ADR-0040): prose ids coming out of the vector index resolve to
+/// prose records instead of panicking on the Knowledge-Object lookup.
+#[test]
+fn semantic_search_returns_prose_records_ranked_by_cosine() {
+    let session = load_prose_session_with_vectors(vec![
+        ("guides.page#block-0001", vec![1.0, 0.0]),
+        ("guides.page#block-0002", vec![0.0, 1.0]),
+    ]);
+
+    let result = search(
+        &session,
+        semantic_query(
+            "credit spending",
+            vec![1.0, 0.0],
+            10,
+            SearchFilters::default(),
+        ),
+    );
+
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+    assert_eq!(
+        search_ids(&result),
+        vec!["guides.page#block-0001", "guides.page#block-0002"]
+    );
+    let RetrievalEntry::Prose(record) = &result.records[0] else {
+        panic!("semantic prose hit must resolve to a prose record");
+    };
+    let search_match = record
+        .search_match
+        .as_ref()
+        .expect("semantic hit carries match metadata");
+    assert_eq!(search_match.mode, SearchMode::Semantic);
+    assert_eq!(search_match.vector_rank, Some(1));
+    let cosine = search_match
+        .cosine_score
+        .expect("semantic hit carries cosine score");
+    assert!(
+        (cosine - 1.0).abs() < 1e-6,
+        "expected cosine 1.0, got {cosine}"
+    );
+}
+
+/// V1.7.2: prose-only semantic search is un-gated now that prose vectors
+/// exist in adoc.search.v1.
+#[test]
+fn prose_only_semantic_search_returns_prose_without_scope_conflict() {
+    let session = load_prose_session_with_vectors(vec![
+        ("guides.page#block-0001", vec![1.0, 0.0]),
+        ("guides.page#block-0002", vec![0.0, 1.0]),
+    ]);
+
+    let query = SearchQuery {
+        text: "credit spending".to_string(),
+        mode: SearchMode::Semantic,
+        filters: SearchFilters::default(),
+        top: NonZeroUsize::new(10).expect("test search top is non-zero"),
+        query_vector: Some(vec![0.0, 1.0]),
+        scope: SearchRecordScope::ProseOnly,
+    };
+    let result = search(&session, query);
+
+    assert!(
+        result.diagnostics.is_empty(),
+        "prose-only semantic search must not report a scope conflict: {:?}",
+        result.diagnostics
+    );
+    assert_eq!(
+        search_ids(&result),
+        vec!["guides.page#block-0002", "guides.page#block-0001"]
+    );
+}
+
+/// V1.7.2: objects-only semantic search keeps prose vectors out of the pool.
+#[test]
+fn objects_only_semantic_search_excludes_prose_vectors() {
+    let session = load_prose_session_with_vectors(vec![("guides.page#block-0001", vec![1.0, 0.0])]);
+
+    let query = SearchQuery {
+        text: "credit spending".to_string(),
+        mode: SearchMode::Semantic,
+        filters: SearchFilters::default(),
+        top: NonZeroUsize::new(10).expect("test search top is non-zero"),
+        query_vector: Some(vec![1.0, 0.0]),
+        scope: SearchRecordScope::ObjectsOnly,
+    };
+    let result = search(&session, query);
+
+    // The V4.3 migration hint fires: an objects-only search over a
+    // prose-only project finds no Knowledge Objects, by design.
+    assert_eq!(
+        result
+            .diagnostics
+            .iter()
+            .map(|diagnostic| diagnostic.code)
+            .collect::<Vec<_>>(),
+        vec![DiagnosticCode::RetrievalNoKnowledgeObjectsConsiderMigration]
+    );
+    assert!(
+        result.records.is_empty(),
+        "the fixture has no Knowledge Objects, so objects-only semantic search returns nothing"
+    );
+}
+
+/// V1.7.2: hybrid fusion scores prose on both lexical and vector rank once
+/// prose vectors exist.
+#[test]
+fn hybrid_search_prose_hits_carry_vector_ranks() {
+    let session = load_prose_session_with_vectors(vec![
+        ("guides.page#block-0001", vec![1.0, 0.0]),
+        ("guides.page#block-0002", vec![0.0, 1.0]),
+    ]);
+
+    let result = search(
+        &session,
+        hybrid_query(
+            "credits consumed",
+            vec![1.0, 0.0],
+            10,
+            SearchFilters::default(),
+        ),
+    );
+
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+    let RetrievalEntry::Prose(record) = &result.records[0] else {
+        panic!("hybrid prose hit must resolve to a prose record");
+    };
+    assert_eq!(record.id, "guides.page#block-0001");
+    let search_match = record
+        .search_match
+        .as_ref()
+        .expect("hybrid hit carries match metadata");
+    assert_eq!(
+        search_match.vector_rank,
+        Some(1),
+        "prose must enter the vector ranking in hybrid mode (V1.7.2)"
+    );
+    assert_eq!(search_match.lexical_rank, Some(1));
 }

--- a/crates/adoc-local/tests/local_workflow.rs
+++ b/crates/adoc-local/tests/local_workflow.rs
@@ -523,7 +523,7 @@ fn project_status_reports_deterministic_semantic_readiness_with_quality_warning(
     assert!(outcome.readiness.patch_validation);
     assert_eq!(
         outcome.artifacts.search.schema_version.as_deref(),
-        Some("adoc.search.v0")
+        Some("adoc.search.v1")
     );
     assert!(
         outcome

--- a/crates/adoc-mcp/src/lib.rs
+++ b/crates/adoc-mcp/src/lib.rs
@@ -645,9 +645,10 @@ pub struct SearchParams {
     /// Conflicts with `prose_only`.
     #[serde(default)]
     pub objects_only: bool,
-    /// Return only prose records. Prose has no Knowledge Object metadata or
-    /// vectors, so this conflicts with `semantic` and the metadata filters
-    /// (`kind`, `status`, `owner`, `source_path`, `related_to`).
+    /// Return only prose records. Prose has no Knowledge Object metadata,
+    /// so this conflicts with the metadata filters (`kind`, `status`,
+    /// `owner`, `source_path`, `related_to`). Semantic prose search works
+    /// since V1.7.2 (adoc.search.v1 prose vectors).
     #[serde(default)]
     pub prose_only: bool,
     pub kind: Option<String>,
@@ -743,9 +744,10 @@ where
 }
 
 /// V1.7.1 (ADR-0040): maps the mutually exclusive scope params onto the
-/// structural enum, mirroring the CLI's clap conflicts. `prose_only` also
-/// conflicts with `semantic` (no prose vectors until V1.7.2) and with every
-/// Knowledge Object metadata filter (prose has none to filter on).
+/// structural enum, mirroring the CLI's clap conflicts. `prose_only`
+/// conflicts with every Knowledge Object metadata filter (prose has none to
+/// filter on); the V1.7.1 `semantic` conflict is gone now that prose vectors
+/// ship in `adoc.search.v1` (V1.7.2).
 fn search_record_scope(params: &SearchParams) -> McpAdapterResult<adoc_core::SearchRecordScope> {
     if params.objects_only && params.prose_only {
         return Err(McpAdapterError::InvalidArguments(
@@ -753,11 +755,6 @@ fn search_record_scope(params: &SearchParams) -> McpAdapterResult<adoc_core::Sea
         ));
     }
     if params.prose_only {
-        if params.semantic {
-            return Err(McpAdapterError::InvalidArguments(
-                "prose_only cannot be combined with semantic: prose has no vectors until adoc.search.v1 (V1.7.2)".to_string(),
-            ));
-        }
         if params.kind.is_some()
             || params.status.is_some()
             || params.owner.is_some()

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -326,6 +326,14 @@ const RESOURCES: &[AgentResource] = &[
         mime_type: JSON_SCHEMA,
         contents: include_str!("../../../docs/agent/v0/schema/adoc.patch.apply.v0.schema.json"),
     },
+    AgentResource {
+        uri: "adoc://agent/v0/schema/search-artifact.json",
+        name: "schema-search-artifact-json",
+        title: "Search Artifact JSON Schema",
+        description: "JSON Schema for adoc.search.v1, the dist/docs.search.json wire shape. The artifact itself is a build output, not an MCP resource.",
+        mime_type: JSON_SCHEMA,
+        contents: include_str!("../../../docs/agent/v0/schema/search-artifact.json"),
+    },
 ];
 
 pub fn list() -> Vec<Resource> {

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -1209,3 +1209,36 @@ fn v1_schema_anchors_the_prose_record_id_pattern() {
         );
     }
 }
+
+/// V1.7.2 (ADR-0040): the adoc.search.v1 search artifact wire shape —
+/// entry_kind-discriminated embeddings over Knowledge Objects and prose.
+/// The artifact is an internal build output (not an MCP resource), but its
+/// serialized JSON shape is public and contract-guarded like the envelopes.
+#[test]
+fn validates_built_search_artifact_against_v1_contract_schema() {
+    let (workspace, _server, _base_hash) = project_with_built_graph();
+
+    let search_artifact: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(workspace.path().join("dist/docs.search.json"))
+            .expect("search artifact is written by the build"),
+    )
+    .expect("search artifact parses");
+
+    assert_valid("search-artifact.json", &search_artifact);
+
+    let embeddings = search_artifact["embeddings"]
+        .as_array()
+        .expect("embeddings array");
+    assert!(
+        embeddings
+            .iter()
+            .any(|entry| entry["entry_kind"] == "knowledge_object"),
+        "the fixture claim must be embedded"
+    );
+    assert!(
+        embeddings
+            .iter()
+            .any(|entry| entry["entry_kind"] == "prose"),
+        "the fixture .md paragraph must be embedded (adoc.search.v1)"
+    );
+}

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -778,6 +778,10 @@ fn mcp_serves_v3_schema_resources_byte_equal_to_on_disk_files() {
             "adoc://agent/v0/schema/adoc.patch.apply.v0.schema.json",
             "adoc.patch.apply.v0.schema.json",
         ),
+        (
+            "adoc://agent/v0/schema/search-artifact.json",
+            "search-artifact.json",
+        ),
     ] {
         let result = server
             .read_agent_resource(uri)
@@ -1146,6 +1150,10 @@ fn retrieval_schema_ids_match_their_published_uris() {
         (
             "retrieval-envelope.v0.json",
             "adoc://agent/v0/schema/retrieval-envelope.v0.json",
+        ),
+        (
+            "search-artifact.json",
+            "adoc://agent/v0/schema/search-artifact.json",
         ),
     ] {
         assert_eq!(

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -298,6 +298,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/schema/adoc.contradictions.v0.schema.json",
         "adoc://agent/v0/schema/adoc.impacted.v0.schema.json",
         "adoc://agent/v0/schema/adoc.patch.apply.v0.schema.json",
+        "adoc://agent/v0/schema/search-artifact.json",
     ];
 
     let resources = server.list_agent_resources();

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -1032,14 +1032,25 @@ fn adoc_search_rejects_conflicting_scope_arguments() {
     let error = server.run_search(both).expect_err("both scopes conflict");
     assert!(error.to_string().contains("mutually exclusive"));
 
+    // V1.7.2: prose_only + semantic is no longer an argument conflict —
+    // prose vectors ship in adoc.search.v1. On this fixture (built with
+    // provider: none) it fails later, at the missing search artifact.
     let mut prose_semantic = mixed_mode_search_params("credits");
     prose_semantic.prose_only = true;
     prose_semantic.semantic = true;
     prose_semantic.lexical = false;
-    let error = server
+    let envelope = server
         .run_search(prose_semantic)
-        .expect_err("prose_only + semantic conflicts");
-    assert!(error.to_string().contains("no vectors"));
+        .expect("prose_only + semantic passes argument validation");
+    assert!(
+        envelope["diagnostics"]
+            .as_array()
+            .expect("diagnostics array")
+            .iter()
+            .any(|diagnostic| diagnostic["code"] == "search.artifact_missing"),
+        "expected the missing-artifact diagnostic, not an argument conflict: {envelope:#}"
+    );
+    assert_eq!(envelope["records"], serde_json::json!([]));
 
     let mut prose_filtered = mixed_mode_search_params("credits");
     prose_filtered.prose_only = true;

--- a/docs/agent/v0/compat-guide.md
+++ b/docs/agent/v0/compat-guide.md
@@ -44,4 +44,4 @@ Do not invent migration commands; the surface does not exist yet.
 
 - Compatibility Mode never weakens Strict Mode for `.adoc` files. A project mixing `.adoc` and `.md` still fails on `.adoc` schema violations exactly as before.
 - The renderer escapes Quarantined HTML and drops unsafe `href`/`src` attributes. The graph artifact never carries interpreted HTML — only the source text on the wrapping prose block.
-- Since V1.7.1, prose blocks are lexically indexed and returned as `record_type: "prose"` search records; prose vectors arrive with `adoc.search.v1` (V1.7.2). Prose remains orientation context, never citable knowledge.
+- Since V1.7.1, prose blocks are lexically indexed and returned as `record_type: "prose"` search records; since V1.7.2, prose blocks also carry vectors in `adoc.search.v1`, so semantic and hybrid search rank them too. Prose remains orientation context, never citable knowledge.

--- a/docs/agent/v0/schema/search-artifact.json
+++ b/docs/agent/v0/schema/search-artifact.json
@@ -1,0 +1,54 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adoc://agent/v0/schema/search-artifact.json",
+  "title": "AgentDoc Search Artifact (adoc.search.v1)",
+  "description": "The dist/docs.search.json build output. One embedding entry per Knowledge Object and per indexed prose block; code blocks and sub-threshold prose are never embedded, and prose cache reuse is keyed by content hash and model, never by order-derived block id (ADR-0040).",
+  "type": "object",
+  "required": ["schema_version", "model", "graph_artifact_hash", "embeddings"],
+  "properties": {
+    "schema_version": { "const": "adoc.search.v1" },
+    "model": {
+      "type": "object",
+      "required": ["id", "provider", "dim"],
+      "properties": {
+        "id": { "type": "string" },
+        "provider": { "type": "string" },
+        "dim": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "graph_artifact_hash": { "type": "string", "pattern": "^sha256:" },
+    "embeddings": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          {
+            "title": "Knowledge Object entry",
+            "type": "object",
+            "required": ["id", "entry_kind", "content_hash", "vector"],
+            "properties": {
+              "id": { "type": "string" },
+              "entry_kind": { "const": "knowledge_object" },
+              "content_hash": { "type": "string", "pattern": "^sha256:" },
+              "vector": { "type": "array", "items": { "type": "number" } }
+            },
+            "additionalProperties": false
+          },
+          {
+            "title": "Prose entry (content_hash derives from the prose Embedding Composition)",
+            "type": "object",
+            "required": ["id", "entry_kind", "content_hash", "vector"],
+            "properties": {
+              "id": { "type": "string", "pattern": "^.+#block-[0-9]+$" },
+              "entry_kind": { "const": "prose" },
+              "content_hash": { "type": "string", "pattern": "^sha256:" },
+              "vector": { "type": "array", "items": { "type": "number" } }
+            },
+            "additionalProperties": false
+          }
+        ]
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/docs/v1-retrieval.md
+++ b/docs/v1-retrieval.md
@@ -199,6 +199,19 @@ info[build.embeddings_cached] embeddings: cached N, computed M
 
 No action is required. It is a visibility diagnostic for cache reuse.
 
+### Migrating a pre-V1.7.2 search artifact
+
+V1.7.2 bumped the search artifact schema from `adoc.search.v0` to
+`adoc.search.v1` (prose entries, `entry_kind` discriminator). The version
+check is exact-match, so an existing `docs.search.json` from V1.7.1 or
+earlier behaves as follows after upgrading:
+
+- `adoc build` warns that the prior cache is ignored and recomputes all
+  vectors once; warm rebuilds are cached again afterwards.
+- `adoc search --semantic` (and hybrid) reject the stale artifact with
+  `schema.unsupported_version`; the diagnostic's help points at the
+  fix — rebuild with `adoc build`.
+
 ### V1.7.2 build-time and size measurements
 
 Recorded on the pilots when prose entries landed in `adoc.search.v1`

--- a/docs/v1-retrieval.md
+++ b/docs/v1-retrieval.md
@@ -154,8 +154,9 @@ metadata filter implies `--objects-only`; `adoc why` returns Knowledge Object
 records only. Each search record includes a `match` block with `mode`,
 `result_rank`, and mode-specific rank metadata. Hybrid records include
 `rrf_score` and may include `lexical_rank` and `vector_rank`. Semantic records
-include `vector_rank` and `cosine_score`; prose records rank lexically until
-`adoc.search.v1` ships prose vectors (V1.7.2).
+include `vector_rank` and `cosine_score`; since V1.7.2 (`adoc.search.v1`)
+prose blocks carry vectors too, so semantic and hybrid ranking cover both
+record types, and `--prose-only --semantic` is a valid combination.
 
 ## Citation Pattern
 
@@ -187,13 +188,37 @@ the retrieval set rationale, and rebuild the artifact.
 
 Each search entry has a content hash. During `adoc build`, unchanged Object IDs
 reuse prior vectors from the previous output directory's `docs.search.json`.
-Build output reports:
+Prose entries (V1.7.2, ADR-0040) reuse by content hash and model alone, never
+by block id — order-derived `#block-NNNN` ids renumber when a block is
+inserted mid-page, and hash-keyed reuse makes renumbering free. Build output
+reports:
 
 ```text
 info[build.embeddings_cached] embeddings: cached N, computed M
 ```
 
 No action is required. It is a visibility diagnostic for cache reuse.
+
+### V1.7.2 build-time and size measurements
+
+Recorded on the pilots when prose entries landed in `adoc.search.v1`
+(post-`adoc.graph.v4`, per the ROADMAP-V7 sequencing note), cold builds into a
+fresh output directory, debug binary, Apple Silicon. "Before" is `origin/main`
+with V1.7.1 (Knowledge-Object-only artifact); "after" is V1.7.2. The Markdown
+Pilot's config pins the deterministic provider; the Expanded Pilot uses local
+fastembed (`bge-small-en-v1.5`, cached model).
+
+| Pilot | Provider | Build before | Build after | Artifact before | Artifact after | Entries before (KO) | Entries after (KO + prose) |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| markdown-pilot | deterministic | 1.8 s | 2.1 s | 49 KiB | 664 KiB | 6 | 6 + 75 |
+| expanded-pilot | fastembed | 0.5 s | 2.0 s | 221 KiB | 377 KiB | 27 | 27 + 19 |
+
+Warm rebuilds with an unchanged tree fully reuse the cache on both pilots
+(`cached 81, computed 0` / `cached 46, computed 0`, ~0.25 s). The size growth
+is proportional to indexed prose volume (vectors dominate; 384 dims per
+entry); code blocks and sub-threshold blocks are never embedded. Chunking and
+ANN indexes remain the named next steps if real corpora push these numbers up
+(measured, per the V1 rule).
 
 ## Retrieval Set Updates
 

--- a/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
+++ b/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
@@ -1,5 +1,5 @@
 {
-  "schema_version": "adoc.search.v0",
+  "schema_version": "adoc.search.v1",
   "model": {
     "id": "hash-v1",
     "provider": "deterministic",
@@ -9,6 +9,7 @@
   "embeddings": [
     {
       "id": "billing.credits",
+      "entry_kind": "knowledge_object",
       "content_hash": "sha256:b92ead57472b302fc075ecf7ef404c8e9f0cc1f7a94176b19748ee9fa3f061b1",
       "vector": [
         0.419,
@@ -19,6 +20,7 @@
     },
     {
       "id": "billing.ledger",
+      "entry_kind": "knowledge_object",
       "content_hash": "sha256:a0cc177269a2bb29028b7cc37db4c8bf88dcd0baf97d29ba3c4c1e165f38e9c6",
       "vector": [
         -0.229,


### PR DESCRIPTION
## Summary

Implements ROADMAP-V7 §V1.7.2 against the contract ADR-0040 fixed at V1.7.1 slice start. Prose blocks now carry vectors in the search artifact, and semantic/hybrid search rank them alongside Knowledge Objects.

- **`adoc.search.v0` → `adoc.search.v1`** (loud exact-match bump): every embedding entry gains `entry_kind: "knowledge_object" | "prose"`; `build_search_artifact` extends from Knowledge Objects to prose nodes. The prose Embedding Composition is contractual: `prose: {text}` plus a `[page: {page_id}]` marker; prose `content_hash` derives from it.
- **Cost controls (ADR-0040)**: code blocks never embedded (code stays lexical-only); blocks under 5 whitespace tokens skipped; prose cache reuse keyed by **content hash + model, never block id** — mid-page insertion renumbers `#block-NNNN` ids for free (verified: warm rebuilds report `cached 81, computed 0`).
- **Semantic path blends prose**: candidate pool mirrors hybrid, hits resolve through `resolve_entry` (prose ids no longer unreachable), hybrid's vector ranking widens to the full pool. Object ID pins stay Knowledge-Object-only; ranking stays parameter-free.
- **Guards removed** (all said "until V1.7.2"): `scope_conflict`'s ProseOnly×Semantic arm, the clap `conflicts_with` on `--prose-only`, and the MCP `search_record_scope` rejection. Metadata-filter conflicts stay — filters imply object intent.
- **Contract schema**: `docs/agent/v0/schema/search-artifact.json` pins the v1 wire shape; `contract_schemas.rs` validates a deterministic build against it. The artifact stays internal — not an MCP resource.
- `--no-embeddings` / `provider: none` skip prose vectors through the existing gate (no new wiring); model-mismatch rejection unchanged.

## Measurements (milestone watch item, post-v4 as the roadmap requires)

Cold builds, fresh out dir, debug binary; before = V1.7.1 on main:

| Pilot | Provider | Build | Artifact | Entries |
| --- | --- | --- | --- | --- |
| markdown-pilot | deterministic | 1.8s → 2.1s | 49 KiB → 664 KiB | 6 KO → 6 KO + 75 prose |
| expanded-pilot | fastembed (cached) | 0.5s → 2.0s | 221 KiB → 377 KiB | 27 KO → 27 KO + 19 prose |

Warm rebuilds ~0.25s with full cache reuse. Recorded in `docs/v1-retrieval.md`.

## Acceptance (roadmap §V1.7.2)

- Markdown Pilot + deterministic provider → v1 artifact with prose entries: `markdown_pilot_search_artifact_carries_prose_entries`
- `adoc search --semantic` returns a prose match for a paraphrase query lexical misses (fixture-pinned deterministic vectors): `semantic_search_returns_prose_match_lexical_misses`; real-model recall in the `fastembed-it` gated suite (settlement paragraph, top 3)
- Model-mismatch rejection behaves as in V1.4 (existing test, v1 fixtures)
- `cargo test --workspace --locked`, clippy `-D warnings`, and the `fastembed-it` gated suites (`semantic_search_cli`, `retrieval_pilot`) all green

V1.7.3 (hybrid evaluation slice) owns the retrieval-set fixtures, the migration-hint retirement, and marking V1.7 implemented.