### PR TITLE
chore: add MIT LICENSE with retroactive grant

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Alex Bako
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -681,4 +681,7 @@ See [docs/roadmap/ROADMAP.md](docs/roadmap/ROADMAP.md) for the full sequence.
 
 ## License
 
-This project declares the MIT license in Cargo package metadata.
+This project is licensed under the [MIT License](LICENSE). The license applies
+to the entire history of this repository, including all revisions prior to the
+commit that introduced the LICENSE file; Cargo package metadata has declared
+`license = "MIT"` since early in the project's history.


### PR DESCRIPTION
## Why

The repository is public and Cargo.toml has declared `license = "MIT"` since a2c2683, but no LICENSE file existed at the root — meaning the actual license text was never distributed with the source.

## What

- `LICENSE`: standard MIT text, `Copyright (c) 2026 Alex Bako` (initial commit 2026-05-03).
- `README.md`: the License section now points at the file and states the retroactive grant.

## Retroactive grant, not history rewrite

The license applies to the **entire history** of this repository, including all revisions prior to this commit. This is done by declaration rather than by rewriting history because:

- Alex Bako is the sole copyright holder (the only other committers are dependabot lockfile bumps and a test identity), so a declaration from the rights holder covers all prior revisions — anyone building from an older commit receives the same MIT grant.
- A `git filter-repo` rewrite would change every commit hash, invalidating the ADR-0042 dogfood-pilot audit trail (the pilot report pins window-open hashes and its git history is the evidence), detaching merged PR anchors, and breaking every commit reference in the ADRs — during an open pilot window (2026-07-08..14).
- Cargo package metadata has carried the SPDX `MIT` declaration for nearly the whole history, so most revisions already state the license of record.

## Pilot-window safety

Both touched files live at the repository root, outside the frozen `docs/` pilot corpus (`agentdoc.config.yaml` sets `docs_path: docs`), so this change does not modify the corpus mid-window. The README edit does not touch the `adoc:mcp-tools` / `adoc:kinds` anchored lists asserted by `docs_manifest_guard.rs`.