### PR TITLE
feat(cli): check --format markdown presenter (V8.3.1)

### DIFF
--- a/crates/adoc-cli/src/cli.rs
+++ b/crates/adoc-cli/src/cli.rs
@@ -192,7 +192,7 @@ pub(crate) enum CliFormat {
     /// Machine-readable JSON.
     Json,
     /// PR-comment-ready GitHub-flavored Markdown (only supported by
-    /// `adoc diff`, `adoc review`, and `adoc impacted-by`).
+    /// `adoc check`, `adoc diff`, `adoc review`, and `adoc impacted-by`).
     Markdown,
 }
 

--- a/crates/adoc-cli/src/commands/check.rs
+++ b/crates/adoc-cli/src/commands/check.rs
@@ -27,7 +27,7 @@ pub(crate) fn check(path: Option<PathBuf>, resolved: ResolvedFormat) -> i32 {
         eprint_diagnostics(&outcome.diagnostics);
         return MarkdownReviewPresenter::write_check(&outcome.diagnostics, &mut io::stdout())
             .map_or_else(
-                |source| report(CliError::RetrievalIo { source }),
+                |source| report(CliError::StdoutIo { source }),
                 |()| outcome.exit_code,
             );
     }

--- a/crates/adoc-cli/src/commands/check.rs
+++ b/crates/adoc-cli/src/commands/check.rs
@@ -1,10 +1,14 @@
+use std::io;
 use std::path::PathBuf;
 
 use adoc_local::{CheckInput, LocalContext, UnrestrictedPathPolicy};
 
-use super::{current_dir, print_diagnostics, print_summary, report};
+use crate::error::CliError;
+use crate::presentation::{MarkdownReviewPresenter, ResolvedFormat};
 
-pub(crate) fn check(path: Option<PathBuf>) -> i32 {
+use super::{current_dir, eprint_diagnostics, print_diagnostics, print_summary, report};
+
+pub(crate) fn check(path: Option<PathBuf>, resolved: ResolvedFormat) -> i32 {
     let config_start = match current_dir() {
         Ok(path) => path,
         Err(error) => return report(error),
@@ -15,6 +19,18 @@ pub(crate) fn check(path: Option<PathBuf>) -> i32 {
         Ok(outcome) => outcome,
         Err(error) => return report(error.into()),
     };
+    // V8.3.1: markdown is the PR-comment surface — stdout carries the body a
+    // bot pastes verbatim; the fix-oriented diagnostics stay on stderr for
+    // terminal users. Exit code is identical across formats (§24.3 keeps
+    // advisory-vs-strict a workflow decision, not a format one).
+    if resolved == ResolvedFormat::Markdown {
+        eprint_diagnostics(&outcome.diagnostics);
+        return MarkdownReviewPresenter::write_check(&outcome.diagnostics, &mut io::stdout())
+            .map_or_else(
+                |source| report(CliError::RetrievalIo { source }),
+                |()| outcome.exit_code,
+            );
+    }
     print_diagnostics(&outcome.diagnostics);
     print_summary(&outcome.diagnostics);
 

--- a/crates/adoc-cli/src/commands/diff.rs
+++ b/crates/adoc-cli/src/commands/diff.rs
@@ -44,7 +44,7 @@ fn write_diff_markdown(envelope: &ObjectDiffEnvelope, exit_code: i32) -> i32 {
         eprint_diagnostics(&envelope.diagnostics);
     }
     MarkdownReviewPresenter::write_diff(envelope, &mut io::stdout()).map_or_else(
-        |source| report(CliError::RetrievalIo { source }),
+        |source| report(CliError::StdoutIo { source }),
         |()| exit_code,
     )
 }

--- a/crates/adoc-cli/src/commands/impacted_by.rs
+++ b/crates/adoc-cli/src/commands/impacted_by.rs
@@ -73,7 +73,7 @@ fn emit_impacted_error(
             eprint_diagnostics(&envelope.diagnostics);
             MarkdownReviewPresenter::write_impacted_error(&envelope.diagnostics, &mut io::stdout())
                 .map_or_else(
-                    |source| report(CliError::RetrievalIo { source }),
+                    |source| report(CliError::StdoutIo { source }),
                     |()| exit_code,
                 )
         }
@@ -86,7 +86,7 @@ fn emit_impacted_error(
 
 fn write_impacted_markdown(envelope: &ImpactedEnvelope, exit_code: i32) -> i32 {
     MarkdownReviewPresenter::write_impacted(envelope, &mut io::stdout()).map_or_else(
-        |source| report(CliError::RetrievalIo { source }),
+        |source| report(CliError::StdoutIo { source }),
         |()| exit_code,
     )
 }

--- a/crates/adoc-cli/src/commands/mod.rs
+++ b/crates/adoc-cli/src/commands/mod.rs
@@ -41,7 +41,7 @@ pub(crate) use why::why;
 /// failure through the standard report path.
 fn write_json_or_report<T: serde::Serialize>(envelope: &T, exit_code: i32) -> i32 {
     json_presentation::write_json(envelope, &mut std::io::stdout()).map_or_else(
-        |source| report(CliError::RetrievalIo { source }),
+        |source| report(CliError::StdoutIo { source }),
         |()| exit_code,
     )
 }
@@ -74,7 +74,7 @@ fn emit_retrieval_error(
             &mut std::io::stdout(),
         )
         .map_or_else(
-            |source| report(CliError::RetrievalIo { source }),
+            |source| report(CliError::StdoutIo { source }),
             |()| exit_code,
         );
     }

--- a/crates/adoc-cli/src/commands/patch.rs
+++ b/crates/adoc-cli/src/commands/patch.rs
@@ -59,7 +59,7 @@ fn patch_apply(apply: String, artifact: Option<PathBuf>, resolved: ResolvedForma
     let source = if apply == "@-" {
         let mut buffer = String::new();
         if let Err(source) = io::stdin().read_to_string(&mut buffer) {
-            return report(CliError::RetrievalIo { source });
+            return report(CliError::StdinIo { source });
         }
         match serde_json::from_str(&buffer) {
             Ok(value) => PatchApplySource::Inline(value),

--- a/crates/adoc-cli/src/commands/review.rs
+++ b/crates/adoc-cli/src/commands/review.rs
@@ -49,7 +49,7 @@ fn write_review_markdown(envelope: &ReviewEnvelope, exit_code: i32) -> i32 {
         eprint_diagnostics(&envelope.diagnostics);
     }
     MarkdownReviewPresenter::write_review(envelope, &mut io::stdout()).map_or_else(
-        |source| report(CliError::RetrievalIo { source }),
+        |source| report(CliError::StdoutIo { source }),
         |()| exit_code,
     )
 }

--- a/crates/adoc-cli/src/commands/search.rs
+++ b/crates/adoc-cli/src/commands/search.rs
@@ -93,7 +93,7 @@ pub(crate) fn search_command(input: SearchCommandInput, resolved: ResolvedFormat
         return presenter
             .present(&view, &mut std::io::stdout())
             .map_or_else(
-                |source| report(CliError::RetrievalIo { source }),
+                |source| report(CliError::StdoutIo { source }),
                 |()| outcome.exit_code,
             );
     }
@@ -122,5 +122,5 @@ pub(crate) fn search_command(input: SearchCommandInput, resolved: ResolvedFormat
     let presenter = make_presenter(resolved, Vec::new());
     presenter
         .present(&view, &mut std::io::stdout())
-        .map_or_else(|source| report(CliError::RetrievalIo { source }), |()| 0)
+        .map_or_else(|source| report(CliError::StdoutIo { source }), |()| 0)
 }

--- a/crates/adoc-cli/src/commands/why.rs
+++ b/crates/adoc-cli/src/commands/why.rs
@@ -62,5 +62,5 @@ pub(crate) fn why(object_id: String, artifact: Option<PathBuf>, resolved: Resolv
     let presenter = make_presenter(resolved, Vec::new());
     presenter
         .present(&view, &mut std::io::stdout())
-        .map_or_else(|source| report(CliError::RetrievalIo { source }), |()| 0)
+        .map_or_else(|source| report(CliError::StdoutIo { source }), |()| 0)
 }

--- a/crates/adoc-cli/src/error.rs
+++ b/crates/adoc-cli/src/error.rs
@@ -3,8 +3,14 @@ pub(crate) enum CliError {
     #[error(transparent)]
     Local(#[from] adoc_local::LocalError),
 
-    #[error("error[retrieval.io] could not write retrieval output: {source}")]
-    RetrievalIo {
+    #[error("error[cli.stdout_io] could not write command output: {source}")]
+    StdoutIo {
+        #[source]
+        source: std::io::Error,
+    },
+
+    #[error("error[cli.stdin_io] could not read stdin: {source}")]
+    StdinIo {
         #[source]
         source: std::io::Error,
     },
@@ -14,7 +20,40 @@ impl CliError {
     pub(crate) fn exit_code(&self) -> i32 {
         match self {
             CliError::Local(error) => error.exit_code(),
-            CliError::RetrievalIo { .. } => 2,
+            CliError::StdoutIo { .. } | CliError::StdinIo { .. } => 2,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn io_error() -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::BrokenPipe, "pipe closed")
+    }
+
+    #[test]
+    fn stdout_io_pins_wire_code_and_exit_code() {
+        let error = CliError::StdoutIo { source: io_error() };
+        assert!(
+            error
+                .to_string()
+                .starts_with("error[cli.stdout_io] could not write command output:"),
+            "got: {error}"
+        );
+        assert_eq!(error.exit_code(), 2);
+    }
+
+    #[test]
+    fn stdin_io_pins_wire_code_and_exit_code() {
+        let error = CliError::StdinIo { source: io_error() };
+        assert!(
+            error
+                .to_string()
+                .starts_with("error[cli.stdin_io] could not read stdin:"),
+            "got: {error}"
+        );
+        assert_eq!(error.exit_code(), 2);
     }
 }

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -42,23 +42,26 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
         Ok(cli) => {
             let resolved = terminal::detect(cli.format.into(), cli.color.into());
             // Markdown is PR-comment output; reject it before any command
-            // that does not implement a markdown presenter. Diff, review,
-            // and impacted-by pass through; every other command exits
-            // non-zero with a fix-oriented stderr line.
+            // that does not implement a markdown presenter. Check, diff,
+            // review, and impacted-by pass through; every other command
+            // exits non-zero with a fix-oriented stderr line.
             if resolved == ResolvedFormat::Markdown
                 && !matches!(
                     cli.command,
-                    Commands::Diff { .. } | Commands::Review { .. } | Commands::ImpactedBy { .. }
+                    Commands::Check { .. }
+                        | Commands::Diff { .. }
+                        | Commands::Review { .. }
+                        | Commands::ImpactedBy { .. }
                 )
             {
                 eprintln!(
-                    "error[cli.format] --format markdown is only supported by `adoc diff`, `adoc review`, and `adoc impacted-by`"
+                    "error[cli.format] --format markdown is only supported by `adoc check`, `adoc diff`, `adoc review`, and `adoc impacted-by`"
                 );
                 return 2;
             }
             match cli.command {
                 Commands::Init => init(),
-                Commands::Check { path } => check(path),
+                Commands::Check { path } => check(path, resolved),
                 Commands::Migrate {
                     path,
                     write,

--- a/crates/adoc-cli/src/presentation/markdown.rs
+++ b/crates/adoc-cli/src/presentation/markdown.rs
@@ -1,7 +1,8 @@
-//! V3.5 Markdown presenter for `adoc diff` and `adoc review`.
+//! Markdown presenter for `adoc diff`, `adoc review`, `adoc impacted-by`
+//! (V6.3), and `adoc check` (V8.3.1).
 //!
 //! Produces GitHub-flavored Markdown that pastes cleanly into a PR review
-//! comment. The shape is frozen at slice time:
+//! comment. The V3.5 diff/review shape is frozen at slice time:
 //!
 //! 1. **Required reviewers** header line (review only, non-empty).
 //! 2. `## Diff: N created, M deleted, K changed` summary heading.
@@ -30,7 +31,7 @@ use std::io;
 
 use adoc_core::{
     ChangedObject, Diagnostic, FieldChange, ImpactReasonKind, ImpactedEnvelope, ImpactedObject,
-    ObjectDiffEnvelope, ProofObligation, RequiredReviewer, ReviewEnvelope,
+    ObjectDiffEnvelope, ProofObligation, RequiredReviewer, ReviewEnvelope, Severity,
 };
 
 pub(crate) struct MarkdownReviewPresenter;
@@ -73,6 +74,20 @@ impl MarkdownReviewPresenter {
         out.write_all(body.as_bytes())
     }
 
+    /// V8.3.1 `adoc check --format markdown`: the §24.4 PR-comment shape —
+    /// error/warning counts in the header, diagnostics grouped by source
+    /// file, `object_id`/`help` as sub-bullets, and a suggested next command.
+    /// A clean project still renders a body: a PR bot pasting stdout must
+    /// never post an empty comment.
+    pub(crate) fn write_check(
+        diagnostics: &[Diagnostic],
+        out: &mut dyn io::Write,
+    ) -> io::Result<()> {
+        let mut body = String::new();
+        render_check(&mut body, diagnostics);
+        out.write_all(body.as_bytes())
+    }
+
     /// V6.3 `adoc impacted-by --format markdown` refusal path: one blockquote
     /// per diagnostic, so a PR-comment consumer pasting stdout never posts an
     /// empty comment (JSON gets the envelope; plain/styled use stderr only).
@@ -94,6 +109,86 @@ impl MarkdownReviewPresenter {
         }
         out.write_all(body.as_bytes())
     }
+}
+
+fn render_check(output: &mut String, diagnostics: &[Diagnostic]) {
+    let errors = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == Severity::Error)
+        .count();
+    let warnings = diagnostics
+        .iter()
+        .filter(|diagnostic| diagnostic.severity == Severity::Warning)
+        .count();
+    // Always-plural counts — the exact convention of the plain summary line
+    // (`commands::format_summary`), so the two surfaces never disagree.
+    writeln!(
+        output,
+        "## adoc check: {errors} errors, {warnings} warnings"
+    )
+    .expect("writing to String cannot fail");
+
+    if diagnostics.is_empty() {
+        writeln!(output).expect("writing to String cannot fail");
+        writeln!(output, "No diagnostics.").expect("writing to String cannot fail");
+    }
+
+    // Group by source file in first-seen order (the compile walk is already
+    // deterministic); spanless diagnostics get an explicit marker group so
+    // they cannot silently vanish from the comment.
+    let mut groups: Vec<(Option<&std::path::Path>, Vec<&Diagnostic>)> = Vec::new();
+    for diagnostic in diagnostics {
+        let file = diagnostic.span.as_ref().map(|span| span.file.as_path());
+        match groups.iter_mut().find(|(key, _)| *key == file) {
+            Some((_, entries)) => entries.push(diagnostic),
+            None => groups.push((file, vec![diagnostic])),
+        }
+    }
+    for (file, entries) in groups {
+        writeln!(output).expect("writing to String cannot fail");
+        match file {
+            Some(path) => writeln!(output, "### `{}`", path.display()),
+            None => writeln!(output, "### _(no source span)_"),
+        }
+        .expect("writing to String cannot fail");
+        writeln!(output).expect("writing to String cannot fail");
+        for diagnostic in entries {
+            let icon = match diagnostic.severity {
+                Severity::Error => "❌",
+                Severity::Warning => "⚠️",
+                Severity::Info => "ℹ️",
+            };
+            // Multi-line messages stay indented inside the list item.
+            let message = diagnostic.message.replace('\n', "\n  ");
+            match diagnostic.span.as_ref() {
+                Some(span) => writeln!(
+                    output,
+                    "- {icon} `{}` (line {}) — {message}",
+                    diagnostic.code, span.start.line
+                ),
+                None => writeln!(output, "- {icon} `{}` — {message}", diagnostic.code),
+            }
+            .expect("writing to String cannot fail");
+            if let Some(object_id) = &diagnostic.object_id {
+                writeln!(output, "  - object_id: `{object_id}`")
+                    .expect("writing to String cannot fail");
+            }
+            if let Some(help) = &diagnostic.help {
+                let help = help.replace('\n', "\n    ");
+                writeln!(output, "  - help: {help}").expect("writing to String cannot fail");
+            }
+        }
+    }
+
+    writeln!(output).expect("writing to String cannot fail");
+    let action = if errors > 0 {
+        "fix the errors above, then re-run `adoc check`."
+    } else if warnings > 0 {
+        "review the warnings above, then re-run `adoc check`."
+    } else {
+        "run `adoc build` to refresh the graph artifact."
+    };
+    writeln!(output, "Suggested action: {action}").expect("writing to String cannot fail");
 }
 
 fn render_impacted_by(output: &mut String, envelope: &ImpactedEnvelope) {

--- a/crates/adoc-cli/src/presentation/markdown.rs
+++ b/crates/adoc-cli/src/presentation/markdown.rs
@@ -128,6 +128,8 @@ fn render_check(output: &mut String, diagnostics: &[Diagnostic]) {
     )
     .expect("writing to String cannot fail");
 
+    // Empty → deliberate fall-through: the group loop below is a no-op and
+    // only the unconditional suggested-action block follows.
     if diagnostics.is_empty() {
         writeln!(output).expect("writing to String cannot fail");
         writeln!(output, "No diagnostics.").expect("writing to String cannot fail");

--- a/crates/adoc-cli/src/presentation/mod.rs
+++ b/crates/adoc-cli/src/presentation/mod.rs
@@ -29,7 +29,8 @@ pub(crate) enum FormatChoice {
     /// Machine-readable JSON.
     Json,
     /// GitHub-flavored Markdown for PR review comments. Only supported by
-    /// `adoc diff` and `adoc review`; rejected at dispatch for other commands.
+    /// `adoc check`, `adoc diff`, `adoc review`, and `adoc impacted-by`;
+    /// rejected at dispatch for other commands.
     Markdown,
 }
 
@@ -51,8 +52,9 @@ pub(crate) enum ResolvedFormat {
     Styled,
     Json,
     /// Markdown is structural like Json — colour flags never alter it.
-    /// Only `adoc diff` and `adoc review` accept this resolved variant; other
-    /// commands reject it in `main.rs` before dispatching.
+    /// Only `adoc check`, `adoc diff`, `adoc review`, and `adoc impacted-by`
+    /// accept this resolved variant; other commands reject it in `main.rs`
+    /// before dispatching.
     Markdown,
 }
 

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -2585,3 +2585,134 @@ fn check_reports_unreadable_source_path() {
     assert!(stdout.contains(source.to_str().expect("source path is utf-8")));
     assert!(stdout.contains("1 errors"));
 }
+
+/// V8.3.1: `adoc check --format markdown` — the PR-comment body. Diagnostics
+/// grouped by file, error/warning counts in the header, object_id/help as
+/// sub-bullets, a suggested next command. Pinned as a golden so the §24.4
+/// shape drifts loudly, not silently.
+#[test]
+fn check_markdown_matches_golden_for_error_and_warning_fixture() {
+    let workspace = TestWorkspace::new("check-markdown-golden");
+    write_fixture_to_workspace(&workspace, "v8_3/broken.adoc", "broken.adoc");
+    write_fixture_to_workspace(&workspace, "v8_3/overdue.adoc", "overdue.adoc");
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", ".", "--format", "markdown"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "errors must exit 1 in markdown format too\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    support::assert_markdown_matches_golden(
+        "v8_3/check.md",
+        &String::from_utf8_lossy(&output.stdout),
+    );
+    // Terminal users keep the fix-oriented diagnostics on stderr — stdout is
+    // reserved for the comment body a PR bot pastes verbatim.
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error[ref.broken]") && stderr.contains("warning[task.overdue]"),
+        "expected plain diagnostics on stderr, got:\n{stderr}"
+    );
+}
+
+/// A clean project still renders a non-empty body — a PR bot pasting stdout
+/// must never post an empty comment.
+#[test]
+fn check_markdown_clean_project_matches_golden() {
+    let workspace = TestWorkspace::new("check-markdown-clean");
+    workspace.write(
+        "guide.adoc",
+        "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", ".", "--format", "markdown"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(output.status.code(), Some(0));
+    support::assert_markdown_matches_golden(
+        "v8_3/check_clean.md",
+        &String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+/// The V8.3.1 acceptance criterion: exit code identical across formats —
+/// §24.3 advisory-vs-strict stays a workflow decision, not a format one.
+#[test]
+fn check_markdown_exit_code_matches_plain_format() {
+    let workspace = TestWorkspace::new("check-markdown-exit-parity");
+    write_fixture_to_workspace(&workspace, "v8_3/broken.adoc", "broken.adoc");
+    write_fixture_to_workspace(&workspace, "v8_3/overdue.adoc", "overdue.adoc");
+
+    let plain = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "."])
+        .output()
+        .expect("adoc check runs");
+    let markdown = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", ".", "--format", "markdown"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(plain.status.code(), Some(1));
+    assert_eq!(markdown.status.code(), plain.status.code());
+}
+
+/// Warnings never fail the build (exit 0), and the suggested action names
+/// the re-run rather than pretending there is something to fix.
+#[test]
+fn check_markdown_warnings_only_exits_zero_with_suggestion() {
+    let workspace = TestWorkspace::new("check-markdown-warnings-only");
+    write_fixture_to_workspace(&workspace, "v8_3/overdue.adoc", "overdue.adoc");
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", ".", "--format", "markdown"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(output.status.code(), Some(0));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("## adoc check: 0 errors, 1 warnings"),
+        "expected warning-only header, got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("Suggested action: review the warnings above, then re-run `adoc check`."),
+        "expected warnings-only suggested action, got:\n{stdout}"
+    );
+}
+
+/// Lifting the rejection for `check` must not lift it for anything else:
+/// commands without a markdown presenter still exit 2.
+#[test]
+fn build_markdown_rejection_still_exits_two() {
+    let workspace = TestWorkspace::new("build-markdown-rejected");
+    workspace.write(
+        "guide.adoc",
+        "# Getting Started @doc(docs.getting-started)\n\nAgentDoc keeps knowledge readable.\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["build", ".", "--format", "markdown"])
+        .output()
+        .expect("adoc build runs");
+
+    assert_eq!(output.status.code(), Some(2));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("error[cli.format]") && stderr.contains("`adoc check`"),
+        "expected rejection naming the supported commands, got:\n{stderr}"
+    );
+}

--- a/crates/adoc-cli/tests/expanded_pilot.rs
+++ b/crates/adoc-cli/tests/expanded_pilot.rs
@@ -806,7 +806,7 @@ fn run_git(workspace: &TestWorkspace, args: &[&str]) {
 /// clock-stable); `--within 36500d` additionally lists the two far-future
 /// verified objects as `expiring_soon`. The command is a query: exit 0 with
 /// records, exit 2 only on artifact-load failure, and `--format markdown`
-/// stays diff/review-only.
+/// is still rejected here (no markdown presenter for this command).
 #[test]
 fn expanded_pilot_stale_query() {
     let repo_root = repo_root();
@@ -984,7 +984,8 @@ fn expanded_pilot_stale_query() {
 /// contradicted claims, each carrying the implicating contradiction ids so
 /// consumers never join the two lists themselves. The envelope is a pure
 /// function of the artifact: no `evaluated_at`. Exit 0 with findings, exit 2
-/// only on artifact-load failure; `--format markdown` stays diff/review-only.
+/// only on artifact-load failure; `--format markdown` is still rejected
+/// here (no markdown presenter for this command).
 #[test]
 fn expanded_pilot_contradictions_query() {
     let repo_root = repo_root();

--- a/crates/adoc-cli/tests/fixtures/v8_3/broken.adoc
+++ b/crates/adoc-cli/tests/fixtures/v8_3/broken.adoc
@@ -1,0 +1,10 @@
+# Broken Relation @doc(ci.broken-relation)
+
+One error-severity diagnostic: the claim depends on an undeclared object.
+
+::claim billing.refunds
+status: draft
+depends_on: missing.object
+--
+Refund workflows depend on knowledge that has not been declared.
+::

--- a/crates/adoc-cli/tests/fixtures/v8_3/check.md
+++ b/crates/adoc-cli/tests/fixtures/v8_3/check.md
@@ -1,0 +1,15 @@
+## adoc check: 1 errors, 1 warnings
+
+### `./broken.adoc`
+
+- ❌ `ref.broken` (line 7) — depends_on target `missing.object` does not resolve to a declared Knowledge Object
+  - object_id: `missing.object`
+  - help: Relation targets must name an existing Knowledge Object. Supported relation fields: `depends_on`, `supersedes`, `related_to`.
+
+### `./overdue.adoc`
+
+- ⚠️ `task.overdue` (line 6) — open task `ci.update-runbook` is overdue (due 2020-01-01)
+  - object_id: `ci.update-runbook`
+  - help: Complete the task and set `status: done`, or move its `due` date.
+
+Suggested action: fix the errors above, then re-run `adoc check`.

--- a/crates/adoc-cli/tests/fixtures/v8_3/check_clean.md
+++ b/crates/adoc-cli/tests/fixtures/v8_3/check_clean.md
@@ -1,0 +1,5 @@
+## adoc check: 0 errors, 0 warnings
+
+No diagnostics.
+
+Suggested action: run `adoc build` to refresh the graph artifact.

--- a/crates/adoc-cli/tests/fixtures/v8_3/overdue.adoc
+++ b/crates/adoc-cli/tests/fixtures/v8_3/overdue.adoc
@@ -1,0 +1,12 @@
+# Overdue Task @doc(ci.overdue-task)
+
+One warning-severity diagnostic: an open task with a wide-margin past due
+date (2020) is overdue on any system clock.
+
+::task ci.update-runbook
+owner: support-ops
+status: open
+due: 2020-01-01
+--
+Update the support runbook to mention refund behavior.
+::

--- a/crates/adoc-cli/tests/review_cli.rs
+++ b/crates/adoc-cli/tests/review_cli.rs
@@ -2,7 +2,7 @@ mod support;
 
 use std::process::Command;
 
-use support::{TestWorkspace, adoc_command, fixture_path, stderr, stdout};
+use support::{TestWorkspace, adoc_command, assert_markdown_matches_golden, stderr, stdout};
 
 // V3.3 / V3.4 base fixture plus a second verified claim `billing.holds-policy`
 // whose head delta exercises every other `FieldChange` variant — status,
@@ -433,33 +433,6 @@ fn review_main_plain_lists_proof_obligations_section() {
     assert!(
         stdout.contains("billing.refunds: review impacted claim"),
         "expected impact-review obligation line\n{stdout}"
-    );
-}
-
-/// Read or refresh a V3.5 golden Markdown file under
-/// `tests/fixtures/review_markdown/`. Set `ADOC_UPDATE_GOLDEN=1` in the env
-/// to rewrite the golden from the current run; otherwise compare for byte
-/// equality.
-fn assert_markdown_matches_golden(relative: &str, actual: &str) {
-    let golden = fixture_path(relative);
-    if std::env::var_os("ADOC_UPDATE_GOLDEN").is_some() {
-        if let Some(parent) = golden.parent() {
-            std::fs::create_dir_all(parent).expect("create golden parent dir");
-        }
-        std::fs::write(&golden, actual).expect("write golden file");
-        return;
-    }
-    let expected = std::fs::read_to_string(&golden).unwrap_or_else(|error| {
-        panic!(
-            "missing golden file at {}: {error}\nTo bootstrap, re-run with ADOC_UPDATE_GOLDEN=1",
-            golden.display()
-        )
-    });
-    assert_eq!(
-        actual,
-        expected,
-        "markdown output diverged from golden at {}\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
-        golden.display()
     );
 }
 

--- a/crates/adoc-cli/tests/support/mod.rs
+++ b/crates/adoc-cli/tests/support/mod.rs
@@ -60,6 +60,33 @@ pub(crate) fn stderr(output: &Output) -> String {
     String::from_utf8_lossy(&output.stderr).into_owned()
 }
 
+/// Read or refresh a golden Markdown file under `tests/fixtures/`. Set
+/// `ADOC_UPDATE_GOLDEN=1` in the env to rewrite the golden from the current
+/// run; otherwise compare for byte equality.
+#[allow(dead_code)]
+pub(crate) fn assert_markdown_matches_golden(relative: &str, actual: &str) {
+    let golden = fixture_path(relative);
+    if std::env::var_os("ADOC_UPDATE_GOLDEN").is_some() {
+        if let Some(parent) = golden.parent() {
+            fs::create_dir_all(parent).expect("create golden parent dir");
+        }
+        fs::write(&golden, actual).expect("write golden file");
+        return;
+    }
+    let expected = fs::read_to_string(&golden).unwrap_or_else(|error| {
+        panic!(
+            "missing golden file at {}: {error}\nTo bootstrap, re-run with ADOC_UPDATE_GOLDEN=1",
+            golden.display()
+        )
+    });
+    assert_eq!(
+        actual,
+        expected,
+        "markdown output diverged from golden at {}\n--- expected ---\n{expected}\n--- actual ---\n{actual}",
+        golden.display()
+    );
+}
+
 pub(crate) struct TestWorkspace {
     pub(crate) root: PathBuf,
 }

--- a/docs/roadmap/ROADMAP-V8.md
+++ b/docs/roadmap/ROADMAP-V8.md
@@ -177,7 +177,7 @@ Most of the plumbing exists: `adoc impacted-by --format markdown` already emits 
 
 ### V8.3.1: Check Markdown Presenter Slice
 
-Goal: `adoc check --format markdown` emits a §24.4-style PR comment body.
+Goal: `adoc check --format markdown` emits a §24.4-style PR comment body. Implemented.
 
 Scope (adapter-only — no domain change, no new envelope, no new codes):
 


### PR DESCRIPTION
## Summary

V8.3.1 (Check Markdown Presenter Slice, ROADMAP-V8 §V8.3.1): `adoc check --format markdown` emits a §24.4-style PR-comment body, unblocking the V8.3.2 workflow slice.

Adapter-only, per the roadmap scope — no domain change, no new envelope, no new diagnostic codes:

- Lift the markdown-format rejection for `check` in `main.rs` (previously only `diff`/`review`/`impacted-by`).
- New `render_check` arm in `presentation/markdown.rs`: error/warning counts in the header, diagnostics grouped by source file in first-seen order, `object_id`/`help` as sub-bullets, suggested next command. A clean project still renders a non-empty body so a PR bot never posts an empty comment.
- stdout carries the comment body verbatim; fix-oriented plain diagnostics stay on stderr for terminal users.
- Exit codes unchanged across formats — 0 clean, 1 on errors — keeping §24.3 advisory-vs-strict a workflow decision, not a code change.

## Acceptance (all pinned in `crates/adoc-cli/tests/check_cli.rs`)

- Markdown output pinned as a golden for a fixture with one error and one warning (`tests/fixtures/v8_3/check.md`), plus a clean-project golden.
- Exit code identical across formats; warnings-only exits 0 with the review suggestion.
- Markdown on still-unsupported commands (`adoc build`) still exits 2 naming the supported set.

## Validation

- `cargo fmt --all --check`, `cargo clippy --workspace --all-targets --locked -- -D warnings`, `cargo test --workspace --locked` (59 suites, 0 failures), `cargo doc --workspace --no-deps --locked` — all green.