### PR TITLE
feat(ci): composite GitHub Action packaging (V8.3.3)

### DIFF
--- a/.github/workflows/adoc-pr.yml
+++ b/.github/workflows/adoc-pr.yml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   report:
-    name: Review Report
+    name: PR Report
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:

--- a/.github/workflows/adoc-pr.yml
+++ b/.github/workflows/adoc-pr.yml
@@ -1,0 +1,32 @@
+name: AgentDoc PR Report
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  report:
+    name: Review Report
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      # Flip enforcement to strict after one clean week (§24.3); record the
+      # flip in this file's history.
+      - uses: agentdoc-dev/action@v1
+        with:
+          enforcement: advisory

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,9 +27,24 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Install Rust toolchain
         run: rustup toolchain install --no-self-update
+
+      - name: Cache Cargo data
+        uses: actions/cache@v6
+        with:
+          path: |
+            ~/.cargo/bin/
+            ~/.cargo/registry/index/
+            ~/.cargo/registry/cache/
+            ~/.cargo/git/db/
+            target/
+          key: ${{ runner.os }}-${{ runner.arch }}-cargo-release-${{ hashFiles('rust-toolchain.toml', '**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-${{ runner.arch }}-cargo-release-
 
       - name: Build release binary
         run: cargo build --release --locked -p adoc-cli
@@ -47,7 +62,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "$GITHUB_REF_NAME" --generate-notes || true
+          # Both matrix legs race to create the release; a create failure is
+          # only tolerable when the release already exists — anything else
+          # (auth, policy) must fail the step, not surface later as a
+          # confusing upload error.
+          gh release create "$GITHUB_REF_NAME" --generate-notes \
+            || gh release view "$GITHUB_REF_NAME" > /dev/null
           gh release upload "$GITHUB_REF_NAME" --clobber \
             "adoc-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz" \
             "adoc-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,53 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  binaries:
+    name: Binaries (${{ matrix.target }})
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      matrix:
+        include:
+          - runner: ubuntu-latest
+            target: x86_64-unknown-linux-gnu
+          - runner: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Install Rust toolchain
+        run: rustup toolchain install --no-self-update
+
+      - name: Build release binary
+        run: cargo build --release --locked -p adoc-cli
+
+      - name: Smoke-check binary against example project
+        run: ./target/release/adoc check examples/expanded-pilot
+
+      - name: Package tarball with checksum
+        run: |
+          ARCHIVE="adoc-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz"
+          tar -czf "$ARCHIVE" -C target/release adoc
+          sha256sum "$ARCHIVE" > "$ARCHIVE.sha256"
+
+      - name: Create release and upload assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "$GITHUB_REF_NAME" --generate-notes || true
+          gh release upload "$GITHUB_REF_NAME" --clobber \
+            "adoc-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz" \
+            "adoc-${GITHUB_REF_NAME}-${{ matrix.target }}.tar.gz.sha256"

--- a/docs/adr/0047-composite-action-packaging.md
+++ b/docs/adr/0047-composite-action-packaging.md
@@ -1,0 +1,61 @@
+# ADR-0047: Composite Action Packaging
+
+**Status:** Accepted
+**Date:** 2026-07-17
+**Slice:** V8.3.3
+
+## Context
+
+V8.3.2 fixed the CI packaging decision as "a documented workflow snippet plus
+a live job in this repo — not a composite GitHub Action", with the un-gating
+threshold reserved for ADR-0044. ADR-0044 was never recorded as a file; the
+threshold existed only as a roadmap reservation ("partners measurably fail to
+adopt the snippet as-is").
+
+The MVP scope has since changed the calculus: a Marketplace-listed action is
+part of the product surface itself, not post-pilot packaging polish.
+Advisory-first adoption — the §24.3 rollout the roadmap already mandates —
+needs a maintained artifact users pin (`agentdoc-dev/action@v1`), not a
+copy-paste snippet that drifts in every consumer repo. This ADR supersedes
+the V8.3.2 packaging paragraph and deliberately jumps the reserved ADR-0044
+gate, recording the decision instead of waiting for adoption-failure
+evidence.
+
+## Decision
+
+1. **A composite GitHub Action lives in its own public repository,
+   `agentdoc-dev/action`.** It is a thin wrapper — bash steps, a problem-matcher
+   JSON, no Node, no Docker. All behavior stays in the adoc CLI presenters
+   (`check --format markdown`, `impacted-by --format markdown|json`); the
+   action is glue. New capability lands in the CLI first, never in the
+   action.
+2. **The action installs prebuilt binaries from this repository's GitHub
+   Releases**, sha256-verified. A tag-triggered `release.yml` (Linux x86_64 +
+   arm64) is therefore load-bearing product infrastructure.
+3. **Version coupling:** each action release pins a tested adoc tag as the
+   `adoc-version` input default. `latest` is accepted but documented as
+   unsupported for pinning.
+4. **Enforcement is a consumer decision, defaulting to advisory** — the
+   `enforcement: advisory | strict` input carries §24.3's advisory-first
+   rollout; `scope: full | diff` bounds the strict gate to PR-changed files
+   when asked.
+5. **Proposed Knowledge Objects are deterministic:** changed paths minus the
+   paths any Impacted Query hit claims (`adoc.impacted.v0`). The comment's
+   "Proposed Knowledge Objects" section is the reserved seam for a later
+   Agent-Patch drafting tier (`create_object` ops); that tier arrives behind
+   a then-new input, so no dead inputs exist today.
+
+## Consequences
+
+- `.github/workflows/adoc-pr.yml` dogfoods the released surface (released
+  action + released binary), exactly what a partner gets; HEAD coverage
+  stays in `ci.yml`.
+- `docs/guides/ci-integration.md` leads with the action; the raw workflow
+  snippet survives as an appendix for non-GitHub CI. (V8.3.2 named this file
+  `docs/ci-integration.md`, but a docs-root `.md` derives a one-segment page
+  ID the Object ID grammar rejects; `guides/` supplies the second segment.)
+- The V8.3.2 snippet-is-the-product stance is superseded; its internals live
+  on verbatim as the action's steps (marker comment, advisory-first, one
+  in-place-updated comment).
+- Marketplace listing requires the action repo to hold its own releases and
+  a floating `v1` major tag; that maintenance cost is accepted.

--- a/docs/adr/0047-composite-action-packaging.md
+++ b/docs/adr/0047-composite-action-packaging.md
@@ -43,7 +43,11 @@ evidence.
    paths any Impacted Query hit claims (`adoc.impacted.v0`). The comment's
    "Proposed Knowledge Objects" section is the reserved seam for a later
    Agent-Patch drafting tier (`create_object` ops); that tier arrives behind
-   a then-new input, so no dead inputs exist today.
+   a then-new input, so no dead inputs exist today. Accepted debt against
+   decision 1: this set-difference currently lives as jq in the action; the
+   follow-up slice moves it into the CLI (an uncovered-paths field on
+   `adoc.impacted.v0` or its markdown presenter) so MCP and non-GitHub CI
+   consumers see the same proposals.
 
 ## Consequences
 

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -1,0 +1,59 @@
+# CI Integration
+
+Run AgentDoc on every pull request: Strict Mode validation, impacted
+knowledge, and proposed new Knowledge Objects, posted as one in-place-updated
+**Review Report** comment.
+
+## GitHub Actions (recommended)
+
+```yaml
+name: AgentDoc PR Report
+on: pull_request
+permissions:
+  contents: read
+  pull-requests: write   # sticky comment; omit → job-summary-only mode
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0   # required for the Impacted Query (--ref)
+      - uses: agentdoc-dev/action@v1
+```
+
+Start in the default `advisory` mode; flip to `enforcement: strict` after a
+clean week. See the [action's README](https://github.com/agentdoc-dev/action) for
+all inputs (`enforcement`, `scope`, `adoc-version`, `working-directory`,
+`github-token`), fork-PR behavior, and security notes.
+
+This repository's own `.github/workflows/adoc-pr.yml` is the continuously
+tested copy of this snippet.
+
+## Appendix: raw workflow (non-GitHub CI, GitHub Enterprise)
+
+Where the Marketplace action is unavailable, run the same commands directly.
+The action is a thin wrapper around exactly this sequence:
+
+```sh
+# install a released binary (or: cargo install --path crates/adoc-cli --locked)
+curl -fsSLO https://github.com/alex-bako/adoc/releases/download/v0.1.0/adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
+curl -fsSLO https://github.com/alex-bako/adoc/releases/download/v0.1.0/adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
+sha256sum -c adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
+tar -xzf adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
+
+# validate and query (from the directory holding agentdoc.config.yaml)
+./adoc build --no-embeddings
+./adoc check --format markdown > check.md        # exit 1 on errors = your gate
+./adoc impacted-by --ref origin/main --format markdown > impacted.md
+
+# post/update one PR comment keyed on the marker
+printf '<!-- adoc:pr-report -->\n## AgentDoc Review Report\n\n' > report.md
+cat check.md impacted.md >> report.md
+# upsert report.md as a comment with your CI's API of choice,
+# matching an existing comment whose body starts with the marker
+```
+
+`adoc check --format markdown` writes the comment body to stdout and
+`file:line:col: severity[code] message` diagnostics to stderr; the exit code
+(0 clean / 1 errors) is identical across formats.

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -37,8 +37,8 @@ The action is a thin wrapper around exactly this sequence:
 
 ```sh
 # install a released binary (or: cargo install --path crates/adoc-cli --locked)
-curl -fsSLO https://github.com/alex-bako/adoc/releases/download/v0.1.0/adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
-curl -fsSLO https://github.com/alex-bako/adoc/releases/download/v0.1.0/adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
+curl -fsSLO https://github.com/agentdoc-dev/adoc/releases/download/v0.1.0/adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
+curl -fsSLO https://github.com/agentdoc-dev/adoc/releases/download/v0.1.0/adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
 sha256sum -c adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
 tar -xzf adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
 

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -2,7 +2,9 @@
 
 Run AgentDoc on every pull request: Strict Mode validation, impacted
 knowledge, and proposed new Knowledge Objects, posted as one in-place-updated
-**Review Report** comment.
+**AgentDoc PR Report** comment. (Not to be confused with the Review Report
+aggregate `adoc.review.v0` produced by `adoc review` — the comment composes
+`adoc check` and the Impacted Query.)
 
 ## GitHub Actions (recommended)
 
@@ -19,6 +21,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0   # required for the Impacted Query (--ref)
+          persist-credentials: false
       - uses: agentdoc-dev/action@v1
 ```
 
@@ -43,12 +46,12 @@ sha256sum -c adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz.sha256
 tar -xzf adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
 
 # validate and query (from the directory holding agentdoc.config.yaml)
-./adoc build --no-embeddings
+./adoc build --no-embeddings || true             # build exit 1 = corpus errors; check is the gate
 ./adoc check --format markdown > check.md        # exit 1 on errors = your gate
 ./adoc impacted-by --ref origin/main --format markdown > impacted.md
 
 # post/update one PR comment keyed on the marker
-printf '<!-- adoc:pr-report -->\n## AgentDoc Review Report\n\n' > report.md
+printf '<!-- adoc:pr-report -->\n## AgentDoc PR Report\n\n' > report.md
 cat check.md impacted.md >> report.md
 # upsert report.md as a comment with your CI's API of choice,
 # matching an existing comment whose body starts with the marker

--- a/docs/roadmap/ROADMAP-V8.md
+++ b/docs/roadmap/ROADMAP-V8.md
@@ -213,6 +213,31 @@ Questions to resolve later:
 
 - Should the comment include the V8.4.2 health delta once `adoc health` ships, or does that belong in a scheduled weekly job instead of per-PR? (Decide on partner feedback; the markdown presenter makes either a one-line change.)
 
+### V8.3.3: Composite Action Slice
+
+**Supersedes the V8.3.2 packaging paragraph — see ADR-0047.** The composite
+Action ships ahead of the reserved ADR-0044 adoption threshold: Marketplace
+distribution is MVP surface, and advisory-first rollout needs a pinnable
+maintained artifact rather than a drifting snippet. The V8.3.2 snippet lives
+on verbatim as the internals of `agentdoc-dev/action`.
+
+Scope:
+
+- `.github/workflows/release.yml` in this repo: tag-triggered prebuilt `adoc`
+  binaries (Linux x86_64 + arm64, sha256) — the action's install source.
+- `agentdoc-dev/action`: composite `action.yml` (inputs `enforcement`, `scope`,
+  `adoc-version`, `working-directory`, `github-token`), problem-matcher
+  annotations, marker-keyed sticky Review Report comment with a deterministic
+  "Proposed Knowledge Objects" section, fixture-based integration workflow.
+- `.github/workflows/adoc-pr.yml` consumes the released action in advisory
+  mode; `docs/guides/ci-integration.md` leads with the action, raw snippet
+  demoted to an appendix (V8.3.2's `docs/ci-integration.md` would derive a
+  one-segment page ID the Object ID grammar rejects — ADR-0047).
+
+Commit shape: `feat(ci): tagged release workflow with prebuilt adoc binaries (V8.3.3)` → `docs(v8): ADR-0047 composite action packaging (V8.3.3)` → `chore(ci): adoc-pr workflow via agentdoc-dev/action, advisory mode (V8.3.3)` → `docs(v8): ci-integration guide for partners (V8.3.3)`.
+
+Acceptance: unchanged from V8.3.2 — a real PR in this repository shows the comment; the advisory→strict decision is recorded in the workflow file's history.
+
 ---
 
 ## V8.4: Contract Freeze and Knowledge Health

--- a/docs/roadmap/ROADMAP-V8.md
+++ b/docs/roadmap/ROADMAP-V8.md
@@ -227,7 +227,7 @@ Scope:
   binaries (Linux x86_64 + arm64, sha256) — the action's install source.
 - `agentdoc-dev/action`: composite `action.yml` (inputs `enforcement`, `scope`,
   `adoc-version`, `working-directory`, `github-token`), problem-matcher
-  annotations, marker-keyed sticky Review Report comment with a deterministic
+  annotations, marker-keyed sticky PR-report comment with a deterministic
   "Proposed Knowledge Objects" section, fixture-based integration workflow.
 - `.github/workflows/adoc-pr.yml` consumes the released action in advisory
   mode; `docs/guides/ci-integration.md` leads with the action, raw snippet


### PR DESCRIPTION
## Summary

V8.3.3 Composite Action Slice — supersedes the V8.3.2 packaging paragraph per **ADR-0047**, deliberately jumping the reserved ADR-0044 gate: Marketplace distribution is MVP surface, and advisory-first rollout needs a pinnable maintained artifact.

- `.github/workflows/release.yml`: tag-triggered prebuilt `adoc` binaries (Linux x86_64 + arm64, sha256-verified) — already live as [v0.1.0](https://github.com/agentdoc-dev/adoc/releases/tag/v0.1.0)
- `docs/adr/0047-composite-action-packaging.md`: the packaging decision, thin-action/brain-in-CLI boundary, version-coupling rule
- Roadmap V8.3.3 entry
- `.github/workflows/adoc-pr.yml`: dogfoods [agentdoc-dev/action@v1](https://github.com/agentdoc-dev/action) in advisory mode (flip to strict after one clean week, §24.3)
- `docs/guides/ci-integration.md`: action-first partner guide, raw snippet as appendix (docs-root `.md` would derive a one-segment page ID the Object ID grammar rejects, hence `guides/`)

## Test plan

- Action integration CI green on both arches (strict+clean passes, strict+broken fails, advisory+broken stays green): https://github.com/agentdoc-dev/action/actions/runs/29589531088
- This PR itself is the V8.3.2/V8.3.3 acceptance check: the AgentDoc Review Report comment should appear below, posted by the dogfood job
- `adoc check` on the dogfood corpus: 0 errors locally

https://claude.ai/code/session_01Q2e1QeRfnawcT7XqB1tusN