### PR TITLE
feat(cli): PR Report presentation redesign — repo-relative paths, --style layouts (V8.3.4)

### DIFF
--- a/crates/adoc-cli/src/cli.rs
+++ b/crates/adoc-cli/src/cli.rs
@@ -3,7 +3,7 @@ use std::path::PathBuf;
 
 use clap::{Parser, Subcommand, ValueEnum};
 
-use crate::presentation::{ColorChoice, FormatChoice};
+use crate::presentation::{CheckStyle, ColorChoice, FormatChoice};
 
 const ROOT_LONG_HELP: &str = "\
 Examples:
@@ -208,6 +208,30 @@ impl From<CliFormat> for FormatChoice {
     }
 }
 
+/// The Markdown layout requested on the command line (`adoc check --style`).
+/// Named "layout" in help text to keep it apart from `--format styled` and
+/// ANSI styling.
+#[derive(Clone, Copy, Default, ValueEnum)]
+pub(crate) enum CliCheckStyle {
+    /// One bullet per diagnostic; remediation help collapsed.
+    #[default]
+    Compact,
+    /// One table row per diagnostic; remediation help collapsed.
+    Table,
+    /// Per-file grouping with object_id/help sub-bullets.
+    Detailed,
+}
+
+impl From<CliCheckStyle> for CheckStyle {
+    fn from(s: CliCheckStyle) -> Self {
+        match s {
+            CliCheckStyle::Compact => Self::Compact,
+            CliCheckStyle::Table => Self::Table,
+            CliCheckStyle::Detailed => Self::Detailed,
+        }
+    }
+}
+
 /// The colour mode requested on the command line (`--color`).
 #[derive(Clone, Copy, Default, ValueEnum)]
 pub(crate) enum CliColor {
@@ -303,6 +327,9 @@ pub(crate) enum Commands {
         /// AgentDoc Source file or directory to check.
         #[arg(value_name = "PATH")]
         path: Option<PathBuf>,
+        /// Markdown layout for `--format markdown`; ignored by other formats.
+        #[arg(long, value_enum, default_value = "compact")]
+        style: CliCheckStyle,
     },
     #[command(
         about = "Convert Markdown sources to prose-mode .adoc, or back with --export (dry-run by default).",

--- a/crates/adoc-cli/src/commands/check.rs
+++ b/crates/adoc-cli/src/commands/check.rs
@@ -4,17 +4,17 @@ use std::path::PathBuf;
 use adoc_local::{CheckInput, LocalContext, UnrestrictedPathPolicy};
 
 use crate::error::CliError;
-use crate::presentation::{MarkdownReviewPresenter, ResolvedFormat};
+use crate::presentation::{CheckStyle, MarkdownReviewPresenter, ResolvedFormat};
 
 use super::{current_dir, eprint_diagnostics, print_diagnostics, print_summary, report};
 
-pub(crate) fn check(path: Option<PathBuf>, resolved: ResolvedFormat) -> i32 {
+pub(crate) fn check(path: Option<PathBuf>, style: CheckStyle, resolved: ResolvedFormat) -> i32 {
     let config_start = match current_dir() {
         Ok(path) => path,
         Err(error) => return report(error),
     };
 
-    let context = LocalContext::new(config_start, UnrestrictedPathPolicy);
+    let context = LocalContext::new(config_start.clone(), UnrestrictedPathPolicy);
     let outcome = match context.check(CheckInput { path }) {
         Ok(outcome) => outcome,
         Err(error) => return report(error.into()),
@@ -25,11 +25,16 @@ pub(crate) fn check(path: Option<PathBuf>, resolved: ResolvedFormat) -> i32 {
     // advisory-vs-strict a workflow decision, not a format one).
     if resolved == ResolvedFormat::Markdown {
         eprint_diagnostics(&outcome.diagnostics);
-        return MarkdownReviewPresenter::write_check(&outcome.diagnostics, &mut io::stdout())
-            .map_or_else(
-                |source| report(CliError::StdoutIo { source }),
-                |()| outcome.exit_code,
-            );
+        return MarkdownReviewPresenter::write_check(
+            &outcome.diagnostics,
+            &config_start,
+            style,
+            &mut io::stdout(),
+        )
+        .map_or_else(
+            |source| report(CliError::StdoutIo { source }),
+            |()| outcome.exit_code,
+        );
     }
     print_diagnostics(&outcome.diagnostics);
     print_summary(&outcome.diagnostics);

--- a/crates/adoc-cli/src/commands/mod.rs
+++ b/crates/adoc-cli/src/commands/mod.rs
@@ -126,13 +126,16 @@ fn current_dir() -> Result<PathBuf, CliError> {
 fn format_diagnostics(diagnostics: &[Diagnostic]) -> String {
     use std::fmt::Write as _;
 
+    // Repo-relative paths: GitHub problem matchers (and humans reading CI
+    // logs) resolve paths against the checkout root = the working directory.
+    let base = std::env::current_dir().ok();
     let mut out = String::new();
     for diagnostic in diagnostics {
         if let Some(span) = &diagnostic.span {
             writeln!(
                 out,
                 "{}:{}:{}: {}[{}] {}",
-                span.file.display(),
+                crate::presentation::relativize_path(&span.file, base.as_deref()).display(),
                 span.start.line,
                 span.start.column,
                 diagnostic.severity,

--- a/crates/adoc-cli/src/main.rs
+++ b/crates/adoc-cli/src/main.rs
@@ -61,7 +61,7 @@ fn run(arguments: impl IntoIterator<Item = String>) -> i32 {
             }
             match cli.command {
                 Commands::Init => init(),
-                Commands::Check { path } => check(path, resolved),
+                Commands::Check { path, style } => check(path, style.into(), resolved),
                 Commands::Migrate {
                     path,
                     write,

--- a/crates/adoc-cli/src/presentation/markdown.rs
+++ b/crates/adoc-cli/src/presentation/markdown.rs
@@ -58,10 +58,11 @@ impl MarkdownReviewPresenter {
         out.write_all(body.as_bytes())
     }
 
-    /// V6.3 `adoc impacted-by --format markdown`: the PR-comment shape —
-    /// `## Impacted by` header with code-quoted changed paths, one bullet per
-    /// impacted object with its reasons, then the same proof-obligations
-    /// task list as `adoc review`.
+    /// V8.3.4 `adoc impacted-by --format markdown`: the embeddable PR-comment
+    /// shape — a count-first changed-paths line with the full list collapsed
+    /// in `<details>`, one bullet per impacted object with its reasons, then
+    /// the proof-obligations task list under a bold label (the `##` heading
+    /// stays exclusive to the frozen `adoc review`/`diff` shape).
     pub(crate) fn write_impacted(
         envelope: &ImpactedEnvelope,
         out: &mut dyn io::Write,
@@ -69,7 +70,9 @@ impl MarkdownReviewPresenter {
         let mut body = String::new();
         render_impacted_by(&mut body, envelope);
         if !envelope.proof_obligations.is_empty() {
-            render_obligations(&mut body, &envelope.proof_obligations);
+            writeln!(body).expect("writing to String cannot fail");
+            writeln!(body, "**Proof obligations**").expect("writing to String cannot fail");
+            render_obligation_items(&mut body, &envelope.proof_obligations);
         }
         out.write_all(body.as_bytes())
     }
@@ -333,21 +336,33 @@ fn render_check_detailed(output: &mut String, diagnostics: &[Diagnostic], base: 
 fn render_impacted_by(output: &mut String, envelope: &ImpactedEnvelope) {
     // An empty changed set (e.g. `--ref` with no diff) gets an explicit
     // marker so a PR-comment reader can tell "ref had no diff" apart from
-    // a header that simply lost its path list.
+    // a count line that simply lost its paths.
     if envelope.changed_paths.is_empty() {
-        writeln!(output, "## Impacted by: _(no changed paths)_")
+        writeln!(output, "**Impacted by** _(no changed paths)_")
             .expect("writing to String cannot fail");
     } else {
-        let paths: Vec<String> = envelope
-            .changed_paths
-            .iter()
-            .map(|path| format!("`{path}`"))
-            .collect();
-        writeln!(output, "## Impacted by: {}", paths.join(", "))
-            .expect("writing to String cannot fail");
-    }
-    if envelope.impacted.is_empty() {
+        // Count-first (always-plural, matching the summary-line convention);
+        // the full list stays available but collapsed, so a large PR cannot
+        // flood the comment with its own file list.
+        writeln!(
+            output,
+            "**Impacted by** {} changed paths",
+            envelope.changed_paths.len()
+        )
+        .expect("writing to String cannot fail");
         writeln!(output).expect("writing to String cannot fail");
+        writeln!(output, "<details>").expect("writing to String cannot fail");
+        writeln!(output, "<summary>Changed paths</summary>")
+            .expect("writing to String cannot fail");
+        writeln!(output).expect("writing to String cannot fail");
+        for path in &envelope.changed_paths {
+            writeln!(output, "- `{path}`").expect("writing to String cannot fail");
+        }
+        writeln!(output).expect("writing to String cannot fail");
+        writeln!(output, "</details>").expect("writing to String cannot fail");
+    }
+    writeln!(output).expect("writing to String cannot fail");
+    if envelope.impacted.is_empty() {
         writeln!(output, "No impacted Knowledge Objects.").expect("writing to String cannot fail");
     }
     for record in &envelope.impacted {
@@ -632,9 +647,16 @@ fn render_impact(output: &mut String, impact: &[ImpactedObject]) {
     }
 }
 
+/// The frozen `adoc review`/`diff` obligations section (V3.5 shape — see the
+/// module doc). `adoc impacted-by` renders the same items under a bold label
+/// via `render_obligation_items`.
 fn render_obligations(output: &mut String, obligations: &[ProofObligation]) {
     writeln!(output).expect("writing to String cannot fail");
     writeln!(output, "## Proof obligations").expect("writing to String cannot fail");
+    render_obligation_items(output, obligations);
+}
+
+fn render_obligation_items(output: &mut String, obligations: &[ProofObligation]) {
     for obligation in obligations {
         if obligation.required_evidence.is_empty() {
             writeln!(
@@ -772,14 +794,60 @@ mod tests {
     #[test]
     fn impacted_by_header_marks_empty_changed_paths() {
         // Reachable via `--ref <ref>` with no diff: valid envelope, empty
-        // changed_paths. The header must say so instead of rendering
-        // `## Impacted by: ` with a trailing space.
+        // changed_paths. The count line must say so instead of rendering
+        // `**Impacted by** 0 changed paths` over a pointless details block.
         let envelope = ImpactedEnvelope::new(Vec::new(), Vec::new(), Vec::new(), Vec::new());
         let mut output = String::new();
         render_impacted_by(&mut output, &envelope);
         assert_eq!(
             output,
-            "## Impacted by: _(no changed paths)_\n\nNo impacted Knowledge Objects.\n"
+            "**Impacted by** _(no changed paths)_\n\nNo impacted Knowledge Objects.\n"
+        );
+    }
+
+    #[test]
+    fn impacted_by_puts_changed_paths_in_details_block() {
+        // V8.3.4: count-first — a large PR must not flood the comment with
+        // its own file list, so the paths collapse into `<details>`.
+        let envelope = ImpactedEnvelope::new(
+            vec!["a.rs".to_string(), "b.rs".to_string()],
+            Vec::new(),
+            Vec::new(),
+            Vec::new(),
+        );
+        let mut output = String::new();
+        render_impacted_by(&mut output, &envelope);
+        assert_eq!(
+            output,
+            "**Impacted by** 2 changed paths\n\n<details>\n<summary>Changed paths</summary>\n\n- `a.rs`\n- `b.rs`\n\n</details>\n\nNo impacted Knowledge Objects.\n"
+        );
+    }
+
+    #[test]
+    fn impacted_obligations_render_under_a_bold_label_not_a_heading() {
+        // The `## Proof obligations` heading stays exclusive to the frozen
+        // `adoc review`/`diff` markdown shape; the embeddable impacted-by
+        // body uses a bold label.
+        let envelope = ImpactedEnvelope::new(
+            vec!["a.rs".to_string()],
+            Vec::new(),
+            vec![obligation("billing.refunds")],
+            Vec::new(),
+        );
+        let mut out = Vec::new();
+        MarkdownReviewPresenter::write_impacted(&envelope, &mut out).expect("write to Vec");
+        let body = String::from_utf8(out).expect("utf8");
+        assert!(
+            body.contains("**Proof obligations**"),
+            "expected bold obligations label; got:\n{body}"
+        );
+        assert!(
+            !body.contains("## Proof obligations"),
+            "impacted-by must not emit the review heading; got:\n{body}"
+        );
+        assert!(
+            body.contains("- [ ] `billing.refunds`"),
+            "obligations keep the task-list items; got:\n{body}"
         );
     }
 

--- a/crates/adoc-cli/src/presentation/markdown.rs
+++ b/crates/adoc-cli/src/presentation/markdown.rs
@@ -74,17 +74,20 @@ impl MarkdownReviewPresenter {
         out.write_all(body.as_bytes())
     }
 
-    /// V8.3.1 `adoc check --format markdown`: the §24.4 PR-comment shape —
-    /// error/warning counts in the header, diagnostics grouped by source
-    /// file, `object_id`/`help` as sub-bullets, and a suggested next command.
-    /// A clean project still renders a body: a PR bot pasting stdout must
-    /// never post an empty comment.
+    /// V8.3.4 `adoc check --format markdown`: the PR-comment body. Heading
+    /// free (the embedder owns the hierarchy), bold error/warning summary
+    /// line, source paths relative to `base` (the working directory — the
+    /// checkout root in CI), one of three `--style` layouts, and a suggested
+    /// next command. A clean project still renders a body: a PR bot pasting
+    /// stdout must never post an empty comment.
     pub(crate) fn write_check(
         diagnostics: &[Diagnostic],
+        base: &std::path::Path,
+        style: CheckStyle,
         out: &mut dyn io::Write,
     ) -> io::Result<()> {
         let mut body = String::new();
-        render_check(&mut body, diagnostics);
+        render_check(&mut body, diagnostics, base, style);
         out.write_all(body.as_bytes())
     }
 
@@ -111,7 +114,24 @@ impl MarkdownReviewPresenter {
     }
 }
 
-fn render_check(output: &mut String, diagnostics: &[Diagnostic]) {
+/// Markdown layout for the `adoc check` PR-comment body (`--style`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CheckStyle {
+    /// One bullet per diagnostic; remediation help collapsed in `<details>`.
+    Compact,
+    /// One table row per diagnostic; remediation help collapsed in
+    /// `<details>`.
+    Table,
+    /// The V8.3.1 per-file grouping with `object_id`/`help` sub-bullets.
+    Detailed,
+}
+
+fn render_check(
+    output: &mut String,
+    diagnostics: &[Diagnostic],
+    base: &std::path::Path,
+    style: CheckStyle,
+) {
     let errors = diagnostics
         .iter()
         .filter(|diagnostic| diagnostic.severity == Severity::Error)
@@ -121,20 +141,147 @@ fn render_check(output: &mut String, diagnostics: &[Diagnostic]) {
         .filter(|diagnostic| diagnostic.severity == Severity::Warning)
         .count();
     // Always-plural counts — the exact convention of the plain summary line
-    // (`commands::format_summary`), so the two surfaces never disagree.
-    writeln!(
-        output,
-        "## adoc check: {errors} errors, {warnings} warnings"
-    )
+    // (`commands::format_summary`), so the two surfaces never disagree. The
+    // warning icon only appears when there is something to warn about.
+    let error_icon = if errors > 0 { "❌" } else { "✅" };
+    if warnings > 0 {
+        writeln!(
+            output,
+            "**{error_icon} {errors} errors · ⚠️ {warnings} warnings**"
+        )
+    } else {
+        writeln!(
+            output,
+            "**{error_icon} {errors} errors · {warnings} warnings**"
+        )
+    }
     .expect("writing to String cannot fail");
 
-    // Empty → deliberate fall-through: the group loop below is a no-op and
-    // only the unconditional suggested-action block follows.
     if diagnostics.is_empty() {
         writeln!(output).expect("writing to String cannot fail");
         writeln!(output, "No diagnostics.").expect("writing to String cannot fail");
+    } else {
+        match style {
+            CheckStyle::Compact => render_check_compact(output, diagnostics, base),
+            CheckStyle::Table => render_check_table(output, diagnostics, base),
+            CheckStyle::Detailed => render_check_detailed(output, diagnostics, base),
+        }
+        if style != CheckStyle::Detailed {
+            render_check_help(output, diagnostics, base);
+        }
     }
 
+    writeln!(output).expect("writing to String cannot fail");
+    let action = if errors > 0 {
+        "fix the errors above, then re-run `adoc check`."
+    } else if warnings > 0 {
+        "review the warnings above, then re-run `adoc check`."
+    } else {
+        "run `adoc build` to refresh the graph artifact."
+    };
+    writeln!(output, "Suggested action: {action}").expect("writing to String cannot fail");
+}
+
+fn check_icon(severity: Severity) -> &'static str {
+    match severity {
+        Severity::Error => "❌",
+        Severity::Warning => "⚠️",
+        Severity::Info => "ℹ️",
+    }
+}
+
+/// `path:line` with the path relative to `base`, or `None` for spanless
+/// diagnostics.
+fn check_location(diagnostic: &Diagnostic, base: &std::path::Path) -> Option<String> {
+    diagnostic.span.as_ref().map(|span| {
+        format!(
+            "{}:{}",
+            super::relativize_path(&span.file, Some(base)).display(),
+            span.start.line
+        )
+    })
+}
+
+fn render_check_compact(output: &mut String, diagnostics: &[Diagnostic], base: &std::path::Path) {
+    writeln!(output).expect("writing to String cannot fail");
+    for diagnostic in diagnostics {
+        let icon = check_icon(diagnostic.severity);
+        // Multi-line messages stay indented inside the list item.
+        let message = diagnostic.message.replace('\n', "\n  ");
+        match check_location(diagnostic, base) {
+            Some(location) => writeln!(
+                output,
+                "- {icon} `{location}` `{}` — {message}",
+                diagnostic.code
+            ),
+            None => writeln!(output, "- {icon} `{}` — {message}", diagnostic.code),
+        }
+        .expect("writing to String cannot fail");
+    }
+}
+
+/// GFM table cells cannot hold raw `|` or newlines.
+fn check_table_cell(text: &str) -> String {
+    text.replace('|', "\\|").replace('\n', "<br>")
+}
+
+fn render_check_table(output: &mut String, diagnostics: &[Diagnostic], base: &std::path::Path) {
+    writeln!(output).expect("writing to String cannot fail");
+    writeln!(output, "|    | Location | Code | Message |").expect("writing to String cannot fail");
+    writeln!(output, "|----|----------|------|---------|").expect("writing to String cannot fail");
+    for diagnostic in diagnostics {
+        let icon = check_icon(diagnostic.severity);
+        let location = check_location(diagnostic, base)
+            .map_or_else(|| "—".to_string(), |location| format!("`{location}`"));
+        writeln!(
+            output,
+            "| {icon} | {location} | `{}` | {} |",
+            diagnostic.code,
+            check_table_cell(&diagnostic.message)
+        )
+        .expect("writing to String cannot fail");
+    }
+}
+
+/// The collapsed remediation block shared by the compact and table styles.
+/// Entries anchor on the diagnostic's `object_id` when it has one — help
+/// texts speak about the Knowledge Object — falling back to `path:line`,
+/// then to the code.
+fn render_check_help(output: &mut String, diagnostics: &[Diagnostic], base: &std::path::Path) {
+    let entries: Vec<(String, &str)> = diagnostics
+        .iter()
+        .filter_map(|diagnostic| {
+            diagnostic.help.as_ref().map(|help| {
+                let anchor = diagnostic
+                    .object_id
+                    .clone()
+                    .or_else(|| check_location(diagnostic, base))
+                    .unwrap_or_else(|| diagnostic.code.to_string());
+                (anchor, help.as_str())
+            })
+        })
+        .collect();
+    if entries.is_empty() {
+        return;
+    }
+    writeln!(output).expect("writing to String cannot fail");
+    writeln!(output, "<details>").expect("writing to String cannot fail");
+    writeln!(
+        output,
+        "<summary>Remediation help ({})</summary>",
+        entries.len()
+    )
+    .expect("writing to String cannot fail");
+    writeln!(output).expect("writing to String cannot fail");
+    for (anchor, help) in entries {
+        let help = help.replace('\n', "\n  ");
+        writeln!(output, "- `{anchor}` — {help}").expect("writing to String cannot fail");
+    }
+    writeln!(output).expect("writing to String cannot fail");
+    writeln!(output, "</details>").expect("writing to String cannot fail");
+}
+
+fn render_check_detailed(output: &mut String, diagnostics: &[Diagnostic], base: &std::path::Path) {
     // Group by source file in first-seen order (the compile walk is already
     // deterministic); spanless diagnostics get an explicit marker group so
     // they cannot silently vanish from the comment.
@@ -149,17 +296,17 @@ fn render_check(output: &mut String, diagnostics: &[Diagnostic]) {
     for (file, entries) in groups {
         writeln!(output).expect("writing to String cannot fail");
         match file {
-            Some(path) => writeln!(output, "### `{}`", path.display()),
-            None => writeln!(output, "### _(no source span)_"),
+            Some(path) => writeln!(
+                output,
+                "**`{}`**",
+                super::relativize_path(path, Some(base)).display()
+            ),
+            None => writeln!(output, "**_(no source span)_**"),
         }
         .expect("writing to String cannot fail");
         writeln!(output).expect("writing to String cannot fail");
         for diagnostic in entries {
-            let icon = match diagnostic.severity {
-                Severity::Error => "❌",
-                Severity::Warning => "⚠️",
-                Severity::Info => "ℹ️",
-            };
+            let icon = check_icon(diagnostic.severity);
             // Multi-line messages stay indented inside the list item.
             let message = diagnostic.message.replace('\n', "\n  ");
             match diagnostic.span.as_ref() {
@@ -181,16 +328,6 @@ fn render_check(output: &mut String, diagnostics: &[Diagnostic]) {
             }
         }
     }
-
-    writeln!(output).expect("writing to String cannot fail");
-    let action = if errors > 0 {
-        "fix the errors above, then re-run `adoc check`."
-    } else if warnings > 0 {
-        "review the warnings above, then re-run `adoc check`."
-    } else {
-        "run `adoc build` to refresh the graph artifact."
-    };
-    writeln!(output, "Suggested action: {action}").expect("writing to String cannot fail");
 }
 
 fn render_impacted_by(output: &mut String, envelope: &ImpactedEnvelope) {

--- a/crates/adoc-cli/src/presentation/markdown.rs
+++ b/crates/adoc-cli/src/presentation/markdown.rs
@@ -1,5 +1,7 @@
-//! Markdown presenter for `adoc diff`, `adoc review`, `adoc impacted-by`
-//! (V6.3), and `adoc check` (V8.3.1).
+//! Markdown presenter for `adoc diff`, `adoc review`, `adoc impacted-by`,
+//! and `adoc check`. The check and impacted-by bodies are embeddable
+//! (heading-free, repo-relative paths — V8.3.4); the diff/review shape below
+//! is frozen.
 //!
 //! Produces GitHub-flavored Markdown that pastes cleanly into a PR review
 //! comment. The V3.5 diff/review shape is frozen at slice time:

--- a/crates/adoc-cli/src/presentation/mod.rs
+++ b/crates/adoc-cli/src/presentation/mod.rs
@@ -7,7 +7,7 @@ pub(crate) mod styled;
 pub(crate) mod terminal;
 
 pub(crate) use json::JsonPresenter;
-pub(crate) use markdown::MarkdownReviewPresenter;
+pub(crate) use markdown::{CheckStyle, MarkdownReviewPresenter};
 pub(crate) use plain::PlainPresenter;
 pub(crate) use port::{
     ExpiresInfo, PresentationEntry, PresentationRecord, RenderMeta, RetrievalPresenter,

--- a/crates/adoc-cli/src/presentation/mod.rs
+++ b/crates/adoc-cli/src/presentation/mod.rs
@@ -23,10 +23,18 @@ use std::path::Path;
 /// and PR-comment readers expect). Paths outside `base` stay unchanged; a
 /// cosmetic leading `./` is stripped either way.
 pub(crate) fn relativize_path<'a>(path: &'a Path, base: Option<&Path>) -> &'a Path {
-    if let Some(base) = base
-        && let Ok(stripped) = path.strip_prefix(base)
-    {
-        return stripped;
+    if let Some(base) = base {
+        if let Ok(stripped) = path.strip_prefix(base) {
+            return stripped;
+        }
+        // strip_prefix is byte-wise: a symlinked base (macOS `/tmp` →
+        // `/private/tmp`) never matches a physical span path. Retry against
+        // the physical base before giving up.
+        if let Ok(canonical) = base.canonicalize()
+            && let Ok(stripped) = path.strip_prefix(&canonical)
+        {
+            return stripped;
+        }
     }
     path.strip_prefix(".").unwrap_or(path)
 }
@@ -132,5 +140,30 @@ mod relativize_tests {
             relativize_path(Path::new("a.adoc"), None),
             Path::new("a.adoc")
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn strips_a_symlinked_base_against_a_physical_path() {
+        // macOS `/tmp` → `/private/tmp`: the cwd can be a symlink while span
+        // paths are physical. A byte-wise strip alone would silently no-op.
+        let dir =
+            std::env::temp_dir().join(format!("adoc-relativize-symlink-{}", std::process::id()));
+        let physical = dir.join("physical");
+        let link = dir.join("link");
+        std::fs::create_dir_all(&physical).expect("create physical dir");
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&physical, &link).expect("create symlink");
+
+        let span_path = physical
+            .canonicalize()
+            .expect("canonicalize")
+            .join("a.adoc");
+        assert_eq!(
+            relativize_path(&span_path, Some(&link)),
+            Path::new("a.adoc")
+        );
+
+        std::fs::remove_dir_all(&dir).expect("cleanup");
     }
 }

--- a/crates/adoc-cli/src/presentation/mod.rs
+++ b/crates/adoc-cli/src/presentation/mod.rs
@@ -16,6 +16,20 @@ pub(crate) use port::{
 pub(crate) use styled::StyledPresenter;
 
 use adoc_core::Diagnostic;
+use std::path::Path;
+
+/// Renders a diagnostic path relative to `base` (the process working
+/// directory — the repo root in CI, which is what GitHub problem matchers
+/// and PR-comment readers expect). Paths outside `base` stay unchanged; a
+/// cosmetic leading `./` is stripped either way.
+pub(crate) fn relativize_path<'a>(path: &'a Path, base: Option<&Path>) -> &'a Path {
+    if let Some(base) = base
+        && let Ok(stripped) = path.strip_prefix(base)
+    {
+        return stripped;
+    }
+    path.strip_prefix(".").unwrap_or(path)
+}
 
 /// The output format requested by the user via `--format`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -79,5 +93,44 @@ pub(crate) fn make_presenter(
         ResolvedFormat::Markdown => {
             unreachable!("markdown format is not supported by retrieval commands")
         }
+    }
+}
+
+#[cfg(test)]
+mod relativize_tests {
+    use std::path::Path;
+
+    use super::relativize_path;
+
+    #[test]
+    fn strips_the_base_prefix() {
+        assert_eq!(
+            relativize_path(Path::new("/repo/docs/a.adoc"), Some(Path::new("/repo"))),
+            Path::new("docs/a.adoc")
+        );
+    }
+
+    #[test]
+    fn keeps_paths_outside_the_base() {
+        assert_eq!(
+            relativize_path(Path::new("/elsewhere/a.adoc"), Some(Path::new("/repo"))),
+            Path::new("/elsewhere/a.adoc")
+        );
+    }
+
+    #[test]
+    fn strips_a_leading_dot_slash() {
+        assert_eq!(
+            relativize_path(Path::new("./a.adoc"), Some(Path::new("/repo"))),
+            Path::new("a.adoc")
+        );
+    }
+
+    #[test]
+    fn keeps_plain_relative_paths_without_a_base() {
+        assert_eq!(
+            relativize_path(Path::new("a.adoc"), None),
+            Path::new("a.adoc")
+        );
     }
 }

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -2693,6 +2693,41 @@ fn check_markdown_warnings_only_exits_zero_with_suggestion() {
     );
 }
 
+/// V8.3.4: stderr diagnostics feed a GitHub problem matcher, which needs
+/// repo-relative paths to annotate PR files — absolute runner paths never
+/// match a repo file, so the annotations silently vanish.
+#[test]
+fn check_stderr_diagnostics_are_repo_relative() {
+    let workspace = TestWorkspace::new("check-stderr-relative-paths");
+    write_fixture_to_workspace(&workspace, "v8_3/broken.adoc", "broken.adoc");
+
+    let root = workspace
+        .root
+        .canonicalize()
+        .expect("workspace root canonicalizes");
+    let output = adoc_command()
+        .current_dir(&root)
+        .args([
+            "check",
+            root.to_str().expect("root path is utf-8"),
+            "--format",
+            "markdown",
+        ])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.lines().any(|line| line.starts_with("broken.adoc:")),
+        "expected repo-relative diagnostic paths on stderr, got:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains(root.to_str().expect("root path is utf-8")),
+        "expected no absolute workspace prefix on stderr, got:\n{stderr}"
+    );
+}
+
 /// Lifting the rejection for `check` must not lift it for anything else:
 /// commands without a markdown presenter still exit 2.
 #[test]

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -2586,10 +2586,11 @@ fn check_reports_unreadable_source_path() {
     assert!(stdout.contains("1 errors"));
 }
 
-/// V8.3.1: `adoc check --format markdown` — the PR-comment body. Diagnostics
-/// grouped by file, error/warning counts in the header, object_id/help as
-/// sub-bullets, a suggested next command. Pinned as a golden so the §24.4
-/// shape drifts loudly, not silently.
+/// V8.3.4: `adoc check --format markdown` — the PR-comment body in the
+/// default compact layout. Bold summary line, one bullet per diagnostic with
+/// repo-relative `path:line`, remediation help collapsed in `<details>`, a
+/// suggested next command. Pinned as a golden so the shape drifts loudly,
+/// not silently.
 #[test]
 fn check_markdown_matches_golden_for_error_and_warning_fixture() {
     let workspace = TestWorkspace::new("check-markdown-golden");
@@ -2684,12 +2685,89 @@ fn check_markdown_warnings_only_exits_zero_with_suggestion() {
     assert_eq!(output.status.code(), Some(0));
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("## adoc check: 0 errors, 1 warnings"),
-        "expected warning-only header, got:\n{stdout}"
+        stdout.contains("**✅ 0 errors · ⚠️ 1 warnings**"),
+        "expected warning-only summary line, got:\n{stdout}"
     );
     assert!(
         stdout.contains("Suggested action: review the warnings above, then re-run `adoc check`."),
         "expected warnings-only suggested action, got:\n{stdout}"
+    );
+}
+
+/// V8.3.4: `--style table` — the same diagnostics as a GFM table, pinned as
+/// a golden alongside the compact default.
+#[test]
+fn check_markdown_table_matches_golden() {
+    let workspace = TestWorkspace::new("check-markdown-table-golden");
+    write_fixture_to_workspace(&workspace, "v8_3/broken.adoc", "broken.adoc");
+    write_fixture_to_workspace(&workspace, "v8_3/overdue.adoc", "overdue.adoc");
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", ".", "--format", "markdown", "--style", "table"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(output.status.code(), Some(1));
+    support::assert_markdown_matches_golden(
+        "v8_3/check_table.md",
+        &String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+/// V8.3.4: `--style detailed` keeps the V8.3.1 per-file grouping with
+/// object_id/help sub-bullets — only the `##`/`###` headings give way to
+/// embeddable bold labels.
+#[test]
+fn check_markdown_detailed_matches_golden() {
+    let workspace = TestWorkspace::new("check-markdown-detailed-golden");
+    write_fixture_to_workspace(&workspace, "v8_3/broken.adoc", "broken.adoc");
+    write_fixture_to_workspace(&workspace, "v8_3/overdue.adoc", "overdue.adoc");
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", ".", "--format", "markdown", "--style", "detailed"])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(output.status.code(), Some(1));
+    support::assert_markdown_matches_golden(
+        "v8_3/check_detailed.md",
+        &String::from_utf8_lossy(&output.stdout),
+    );
+}
+
+/// V8.3.4: the markdown body (the PR comment) relativizes absolute source
+/// paths the same way the stderr diagnostics do.
+#[test]
+fn check_markdown_body_relativizes_absolute_source_paths() {
+    let workspace = TestWorkspace::new("check-markdown-relative-paths");
+    write_fixture_to_workspace(&workspace, "v8_3/broken.adoc", "broken.adoc");
+
+    let root = workspace
+        .root
+        .canonicalize()
+        .expect("workspace root canonicalizes");
+    let output = adoc_command()
+        .current_dir(&root)
+        .args([
+            "check",
+            root.to_str().expect("root path is utf-8"),
+            "--format",
+            "markdown",
+        ])
+        .output()
+        .expect("adoc check runs");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("`broken.adoc:7`"),
+        "expected repo-relative path in the comment body, got:\n{stdout}"
+    );
+    assert!(
+        !stdout.contains(root.to_str().expect("root path is utf-8")),
+        "expected no absolute workspace prefix in the comment body, got:\n{stdout}"
     );
 }
 

--- a/crates/adoc-cli/tests/fixtures/v8_3/check_clean.md
+++ b/crates/adoc-cli/tests/fixtures/v8_3/check_clean.md
@@ -1,4 +1,4 @@
-## adoc check: 0 errors, 0 warnings
+**✅ 0 errors · 0 warnings**
 
 No diagnostics.
 

--- a/crates/adoc-cli/tests/fixtures/v8_3/check_detailed.md
+++ b/crates/adoc-cli/tests/fixtures/v8_3/check_detailed.md
@@ -1,0 +1,15 @@
+**❌ 1 errors · ⚠️ 1 warnings**
+
+**`broken.adoc`**
+
+- ❌ `ref.broken` (line 7) — depends_on target `missing.object` does not resolve to a declared Knowledge Object
+  - object_id: `missing.object`
+  - help: Relation targets must name an existing Knowledge Object. Supported relation fields: `depends_on`, `supersedes`, `related_to`.
+
+**`overdue.adoc`**
+
+- ⚠️ `task.overdue` (line 6) — open task `ci.update-runbook` is overdue (due 2020-01-01)
+  - object_id: `ci.update-runbook`
+  - help: Complete the task and set `status: done`, or move its `due` date.
+
+Suggested action: fix the errors above, then re-run `adoc check`.

--- a/crates/adoc-cli/tests/fixtures/v8_3/check_table.md
+++ b/crates/adoc-cli/tests/fixtures/v8_3/check_table.md
@@ -1,7 +1,9 @@
 **❌ 1 errors · ⚠️ 1 warnings**
 
-- ❌ `broken.adoc:7` `ref.broken` — depends_on target `missing.object` does not resolve to a declared Knowledge Object
-- ⚠️ `overdue.adoc:6` `task.overdue` — open task `ci.update-runbook` is overdue (due 2020-01-01)
+|    | Location | Code | Message |
+|----|----------|------|---------|
+| ❌ | `broken.adoc:7` | `ref.broken` | depends_on target `missing.object` does not resolve to a declared Knowledge Object |
+| ⚠️ | `overdue.adoc:6` | `task.overdue` | open task `ci.update-runbook` is overdue (due 2020-01-01) |
 
 <details>
 <summary>Remediation help (2)</summary>

--- a/crates/adoc-cli/tests/review_cli.rs
+++ b/crates/adoc-cli/tests/review_cli.rs
@@ -1053,8 +1053,9 @@ fn impacted_by_input_shapes_are_mutually_exclusive_and_one_is_required() {
     );
 }
 
-/// `--format markdown` renders the V3.5-style PR-comment shape: an
-/// `## Impacted by` header plus the proof-obligations task list.
+/// `--format markdown` renders the V8.3.4 embeddable PR-comment shape: a
+/// count-first changed-paths line with the list collapsed in `<details>`,
+/// plus the proof-obligations task list under a bold label.
 #[test]
 fn impacted_by_markdown_renders_header_and_obligation_task_list() {
     let workspace = build_billing_pilot_with_impacts("impacted-by-markdown");
@@ -1079,8 +1080,12 @@ fn impacted_by_markdown_renders_header_and_obligation_task_list() {
     );
     let stdout = stdout(&output);
     assert!(
-        stdout.contains("## Impacted by"),
-        "markdown must open with the impacted-by header; got:\n{stdout}"
+        stdout.contains("**Impacted by** 1 changed paths"),
+        "markdown must open with the count-first changed-paths line; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("<details>") && stdout.contains("<summary>Changed paths</summary>"),
+        "changed paths must collapse into a details block; got:\n{stdout}"
     );
     assert!(
         stdout.contains("`billing.refunds`"),
@@ -1089,6 +1094,10 @@ fn impacted_by_markdown_renders_header_and_obligation_task_list() {
     assert!(
         stdout.contains("`crates/billing/src/refund.rs`"),
         "matched path must be code-quoted; got:\n{stdout}"
+    );
+    assert!(
+        stdout.contains("**Proof obligations**"),
+        "obligations must sit under a bold label, not a heading; got:\n{stdout}"
     );
     assert!(
         stdout.contains("- [ ] `billing.refunds`"),

--- a/docs/guides/ci-integration.md
+++ b/docs/guides/ci-integration.md
@@ -27,8 +27,8 @@ jobs:
 
 Start in the default `advisory` mode; flip to `enforcement: strict` after a
 clean week. See the [action's README](https://github.com/agentdoc-dev/action) for
-all inputs (`enforcement`, `scope`, `adoc-version`, `working-directory`,
-`github-token`), fork-PR behavior, and security notes.
+all inputs (`enforcement`, `scope`, `report-style`, `adoc-version`,
+`working-directory`, `github-token`), fork-PR behavior, and security notes.
 
 This repository's own `.github/workflows/adoc-pr.yml` is the continuously
 tested copy of this snippet.
@@ -48,6 +48,7 @@ tar -xzf adoc-v0.1.0-x86_64-unknown-linux-gnu.tar.gz
 # validate and query (from the directory holding agentdoc.config.yaml)
 ./adoc build --no-embeddings || true             # build exit 1 = corpus errors; check is the gate
 ./adoc check --format markdown > check.md        # exit 1 on errors = your gate
+# --style compact (default) | table | detailed picks the check body layout
 ./adoc impacted-by --ref origin/main --format markdown > impacted.md
 
 # post/update one PR comment keyed on the marker
@@ -59,4 +60,6 @@ cat check.md impacted.md >> report.md
 
 `adoc check --format markdown` writes the comment body to stdout and
 `file:line:col: severity[code] message` diagnostics to stderr; the exit code
-(0 clean / 1 errors) is identical across formats.
+(0 clean / 1 errors) is identical across formats. Both surfaces render paths
+relative to the working directory — the checkout root in CI — so problem
+matchers and PR readers see repo paths, never runner paths (V8.3.4).

--- a/docs/roadmap/ROADMAP-V8.md
+++ b/docs/roadmap/ROADMAP-V8.md
@@ -238,6 +238,32 @@ Commit shape: `feat(ci): tagged release workflow with prebuilt adoc binaries (V8
 
 Acceptance: unchanged from V8.3.2 — a real PR in this repository shows the comment; the advisory→strict decision is recorded in the workflow file's history.
 
+### V8.3.4: PR Report Presentation Slice
+
+The first live consumer comment (storyos) exposed three presentation defects:
+absolute runner paths in check spans (breaking problem-matcher annotations and
+dominating the layout), `##` headings inside embeddable markdown bodies
+(inverting the embedder's hierarchy), and noise (per-file headings, inline
+changed-path lists). Presentation-layer fixes only; span semantics, envelopes,
+and the frozen `adoc review` markdown shape are untouched.
+
+Scope:
+
+- Diagnostic paths (stderr/plain and markdown bodies) render relative to the
+  working directory — the checkout root in CI — falling back to the original
+  path outside it.
+- `adoc check --format markdown` gains `--style compact|table|detailed`
+  (default `compact`): heading-free body, bold summary line, one bullet or
+  table row per diagnostic, remediation help collapsed in a `<details>` block;
+  `detailed` keeps the V8.3.1 per-file grouping with bold labels.
+- `adoc impacted-by --format markdown`: count-first changed-paths line with
+  the full list in `<details>`; Proof obligations keep their task list under a
+  bold label (the `##` wrapper remains exclusive to `adoc review`/`diff`).
+
+Commit shape: `feat(cli): repo-relative diagnostic paths for problem matchers (V8.3.4)` → `feat(cli): check --style compact|table|detailed markdown layouts (V8.3.4)` → `feat(cli): impacted-by markdown count-first PR-comment shape (V8.3.4)` → `docs(v8): ci-integration guide for redesigned PR-comment shapes (V8.3.4)`.
+
+Acceptance: the sticky comment on a real PR renders repo-relative paths with correct heading hierarchy, and problem-matcher annotations appear in the Files-changed tab.
+
 ---
 
 ## V8.4: Contract Freeze and Knowledge Health


### PR DESCRIPTION
## Summary

The first live consumer comment (storyos PR #636) exposed three presentation defects in the PR Report surfaces; this is the V8.3.4 presentation slice fixing all three in the CLI presenters:

- **Repo-relative diagnostic paths** — stderr diagnostics and the markdown bodies strip the working-directory prefix, so GitHub problem-matcher annotations resolve to repo files (they silently vanished before) and the comment stops printing `/home/runner/...` paths.
- **`adoc check --style compact|table|detailed`** — the check markdown body is now heading-free with a bold summary line; compact (new default) renders one bullet per diagnostic with remediation help collapsed in `<details>`; table adds GFM cell escaping; detailed keeps the V8.3.1 per-file grouping under bold labels. Golden-pinned per layout.
- **impacted-by count-first shape** — changed paths collapse into `<details>` behind a count line; Proof obligations render under a bold label. The `## Proof obligations` heading stays exclusive to the frozen `adoc review`/`diff` shape (`render_obligation_items` split; review goldens unchanged).

Roadmap: V8.3.4 entry added. Follow-up: adoc v0.1.1 release + `agentdoc-dev/action` v1.1.0 consuming it (`report-style` input, diff-gate path fix).

## Testing

- New goldens `check.md` (compact), `check_table.md`, `check_detailed.md` + relativization integration tests (stderr + body)
- `render_impacted_by`/obligation-label unit tests; review markdown goldens intentionally untouched
- `cargo test --workspace --locked`, clippy `-D warnings`, `cargo doc` all green

https://claude.ai/code/session_01Q2e1QeRfnawcT7XqB1tusN