### PR TITLE
feat: V8.5.1 Evidence Anchor — deterministic evidence hash verification in adoc check

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -348,6 +348,10 @@ _Avoid_: automated contradiction detection in V5, contradiction with one claim, 
 A reusable evidence **Knowledge Object** (PRD §13.15). Required fields: `id`, `kind` (**Evidence Kind**), exactly one of `path: RelPath` or `url: Url`, `body`. The `body` is the prose explanation of what this source contains. Per ADR-0027, **Source Objects** coexist with inline V0 evidence fields on `claim` and `decision`; references to source objects are an opt-in upgrade, never a forced migration. Lives at `domain/knowledge_object/source.rs`.
 _Avoid_: source object with both `path:` and `url:`, source object with neither, deprecating inline evidence in V5
 
+**Evidence Anchor**:
+The opt-in `hash` field on a path-target **Source Object**: a `sha256:` + 64-lowercase-hex hash of the cited file's full bytes taken at verification time (ADR-0048, V8.5.1). `adoc check` re-hashes the file through the `EvidenceFileReader` port and warns `evidence.hash_drift` when the cited content has changed — a deterministic changed-not-necessarily-wrong signal; the semantic judgment stays human. Absent `hash` means no reads and no diagnostics. Complements the path axis: `impacts:`/evidence paths answer "is a cited path in this diff", the anchor answers "did the cited bytes move since verification".
+_Avoid_: line-span anchor, symbol resolution, automatic hash refresh, drift as a validation error or CI gate, automated contradiction detection, confusing it with **Base Hash** (graph-node hash for patches) or `patch.source_drift` (artifact-vs-source freshness)
+
 **Evidence Kind**:
 A value object enumerating the PRD §15.1 evidence types: `source_code`, `test`, `commit`, `pull_request`, `issue`, `design_doc`, `human_review`, `external_url`, `api_schema`, `runtime_metric`, `incident`, `support_ticket`, `audit_record`, `policy_reference`, `dataset`, `experiment`. Lives at `domain/value_objects/evidence_kind.rs`; `#[non_exhaustive]`, case-sensitive `TryFrom<&str>`, unknown kinds emit `schema.evidence_unknown_kind`.
 _Avoid_: free-form evidence kind strings, deriving evidence kind from field name alone, accepting alias spellings

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -315,6 +315,58 @@ fn check_rejects_unsafe_link_with_source_location() {
 }
 
 #[test]
+fn check_warns_on_drifted_evidence_anchor_and_exits_zero() {
+    let workspace = TestWorkspace::new("check-evidence-anchor-drift");
+    workspace.write("src/consume.ts", "export const consume = 1;\n");
+    let stale_hash = format!("sha256:{}", "a".repeat(64));
+    workspace.write(
+        "docs/index.adoc",
+        &format!(
+            "# Billing @doc(team.billing)\n\n::source billing.consume\nkind: source_code\npath: src/consume.ts\nhash: {stale_hash}\n--\nConsume implementation.\n::\n"
+        ),
+    );
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: none\n",
+    );
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check"])
+        .output()
+        .expect("adoc check runs");
+
+    assert!(
+        output.status.success(),
+        "anchor drift is a warning and must not fail check\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("warning[evidence.hash_drift]"),
+        "expected evidence.hash_drift warning:\n{stdout}"
+    );
+    assert!(
+        stdout.contains(&stale_hash),
+        "help should name the expected (authored) hash:\n{stdout}"
+    );
+    assert!(stdout.contains("0 errors, 1 warnings"), "{stdout}");
+
+    let markdown = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["check", "--format", "markdown"])
+        .output()
+        .expect("adoc check --format markdown runs");
+    assert!(markdown.status.success());
+    let markdown_stdout = String::from_utf8_lossy(&markdown.stdout);
+    assert!(
+        markdown_stdout.contains("evidence.hash_drift"),
+        "markdown report should carry the drift code:\n{markdown_stdout}"
+    );
+}
+
+#[test]
 fn build_renders_v0_1_prose_fixture_to_graph_json() {
     let workspace = TestWorkspace::new("build-renders-prose-golden-graph");
     let fixture_contents = fs::read_to_string(fixture_path("v0_1/prose_page.adoc"))

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 
 use chrono::NaiveDate;
 
+use crate::application::evidence_anchor::check_evidence_anchors;
 use crate::application::resolve_knowledge_objects::{
     resolve_knowledge_objects, suppress_unknown_kind_shape_diagnostics,
 };
@@ -10,6 +11,7 @@ use crate::application::resolve_object_references::resolve_object_references;
 use crate::domain::ast::{PageAst, WorkspaceAst};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 use crate::domain::ports::embedding_provider::{EmbeddingError, EmbeddingProvider};
+use crate::domain::ports::evidence_file::EvidenceFileReader;
 use crate::domain::ports::source_provider::{SourceLoadError, SourceLoadErrorKind, SourceProvider};
 use crate::domain::source::SourceFile;
 use crate::infrastructure::artifact::GraphJsonArtifact;
@@ -76,7 +78,26 @@ pub(crate) fn compile_with_provider_for_date<P: SourceProvider>(
     provider: &P,
     today: NaiveDate,
 ) -> CompileResult {
-    run_compile_pipeline(provider, None, today)
+    run_compile_pipeline(provider, None, today, None)
+}
+
+/// The check entry with Evidence Anchor verification (V8.5.1, ADR-0048).
+/// Only check threads a reader — build, review, diff, and patch recompiles
+/// stay anchor-free so worktree snapshots and pinned fixtures never read
+/// evidence files.
+pub(crate) fn compile_with_provider_anchored<P: SourceProvider>(
+    provider: &P,
+    anchor: &dyn EvidenceFileReader,
+) -> CompileResult {
+    compile_with_provider_anchored_for_date(provider, anchor, local_today())
+}
+
+pub(crate) fn compile_with_provider_anchored_for_date<P: SourceProvider>(
+    provider: &P,
+    anchor: &dyn EvidenceFileReader,
+    today: NaiveDate,
+) -> CompileResult {
+    run_compile_pipeline(provider, None, today, Some(anchor))
 }
 
 pub(crate) fn build_with_provider<P: SourceProvider>(
@@ -91,7 +112,7 @@ pub(crate) fn build_with_provider_for_date<P: SourceProvider>(
     options: BuildOptions<'_>,
     today: NaiveDate,
 ) -> CompileResult {
-    run_compile_pipeline(provider, Some(options), today)
+    run_compile_pipeline(provider, Some(options), today, None)
 }
 
 pub(crate) struct BuildOptions<'a> {
@@ -114,6 +135,7 @@ fn run_compile_pipeline<P: SourceProvider>(
     provider: &P,
     mut build_options: Option<BuildOptions<'_>>,
     today: NaiveDate,
+    anchor: Option<&dyn EvidenceFileReader>,
 ) -> CompileResult {
     // Pipeline stages: load → validate-source-pages → resolve-KOs →
     // resolve-object-references → validate-resolved-pages → assemble →
@@ -139,6 +161,9 @@ fn run_compile_pipeline<P: SourceProvider>(
     diagnostics.extend(validate_resolved_pages(&parsed, today));
     let workspace = assemble_workspace(parsed);
     diagnostics.extend(validate_workspace(&workspace));
+    if let Some(reader) = anchor {
+        diagnostics.extend(check_evidence_anchors(&workspace, reader));
+    }
     if let Some(options) = &build_options {
         diagnostics.extend(build_embedding_diagnostics(options));
     }

--- a/crates/adoc-core/src/application/evidence_anchor.rs
+++ b/crates/adoc-core/src/application/evidence_anchor.rs
@@ -71,11 +71,27 @@ pub(crate) fn check_evidence_anchors(
             match AnchorHash::try_new(authored) {
                 Err(_) => {
                     let mut help = DiagnosticCode::EvidenceHashInvalid.default_help().to_string();
-                    if let CachedRead::Hash(actual) = read {
-                        help = format!(
-                            "{help} The actual content hash of `{path}` is `{actual}`.",
-                            path = path.as_str()
-                        );
+                    // Surface the read outcome too, so a missing/unreadable
+                    // target is not discovered only after the hash is fixed.
+                    match read {
+                        CachedRead::Hash(actual) => {
+                            help = format!(
+                                "{help} The actual content hash of `{path}` is `{actual}`.",
+                                path = path.as_str()
+                            );
+                        }
+                        CachedRead::Missing => {
+                            help = format!(
+                                "{help} Also: the anchored path `{path}` does not exist.",
+                                path = path.as_str()
+                            );
+                        }
+                        CachedRead::Unreadable(message) => {
+                            help = format!(
+                                "{help} Also: `{path}` could not be read: {message}.",
+                                path = path.as_str()
+                            );
+                        }
                     }
                     diagnostics.push(
                         Diagnostic::warning(
@@ -312,6 +328,23 @@ mod tests {
                 .expect("help")
                 .contains(&cited_hash()),
             "bootstrap path: help carries the actual hash"
+        );
+    }
+
+    #[test]
+    fn malformed_hash_on_missing_target_names_the_missing_path_in_help() {
+        let reader = RecordingReader::new(BTreeMap::new());
+        let text = source_page("hash: sha256:0\n");
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.code, DiagnosticCode::EvidenceHashInvalid);
+        let help = diagnostic.help.as_deref().expect("help");
+        assert!(
+            help.contains("`src/consume.ts` does not exist"),
+            "help surfaces the missing target alongside the invalid hash: {help}"
         );
     }
 

--- a/crates/adoc-core/src/application/evidence_anchor.rs
+++ b/crates/adoc-core/src/application/evidence_anchor.rs
@@ -1,0 +1,392 @@
+//! Evidence Anchor verification pass (V8.5.1, ADR-0048).
+//!
+//! Re-hashes every file a path-target `source` object anchors via its
+//! `hash` field and emits `evidence.*` warnings when the cited bytes
+//! drifted, the target is gone, the value is malformed, or the anchor sits
+//! on a url source. Runs only from the check entry point — build, review,
+//! diff, and patch recompiles never read evidence files. Opt-in: a source
+//! without `hash` costs zero reads and zero diagnostics.
+
+use std::collections::BTreeMap;
+
+use crate::application::hashing::sha256_prefixed;
+use crate::domain::ast::{BlockAst, WorkspaceAst};
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
+use crate::domain::knowledge_object::KnowledgeObject;
+use crate::domain::ports::evidence_file::{EvidenceFileRead, EvidenceFileReader};
+use crate::domain::value_objects::anchor_hash::AnchorHash;
+
+const HASH_FIELD: &str = "hash";
+
+/// One read + hash per distinct cited path, however many sources cite it.
+enum CachedRead {
+    Hash(String),
+    Missing,
+    Unreadable(String),
+}
+
+pub(crate) fn check_evidence_anchors(
+    workspace: &WorkspaceAst,
+    reader: &dyn EvidenceFileReader,
+) -> Vec<Diagnostic> {
+    let mut cache: BTreeMap<&str, CachedRead> = BTreeMap::new();
+    let mut diagnostics = Vec::new();
+
+    for page in &workspace.pages {
+        for block in &page.blocks {
+            let BlockAst::KnowledgeObject(ko) = block else {
+                continue;
+            };
+            let KnowledgeObject::Source(source) = ko.as_ref() else {
+                continue;
+            };
+            let Some(authored) = source.fields().get(HASH_FIELD) else {
+                continue;
+            };
+            let id = source.id().as_str();
+
+            let Some(path) = source.path() else {
+                diagnostics.push(
+                    Diagnostic::warning(
+                        DiagnosticCode::EvidenceHashUnverifiable,
+                        format!(
+                            "source `{id}` has a `hash` anchor but a `url` target; \
+                             url evidence cannot be verified offline"
+                        ),
+                    )
+                    .with_span(source.span().clone())
+                    .with_object_id(id),
+                );
+                continue;
+            };
+
+            let read = cache
+                .entry(path.as_str())
+                .or_insert_with(|| match reader.read(path) {
+                    EvidenceFileRead::Found(bytes) => CachedRead::Hash(sha256_prefixed(&bytes)),
+                    EvidenceFileRead::Missing => CachedRead::Missing,
+                    EvidenceFileRead::Unreadable(message) => CachedRead::Unreadable(message),
+                });
+
+            match AnchorHash::try_new(authored) {
+                Err(_) => {
+                    let mut help = DiagnosticCode::EvidenceHashInvalid.default_help().to_string();
+                    if let CachedRead::Hash(actual) = read {
+                        help = format!(
+                            "{help} The actual content hash of `{path}` is `{actual}`.",
+                            path = path.as_str()
+                        );
+                    }
+                    diagnostics.push(
+                        Diagnostic::warning(
+                            DiagnosticCode::EvidenceHashInvalid,
+                            format!("source `{id}` has invalid `hash` value `{authored}`"),
+                        )
+                        .with_span(source.span().clone())
+                        .with_object_id(id)
+                        .with_help(help),
+                    );
+                }
+                Ok(anchor) => match read {
+                    CachedRead::Missing => diagnostics.push(
+                        Diagnostic::warning(
+                            DiagnosticCode::EvidenceHashTargetMissing,
+                            format!(
+                                "source `{id}` anchors `hash` to `{path}`, which does not exist",
+                                path = path.as_str()
+                            ),
+                        )
+                        .with_span(source.span().clone())
+                        .with_object_id(id),
+                    ),
+                    CachedRead::Unreadable(message) => diagnostics.push(
+                        Diagnostic::warning(
+                            DiagnosticCode::EvidenceHashTargetMissing,
+                            format!(
+                                "source `{id}` anchors `hash` to `{path}`, which could not be read: {message}",
+                                path = path.as_str()
+                            ),
+                        )
+                        .with_span(source.span().clone())
+                        .with_object_id(id),
+                    ),
+                    CachedRead::Hash(actual) if actual.as_str() != anchor.as_str() => diagnostics
+                        .push(
+                            Diagnostic::warning(
+                                DiagnosticCode::EvidenceHashDrift,
+                                format!(
+                                    "source `{id}` evidence anchor drifted: the content of `{path}` \
+                                     changed since it was verified",
+                                    path = path.as_str()
+                                ),
+                            )
+                            .with_span(source.span().clone())
+                            .with_object_id(id)
+                            .with_help(format!(
+                                "Re-verify the knowledge citing this source, then update `hash:` \
+                                 (and `last_seen_at`). Expected `{expected}`, actual `{actual}`.",
+                                expected = anchor.as_str()
+                            )),
+                        ),
+                    CachedRead::Hash(_) => {}
+                },
+            }
+        }
+    }
+
+    diagnostics
+}
+
+#[cfg(test)]
+mod tests {
+    use std::cell::RefCell;
+
+    use super::*;
+    use crate::application::compile::compile_with_provider_anchored_for_date;
+    use crate::domain::diagnostic::Severity;
+    use crate::domain::source::SourceFile;
+    use crate::domain::value_objects::rel_path::RelPath;
+    use crate::infrastructure::source::in_memory::InMemorySourceProvider;
+    use chrono::NaiveDate;
+    use std::path::PathBuf;
+
+    const CITED_BYTES: &[u8] = b"fn consume() {}\n";
+
+    fn cited_hash() -> String {
+        sha256_prefixed(CITED_BYTES)
+    }
+
+    fn fixed_today() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 5, 8).expect("valid test date")
+    }
+
+    /// In-memory reader that records every read so tests can assert the
+    /// no-anchor ⇒ no-reads invariant and the one-read-per-path cache.
+    struct RecordingReader {
+        files: BTreeMap<String, EvidenceFileRead>,
+        reads: RefCell<Vec<String>>,
+    }
+
+    impl RecordingReader {
+        fn new(files: BTreeMap<String, EvidenceFileRead>) -> Self {
+            Self {
+                files,
+                reads: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_cited_file() -> Self {
+            Self::new(BTreeMap::from([(
+                "src/consume.ts".to_string(),
+                EvidenceFileRead::Found(CITED_BYTES.to_vec()),
+            )]))
+        }
+
+        fn reads(&self) -> Vec<String> {
+            self.reads.borrow().clone()
+        }
+    }
+
+    impl EvidenceFileReader for RecordingReader {
+        fn read(&self, path: &RelPath) -> EvidenceFileRead {
+            self.reads.borrow_mut().push(path.as_str().to_string());
+            self.files
+                .get(path.as_str())
+                .cloned()
+                .unwrap_or(EvidenceFileRead::Missing)
+        }
+    }
+
+    fn source_page(hash_line: &str) -> String {
+        format!(
+            concat!(
+                "# Guide @doc(team.guide)\n\n",
+                "::source billing.consume\n",
+                "kind: source_code\n",
+                "path: src/consume.ts\n",
+                "{hash_line}",
+                "--\n",
+                "Implementation of credit consumption.\n",
+                "::\n",
+            ),
+            hash_line = hash_line
+        )
+    }
+
+    fn compile_anchored(text: &str, reader: &RecordingReader) -> Vec<Diagnostic> {
+        let provider =
+            InMemorySourceProvider::new().with_source(SourceFile::new_with_identity_path(
+                PathBuf::from("/work/guide.adoc"),
+                text.to_string(),
+                PathBuf::from("guide.adoc"),
+            ));
+        compile_with_provider_anchored_for_date(&provider, reader, fixed_today()).diagnostics
+    }
+
+    #[test]
+    fn fresh_anchor_emits_no_diagnostics() {
+        let reader = RecordingReader::with_cited_file();
+        let text = source_page(&format!("hash: {}\n", cited_hash()));
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert_eq!(reader.reads(), vec!["src/consume.ts".to_string()]);
+    }
+
+    #[test]
+    fn drifted_anchor_warns_with_expected_and_actual_in_help() {
+        let reader = RecordingReader::with_cited_file();
+        let stale = sha256_prefixed(b"older bytes");
+        let text = source_page(&format!("hash: {stale}\n"));
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.code, DiagnosticCode::EvidenceHashDrift);
+        assert_eq!(diagnostic.severity, Severity::Warning);
+        assert_eq!(diagnostic.object_id.as_deref(), Some("billing.consume"));
+        assert!(
+            diagnostic.span.is_some(),
+            "drift warning carries the block span"
+        );
+        let help = diagnostic.help.as_deref().expect("help");
+        assert!(
+            help.contains(&stale),
+            "help names the expected hash: {help}"
+        );
+        assert!(
+            help.contains(&cited_hash()),
+            "help names the actual hash: {help}"
+        );
+    }
+
+    #[test]
+    fn missing_target_warns_target_missing() {
+        let reader = RecordingReader::new(BTreeMap::new());
+        let text = source_page(&format!("hash: {}\n", cited_hash()));
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::EvidenceHashTargetMissing
+        );
+        assert!(diagnostics[0].message.contains("does not exist"));
+    }
+
+    #[test]
+    fn unreadable_target_warns_target_missing_with_io_message() {
+        let reader = RecordingReader::new(BTreeMap::from([(
+            "src/consume.ts".to_string(),
+            EvidenceFileRead::Unreadable("permission denied".to_string()),
+        )]));
+        let text = source_page(&format!("hash: {}\n", cited_hash()));
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::EvidenceHashTargetMissing
+        );
+        assert!(diagnostics[0].message.contains("permission denied"));
+    }
+
+    #[test]
+    fn malformed_hash_warns_invalid_and_offers_actual_hash() {
+        let reader = RecordingReader::with_cited_file();
+        let text = source_page("hash: sha256:0\n");
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        let diagnostic = &diagnostics[0];
+        assert_eq!(diagnostic.code, DiagnosticCode::EvidenceHashInvalid);
+        assert!(
+            diagnostic
+                .help
+                .as_deref()
+                .expect("help")
+                .contains(&cited_hash()),
+            "bootstrap path: help carries the actual hash"
+        );
+    }
+
+    #[test]
+    fn hash_on_url_source_warns_unverifiable() {
+        let reader = RecordingReader::new(BTreeMap::new());
+        let text = concat!(
+            "# Guide @doc(team.guide)\n\n",
+            "::source billing.docs\n",
+            "kind: external_url\n",
+            "url: https://example.com/spec\n",
+            "hash: sha256:0\n",
+            "--\n",
+            "External spec.\n",
+            "::\n",
+        );
+
+        let diagnostics = compile_anchored(text, &reader);
+
+        assert_eq!(diagnostics.len(), 1, "diagnostics: {diagnostics:?}");
+        assert_eq!(
+            diagnostics[0].code,
+            DiagnosticCode::EvidenceHashUnverifiable
+        );
+        assert!(reader.reads().is_empty(), "url sources are never read");
+    }
+
+    #[test]
+    fn source_without_hash_costs_zero_reads_and_zero_diagnostics() {
+        let reader = RecordingReader::with_cited_file();
+        let text = source_page("");
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert!(diagnostics.is_empty(), "diagnostics: {diagnostics:?}");
+        assert!(reader.reads().is_empty(), "no anchor must mean no reads");
+    }
+
+    #[test]
+    fn two_sources_citing_one_path_read_it_once() {
+        let reader = RecordingReader::with_cited_file();
+        let stale = sha256_prefixed(b"older bytes");
+        let text = format!(
+            concat!(
+                "# Guide @doc(team.guide)\n\n",
+                "::source billing.consume\n",
+                "kind: source_code\n",
+                "path: src/consume.ts\n",
+                "hash: {stale}\n",
+                "--\n",
+                "First citation.\n",
+                "::\n\n",
+                "::source billing.consume-test\n",
+                "kind: test\n",
+                "path: src/consume.ts\n",
+                "hash: {stale}\n",
+                "--\n",
+                "Second citation.\n",
+                "::\n",
+            ),
+            stale = stale
+        );
+
+        let diagnostics = compile_anchored(&text, &reader);
+
+        assert_eq!(diagnostics.len(), 2, "one warning per source");
+        assert!(
+            diagnostics
+                .iter()
+                .all(|d| d.code == DiagnosticCode::EvidenceHashDrift)
+        );
+        assert_eq!(
+            reader.reads(),
+            vec!["src/consume.ts".to_string()],
+            "one read per distinct path"
+        );
+    }
+}

--- a/crates/adoc-core/src/application/mod.rs
+++ b/crates/adoc-core/src/application/mod.rs
@@ -2,6 +2,7 @@
 pub(crate) mod apply;
 pub(crate) mod artifact_inspection;
 pub(crate) mod compile;
+pub(crate) mod evidence_anchor;
 pub(crate) mod graph;
 pub(crate) mod hashing;
 pub(crate) mod migrate;

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -340,6 +340,25 @@ diagnostic_codes! {
     /// output time without touching the authored field.
     SchemaClaimContradictedByUnresolved = "schema.claim_contradicted_by_unresolved" =>
         "This claim is referenced by an unresolved contradiction. Consider setting `status: contradicted` on the claim to make its effective state explicit. The effective_status is already projected as `contradicted` in graph and HTML output regardless of the authored status.";
+    /// V8.5.1 (ADR-0048): an anchored source's cited file bytes no longer
+    /// match the authored `hash` — changed, not necessarily wrong; the
+    /// semantic judgment stays human. Per-diagnostic help carries the
+    /// expected and actual hashes.
+    EvidenceHashDrift = "evidence.hash_drift" =>
+        "The cited file's content changed since this source was anchored. Re-verify the knowledge citing it, then update `hash:` to the actual content hash and refresh `last_seen_at`.";
+    /// V8.5.1 (ADR-0048): an anchored source's `path` does not exist or
+    /// cannot be read under the anchor root.
+    EvidenceHashTargetMissing = "evidence.hash_target_missing" =>
+        "Check that the anchored `path` exists relative to the project root and is readable, or update the source object's `path`.";
+    /// V8.5.1 (ADR-0048): a `hash` value is not `sha256:` + 64 lowercase
+    /// hex. Per-diagnostic help carries the file's actual hash when
+    /// readable — the bootstrap path for authoring anchors.
+    EvidenceHashInvalid = "evidence.hash_invalid" =>
+        "Use `sha256:` followed by 64 lowercase hex characters, e.g. from `shasum -a 256 <file>`.";
+    /// V8.5.1 (ADR-0048): a `hash` anchor on a url-target source; URLs are
+    /// not verifiable offline.
+    EvidenceHashUnverifiable = "evidence.hash_unverifiable" =>
+        "Evidence anchors apply to `path` sources only; remove `hash` from url-target sources.";
     /// V6.3: a positional `adoc impacted-by` path argument is not a valid
     /// repo-relative path (absolute, escaping, or empty).
     ImpactedInvalidPath = "impacted.invalid_path" =>

--- a/crates/adoc-core/src/domain/ports/evidence_file.rs
+++ b/crates/adoc-core/src/domain/ports/evidence_file.rs
@@ -1,0 +1,24 @@
+//! Adapter trait for reading cited evidence files at check time
+//! (V8.5.1, ADR-0048).
+//!
+//! The Evidence Anchor pass re-hashes files that `source` objects cite via
+//! `path`. All filesystem access goes through this port so the pass stays a
+//! pure function of `(workspace, reader)`; the fs adapter lives in
+//! `infrastructure/source/evidence_fs.rs` and tests substitute in-memory
+//! fakes.
+
+use crate::domain::value_objects::rel_path::RelPath;
+
+pub(crate) trait EvidenceFileReader {
+    fn read(&self, path: &RelPath) -> EvidenceFileRead;
+}
+
+/// Outcome of one evidence-file read. `Missing` and `Unreadable` are
+/// distinct on purpose: a deleted target and a permission failure need
+/// different remediation messages.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum EvidenceFileRead {
+    Found(Vec<u8>),
+    Missing,
+    Unreadable(String),
+}

--- a/crates/adoc-core/src/domain/ports/mod.rs
+++ b/crates/adoc-core/src/domain/ports/mod.rs
@@ -3,6 +3,7 @@ pub(crate) mod artifact_reader;
 pub(crate) mod artifact_writer;
 pub(crate) mod changed_files;
 pub(crate) mod embedding_provider;
+pub(crate) mod evidence_file;
 pub(crate) mod snapshot_workspace;
 pub(crate) mod source_provider;
 pub(crate) mod workspace_writer;

--- a/crates/adoc-core/src/domain/value_objects/anchor_hash.rs
+++ b/crates/adoc-core/src/domain/value_objects/anchor_hash.rs
@@ -1,0 +1,72 @@
+//! `AnchorHash` value object (V8.5.1, ADR-0048).
+//!
+//! The validated form of an Evidence Anchor: `sha256:` followed by exactly
+//! 64 lowercase hex characters — byte-identical to what
+//! `application::hashing::sha256_prefixed` emits, so `shasum -a 256`
+//! output is accepted verbatim.
+
+const PREFIX: &str = "sha256:";
+const HEX_LEN: usize = 64;
+
+/// A validated Evidence Anchor hash value.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct AnchorHash(String);
+
+/// Why a `hash` field value is not a valid Evidence Anchor.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct AnchorHashError;
+
+impl AnchorHash {
+    pub(crate) fn try_new(value: &str) -> Result<Self, AnchorHashError> {
+        let hex = value.strip_prefix(PREFIX).ok_or(AnchorHashError)?;
+        let valid = hex.len() == HEX_LEN
+            && hex
+                .bytes()
+                .all(|byte| matches!(byte, b'0'..=b'9' | b'a'..=b'f'));
+        if valid {
+            Ok(Self(value.to_string()))
+        } else {
+            Err(AnchorHashError)
+        }
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const VALID: &str = "sha256:ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+
+    #[test]
+    fn try_new_accepts_sha256_prefix_with_64_lowercase_hex() {
+        let anchor = AnchorHash::try_new(VALID).expect("valid anchor");
+        assert_eq!(anchor.as_str(), VALID);
+    }
+
+    #[test]
+    fn try_new_rejects_missing_prefix() {
+        assert!(AnchorHash::try_new(&VALID[PREFIX.len()..]).is_err());
+    }
+
+    #[test]
+    fn try_new_rejects_wrong_length() {
+        assert!(AnchorHash::try_new("sha256:abc123").is_err());
+        assert!(AnchorHash::try_new(&format!("{VALID}0")).is_err());
+    }
+
+    #[test]
+    fn try_new_rejects_uppercase_and_non_hex() {
+        assert!(AnchorHash::try_new(&VALID.to_uppercase()).is_err());
+        let non_hex = format!("sha256:{}", "g".repeat(HEX_LEN));
+        assert!(AnchorHash::try_new(&non_hex).is_err());
+    }
+
+    #[test]
+    fn try_new_rejects_other_algorithms() {
+        assert!(AnchorHash::try_new(&format!("sha512:{}", "a".repeat(HEX_LEN))).is_err());
+    }
+}

--- a/crates/adoc-core/src/domain/value_objects/mod.rs
+++ b/crates/adoc-core/src/domain/value_objects/mod.rs
@@ -7,6 +7,7 @@
 
 pub(crate) mod action;
 pub(crate) mod action_set;
+pub(crate) mod anchor_hash;
 pub(crate) mod approved_by;
 pub(crate) mod contradiction_claims;
 pub(crate) mod contradiction_status;

--- a/crates/adoc-core/src/domain/values.rs
+++ b/crates/adoc-core/src/domain/values.rs
@@ -74,6 +74,10 @@ impl OptionalFields {
         self.0.iter()
     }
 
+    pub(crate) fn get(&self, key: &str) -> Option<&str> {
+        self.0.get(key).map(String::as_str)
+    }
+
     #[cfg(test)]
     pub(crate) fn is_empty(&self) -> bool {
         self.0.is_empty()

--- a/crates/adoc-core/src/infrastructure/source/evidence_fs.rs
+++ b/crates/adoc-core/src/infrastructure/source/evidence_fs.rs
@@ -1,0 +1,49 @@
+//! Filesystem adapter for [`EvidenceFileReader`] (V8.5.1, ADR-0048).
+
+use std::path::PathBuf;
+
+use crate::domain::ports::evidence_file::{EvidenceFileRead, EvidenceFileReader};
+use crate::domain::value_objects::rel_path::RelPath;
+
+/// Reads anchored evidence files relative to the project's anchor root
+/// (the discovered config directory, else the context start directory).
+/// `RelPath` already rejects `..` segments and absolute paths, so the join
+/// cannot escape the root.
+pub(crate) struct FsEvidenceFileReader {
+    root: PathBuf,
+}
+
+impl FsEvidenceFileReader {
+    pub(crate) fn new(root: PathBuf) -> Self {
+        Self { root }
+    }
+}
+
+impl EvidenceFileReader for FsEvidenceFileReader {
+    fn read(&self, path: &RelPath) -> EvidenceFileRead {
+        let full = self.root.join(path.as_str());
+        match std::fs::read(&full) {
+            Ok(bytes) => EvidenceFileRead::Found(bytes),
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => EvidenceFileRead::Missing,
+            Err(error) => EvidenceFileRead::Unreadable(error.to_string()),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn read_distinguishes_found_and_missing() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        std::fs::write(dir.path().join("cited.rs"), b"fn main() {}").expect("write");
+        let reader = FsEvidenceFileReader::new(dir.path().to_path_buf());
+
+        let found = reader.read(&RelPath::try_new("cited.rs").expect("rel path"));
+        assert_eq!(found, EvidenceFileRead::Found(b"fn main() {}".to_vec()));
+
+        let missing = reader.read(&RelPath::try_new("absent.rs").expect("rel path"));
+        assert_eq!(missing, EvidenceFileRead::Missing);
+    }
+}

--- a/crates/adoc-core/src/infrastructure/source/evidence_fs.rs
+++ b/crates/adoc-core/src/infrastructure/source/evidence_fs.rs
@@ -7,8 +7,11 @@ use crate::domain::value_objects::rel_path::RelPath;
 
 /// Reads anchored evidence files relative to the project's anchor root
 /// (the discovered config directory, else the context start directory).
-/// `RelPath` already rejects `..` segments and absolute paths, so the join
-/// cannot escape the root.
+/// Containment is lexical only: `RelPath` rejects `..` segments and
+/// absolute paths, but `std::fs::read` follows symlinks, so a symlinked
+/// target resolves wherever the filesystem points. Accepted (ADR-0048):
+/// this is a read-only pass over an author-controlled tree, and refusing
+/// symlinks would break legitimate in-repo links.
 pub(crate) struct FsEvidenceFileReader {
     root: PathBuf,
 }

--- a/crates/adoc-core/src/infrastructure/source/mod.rs
+++ b/crates/adoc-core/src/infrastructure/source/mod.rs
@@ -1,4 +1,5 @@
 // see ADR-0009
+pub(crate) mod evidence_fs;
 pub(crate) mod fs;
 pub(crate) mod fs_writer;
 #[cfg(test)]

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -131,6 +131,25 @@ pub fn compile_workspace(input: CompileInput) -> CompileResult {
     application::compile::compile_with_provider(&provider)
 }
 
+/// V8.5.1 (ADR-0048): [`compile_workspace`] plus Evidence Anchor
+/// verification — anchored `source` paths are re-hashed against
+/// `anchor_root`. `None` behaves exactly like [`compile_workspace`]; only
+/// the check entry passes `Some`.
+#[tracing::instrument(level = "debug", skip_all)]
+pub fn compile_workspace_with_anchor_root(
+    input: CompileInput,
+    anchor_root: Option<std::path::PathBuf>,
+) -> CompileResult {
+    let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
+    match anchor_root {
+        Some(root) => {
+            let reader = infrastructure::source::evidence_fs::FsEvidenceFileReader::new(root);
+            application::compile::compile_with_provider_anchored(&provider, &reader)
+        }
+        None => application::compile::compile_with_provider(&provider),
+    }
+}
+
 /// V8.1.1: convert every Compatibility Mode (`.md`) source under `root` to
 /// canonical prose-mode `.adoc` text (ADR-0043). Performs no writes — the
 /// result carries the rendered text per file; the local adapter executes

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -18,7 +18,7 @@ use adoc_core::{
     SearchQuery, SearchRecordScope, Severity, SnapshotSelector, StaleEnvelope,
     apply_patch as core_apply_patch, build_workspace_with_embedding_provider,
     changed_files_from_git, changed_paths_strings, check_patch as core_check_patch,
-    compile_workspace, diff_objects, embed_query_with_embedding_provider,
+    compile_workspace_with_anchor_root, diff_objects, embed_query_with_embedding_provider,
     empty_contradictions_envelope, empty_impacted_envelope, empty_stale_envelope,
     evaluate_contradictions, evaluate_impacted, evaluate_stale, export_workspace,
     git_review_available, inspect_graph_artifact, inspect_search_artifact, load_graph_session,
@@ -501,9 +501,17 @@ where
         .map(|path| context.path_policy().resolve_read_path(path))
         .transpose()?;
     let config = discover_project_config_if(path.is_none(), context.config_start())?;
+    // Evidence Anchors (ADR-0048) resolve against the project root: the
+    // discovered config's directory, else the context start — the same seam
+    // impacted-by uses for git discovery. Only check threads this; build,
+    // review, diff, and patch recompiles stay anchor-free.
+    let anchor_root = config
+        .as_ref()
+        .and_then(|config| config.path.parent().map(Path::to_path_buf))
+        .unwrap_or_else(|| context.config_start().to_path_buf());
     let path = resolve_docs_path_with_config(path, config.as_ref())?;
     let path = context.path_policy().resolve_read_path(&path)?;
-    let result = compile_workspace(CompileInput { root: path });
+    let result = compile_workspace_with_anchor_root(CompileInput { root: path }, Some(anchor_root));
     let exit_code = if result.has_errors() { 1 } else { 0 };
 
     Ok(CheckOutcome {

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -500,11 +500,12 @@ where
         .as_deref()
         .map(|path| context.path_policy().resolve_read_path(path))
         .transpose()?;
-    let config = discover_project_config_if(path.is_none(), context.config_start())?;
+    // Check always discovers the config — even with an explicit path — so
     // Evidence Anchors (ADR-0048) resolve against the project root: the
-    // discovered config's directory, else the context start — the same seam
-    // impacted-by uses for git discovery. Only check threads this; build,
-    // review, diff, and patch recompiles stay anchor-free.
+    // discovered config's directory, else the context start. The explicit
+    // path still wins for docs resolution. Only check threads the anchor
+    // root; build, review, diff, and patch recompiles stay anchor-free.
+    let config = discover_project_config_if(true, context.config_start())?;
     let anchor_root = config
         .as_ref()
         .and_then(|config| config.path.parent().map(Path::to_path_buf))

--- a/crates/adoc-local/tests/local_workflow.rs
+++ b/crates/adoc-local/tests/local_workflow.rs
@@ -124,6 +124,66 @@ fn check_uses_configured_docs_path_and_returns_diagnostics_without_printing() {
 }
 
 #[test]
+fn check_verifies_evidence_anchors_against_the_config_root() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(&root.join("src/consume.ts"), "export const consume = 1;\n");
+    write(
+        &root.join("docs/index.adoc"),
+        &format!(
+            "# Billing @doc(team.billing)\n\n::source billing.consume\nkind: source_code\npath: src/consume.ts\nhash: sha256:{}\n--\nConsume implementation.\n::\n",
+            "a".repeat(64)
+        ),
+    );
+    write(
+        &root.join("agentdoc.config.yaml"),
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: none\n",
+    );
+
+    let outcome = context(root)
+        .check(CheckInput { path: None })
+        .expect("check should run");
+
+    assert_eq!(outcome.exit_code, 0, "anchor warnings never fail check");
+    assert!(
+        outcome
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == adoc_core::DiagnosticCode::EvidenceHashDrift),
+        "expected evidence.hash_drift, got: {:?}",
+        outcome.diagnostics
+    );
+}
+
+#[test]
+fn check_with_explicit_path_resolves_anchors_from_the_context_start() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(
+        &root.join("docs/index.adoc"),
+        &format!(
+            "# Billing @doc(team.billing)\n\n::source billing.consume\nkind: source_code\npath: src/absent.ts\nhash: sha256:{}\n--\nConsume implementation.\n::\n",
+            "a".repeat(64)
+        ),
+    );
+
+    let outcome = context(root)
+        .check(CheckInput {
+            path: Some(root.join("docs")),
+        })
+        .expect("check should run");
+
+    assert_eq!(outcome.exit_code, 0);
+    assert!(
+        outcome.diagnostics.iter().any(|diagnostic| {
+            diagnostic.code == adoc_core::DiagnosticCode::EvidenceHashTargetMissing
+        }),
+        "expected evidence.hash_target_missing, got: {:?}",
+        outcome.diagnostics
+    );
+}
+
+#[test]
 fn build_writes_artifacts_and_reports_written_paths() {
     let workspace = tempfile::tempdir().expect("workspace");
     let root = workspace.path();

--- a/crates/adoc-local/tests/local_workflow.rs
+++ b/crates/adoc-local/tests/local_workflow.rs
@@ -156,7 +156,44 @@ fn check_verifies_evidence_anchors_against_the_config_root() {
 }
 
 #[test]
-fn check_with_explicit_path_resolves_anchors_from_the_context_start() {
+fn check_with_explicit_path_resolves_anchors_from_the_discovered_config_root() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(&root.join("src/consume.ts"), "export const consume = 1;\n");
+    write(
+        &root.join("docs/index.adoc"),
+        &format!(
+            "# Billing @doc(team.billing)\n\n::source billing.consume\nkind: source_code\npath: src/consume.ts\nhash: sha256:{}\n--\nConsume implementation.\n::\n",
+            "a".repeat(64)
+        ),
+    );
+    write(
+        &root.join("agentdoc.config.yaml"),
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: none\n",
+    );
+    fs::create_dir_all(root.join("nested")).expect("nested dir");
+
+    // Context starts in a subdirectory; the anchor must still resolve
+    // against the config's directory, not the context start.
+    let outcome = context(&root.join("nested"))
+        .check(CheckInput {
+            path: Some(root.join("docs")),
+        })
+        .expect("check should run");
+
+    assert_eq!(outcome.exit_code, 0);
+    assert!(
+        outcome
+            .diagnostics
+            .iter()
+            .any(|diagnostic| diagnostic.code == adoc_core::DiagnosticCode::EvidenceHashDrift),
+        "expected evidence.hash_drift (file found under the config root), got: {:?}",
+        outcome.diagnostics
+    );
+}
+
+#[test]
+fn check_with_explicit_path_falls_back_to_the_context_start_without_config() {
     let workspace = tempfile::tempdir().expect("workspace");
     let root = workspace.path();
     write(
@@ -181,6 +218,22 @@ fn check_with_explicit_path_resolves_anchors_from_the_context_start() {
         "expected evidence.hash_target_missing, got: {:?}",
         outcome.diagnostics
     );
+}
+
+#[test]
+fn check_with_explicit_path_fails_loudly_on_a_malformed_config() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(&root.join("docs/index.adoc"), &valid_source());
+    write(&root.join("agentdoc.config.yaml"), "version: [broken\n");
+
+    let error = context(root)
+        .check(CheckInput {
+            path: Some(root.join("docs")),
+        })
+        .expect_err("a broken config must never be silently ignored");
+
+    assert_eq!(error.exit_code(), 1);
 }
 
 #[test]

--- a/docs/adr/0048-deterministic-evidence-anchoring.md
+++ b/docs/adr/0048-deterministic-evidence-anchoring.md
@@ -47,10 +47,14 @@ re-verification — never a semantic judgment.
      feature cures.
 4. **Opt-in per source object.** No `hash` field means no diagnostics and no
    file reads — existing corpora compile byte-identically.
-5. **Anchor root**: the discovered project-config directory when config
-   discovery ran, else the context start directory — the same seam
-   `impacted-by` uses for git discovery. Cited paths are repo-relative in
-   the same sense `git diff --name-only` output is.
+5. **Anchor root**: the discovered project-config directory, else the
+   context start directory. `adoc check` runs config discovery even when an
+   explicit docs path is passed (the explicit path still wins for docs
+   resolution), so anchors resolve identically however check is invoked —
+   the same walk-up seam `impacted-by` uses for git discovery. A malformed
+   config found during the walk fails check loudly rather than being
+   ignored. Cited paths are repo-relative in the same sense
+   `git diff --name-only` output is.
 
 ## What this can and cannot claim
 

--- a/docs/adr/0048-deterministic-evidence-anchoring.md
+++ b/docs/adr/0048-deterministic-evidence-anchoring.md
@@ -81,6 +81,11 @@ the cited file; that noise is priced in (see Rejected).
   on every PR. The graph artifact already carries source-object fields, so
   a future artifact-side consumer needs no schema bump. Revisit on agent
   demand.
+- **Symlink containment** (canonicalize-and-verify or rejecting symlinked
+  targets) — containment under the anchor root is lexical only; the read
+  follows symlinks and hashes whatever bytes the filesystem serves at the
+  authored path. The pass is read-only over an author-controlled tree, and
+  refusing symlinks would break legitimate in-repo links.
 
 ## Relationships
 

--- a/docs/adr/0048-deterministic-evidence-anchoring.md
+++ b/docs/adr/0048-deterministic-evidence-anchoring.md
@@ -1,0 +1,101 @@
+# ADR-0048: Deterministic Evidence Anchoring via `source` hash
+
+**Status:** Accepted
+**Date:** 2026-07-20
+**Slice:** V8.5.1
+
+## Context
+
+A `source` Knowledge Object documents `hash`, `symbol`, `commit`, and
+`last_seen_at` as optional fields (`docs/agent/v0/source-guide.md`), but
+nothing consumes them — they are inert metadata. The only code-to-knowledge
+drift signal the system has is path-level: `adoc impacted-by` (ADR-0019,
+V6.3) reports that a path a claim cites appeared in a git diff. It cannot
+say whether the *content* of a cited file changed since the claim was
+verified — a drift merged weeks ago is invisible to any reasonable `--ref`
+window.
+
+The V8.3 CI surface posts `adoc check --format markdown` on every pull
+request, so a check-time diagnostic reaches the whole team with zero new
+workflow. Partners asking for LLM-free contradiction detection get, honestly,
+the deterministic ceiling: detect that cited bytes changed and force a human
+re-verification — never a semantic judgment.
+
+## Decision
+
+1. **The `hash` field on a path-target `source` object becomes an Evidence
+   Anchor**: a `sha256:` + 64-lowercase-hex hash of the cited file's full
+   raw bytes at verification time — the exact format `sha256_prefixed`
+   already emits for **Base Hash** values. `shasum -a 256 <file>` produces
+   it with standard tooling.
+2. **Anchors are verified at check time** by an I/O-bearing application pass
+   (`application/evidence_anchor.rs`) behind a new internal port
+   (`EvidenceFileReader`, fs adapter in `infrastructure/source/`). Only the
+   check entry point threads the anchor root; build, review, diff, and
+   patch-apply recompiles stay anchor-free, so review worktree snapshots and
+   pinned fixtures are unaffected.
+3. **Four warning codes**, never errors, never gates (ADR-0038 posture —
+   signals are data):
+   - `evidence.hash_drift` — file readable, computed hash differs; help
+     carries expected and actual so the fix is copy-paste.
+   - `evidence.hash_target_missing` — anchored path absent or unreadable.
+   - `evidence.hash_invalid` — value not `sha256:` + 64 lowercase hex; help
+     carries the file's actual hash when readable (the bootstrap path:
+     author a placeholder, copy the real value from the diagnostic).
+   - `evidence.hash_unverifiable` — `hash` on a url-target source; URLs are
+     not verifiable offline, and silent inertness is the disease this
+     feature cures.
+4. **Opt-in per source object.** No `hash` field means no diagnostics and no
+   file reads — existing corpora compile byte-identically.
+5. **Anchor root**: the discovered project-config directory when config
+   discovery ran, else the context start directory — the same seam
+   `impacted-by` uses for git discovery. Cited paths are repo-relative in
+   the same sense `git diff --name-only` output is.
+
+## What this can and cannot claim
+
+An anchor mismatch means *the cited bytes changed since anchoring* — changed,
+not wrong. The semantic judgment (does the change invalidate the claim?)
+stays with a human or an explicitly model-assisted step outside the
+deterministic core, extending the ADR-0026 posture: no NLP, no model, in the
+compile pipeline, ever. Whole-file granularity also flags unrelated edits to
+the cited file; that noise is priced in (see Rejected).
+
+## Rejected
+
+- **Line-span anchors** — positionally brittle: any edit above the span
+  drifts it, demanding constant maintenance for zero added truth.
+- **`symbol` resolution** — needs language parsing. A naive byte-search
+  presence check never false-positives but false-negatives when the name
+  survives in a comment or string; recorded as a possible later warning, not
+  shipped.
+- **`commit` verification** — would drag git into `adoc check`, which is
+  git-free by design.
+- **URL anchoring** — offline-unverifiable; warned, not checked.
+- **A dedicated signal command/envelope** — the actor is the *author* (the
+  remedy is a source edit), and check is the source-facing surface already
+  on every PR. The graph artifact already carries source-object fields, so
+  a future artifact-side consumer needs no schema bump. Revisit on agent
+  demand.
+
+## Relationships
+
+- **ADR-0034 (evidence quality)**: an anchor does not change an evidence
+  tier in this slice; "anchored ⇒ stronger" is named, not shipped.
+- **ADR-0036 (`patch.source_drift`)**: distinct axis — that code is
+  artifact-vs-`.adoc`-source freshness during patch apply;
+  `evidence.hash_drift` is cited-code-bytes-vs-authored-anchor.
+- **ADR-0038**: why these are check warnings and not a fifth read command.
+- **ADR-0019**: anchoring complements `impacts:`/evidence-path matching —
+  the path answers "is it in this diff", the anchor answers "did the bytes
+  move since verification".
+
+## Consequences
+
+- `adoc check` reads non-source repo files for the first time — opt-in only,
+  deterministic, bounded by the count of anchored sources (one read per
+  distinct path).
+- Every legitimate change to a cited file costs a hash update. That friction
+  is the feature: it *is* the re-verification prompt.
+- Warning budgets in pilots gain a new possible contributor; fixtures pin
+  exact budgets, so any change is a visible test edit.

--- a/docs/agent/v0/source-guide.md
+++ b/docs/agent/v0/source-guide.md
@@ -25,7 +25,7 @@ Source objects appear in `adoc.graph.v4` nodes with `kind: "source"`. Evidence k
 | `symbol` | Exported symbol name within the artefact (e.g. a function or class) |
 | `commit` | Git commit SHA at which the artefact was last reviewed |
 | `last_seen_at` | Date the artefact was last verified (ISO 8601) |
-| `hash` | Content hash of the artefact at review time (e.g. `sha256:deadbeef`) |
+| `hash` | Evidence Anchor (ADR-0048): `sha256:` + 64 lowercase hex over the cited file's full bytes (`shasum -a 256 <file>`). On path-target sources `adoc check` re-hashes the file and warns `evidence.hash_drift` when the content changed, `evidence.hash_target_missing` when the path is gone, and `evidence.hash_invalid` for malformed values (the help carries the actual hash). On url-target sources a `hash` warns `evidence.hash_unverifiable`. Warnings never fail check |
 
 ## Evidence kind vocabulary
 

--- a/docs/roadmap/ROADMAP-V8.md
+++ b/docs/roadmap/ROADMAP-V8.md
@@ -317,6 +317,46 @@ Deferred: an MCP `adoc_health` tool (`adoc_project_status` covers agent self-ori
 
 ---
 
+## V8.5: Evidence Anchor
+
+### V8.5.1: Deterministic Evidence Anchoring Slice
+
+Goal: consume the inert `hash` field on path-target `source` objects so
+`adoc check` deterministically detects "the cited bytes changed since
+verification" — the LLM-free ceiling of code-vs-knowledge drift detection.
+**ADR-0048 — Deterministic evidence anchoring** at slice start.
+
+Scope:
+
+- Value object `AnchorHash` (`sha256:` + 64 lowercase hex — the existing
+  `sha256_prefixed` format); internal port `EvidenceFileReader` with fs
+  adapter; I/O-bearing pass `application/evidence_anchor.rs` run only by the
+  check entry (build/review/diff/patch recompiles stay anchor-free).
+- Four warning codes: `evidence.hash_drift` (expected/actual in help),
+  `evidence.hash_target_missing`, `evidence.hash_invalid` (actual hash in
+  help — the bootstrap path), `evidence.hash_unverifiable` (hash on a url
+  source). Warnings never fail; no envelope or schema change — the feature
+  is diagnostics-only, so the V8.4.1 stable-at-v0 declarations are untouched.
+- Anchor root: discovered config directory, else the context start — the
+  impacted-by git-discovery seam.
+
+Commit shape: `docs(v8): ADR-0048 deterministic evidence anchoring` →
+`feat(core): evidence anchor hash verification in adoc check (V8.5.1)` →
+`feat(local): anchor root resolution for check (V8.5.1)` →
+`test(cli): check_cli anchor fixtures + source-guide truth-up (V8.5.1)`.
+
+Acceptance: an anchored, drifted source warns `evidence.hash_drift` with
+expected and actual hashes in help and exit code 0; a corpus without `hash`
+fields compiles byte-identically (recording-reader test proves zero reads);
+`docs/agent/v0/source-guide.md` names the enforced format (docs-truth).
+
+Deferred: `symbol` presence check (`evidence.symbol_missing`, on partner
+friction); drifted-anchor counts as an `adoc health` input (coordinate with
+ADR-0046); a machine-readable drift envelope (on agent demand — the graph
+already carries source fields, no bump needed).
+
+---
+
 ## Contract and Versioning Inventory
 
 | Envelope / artifact | Change | Milestone |
@@ -333,6 +373,7 @@ ADRs to record at slice start (continuing from ADR-0042, reserved by ROADMAP-V7;
 - **ADR-0044** — External pilot thresholds: the §8.3 partner profile, per-Later-item numeric un-gating gates fixed before the first partner session, redaction rules for external corpora, and the composite-Action packaging threshold for the V8.3 snippet. Extends the ADR-0042 mechanism from dogfood to external evidence.
 - **ADR-0045** — Contract stability policy: the frozen / stable-at-v0 / experimental taxonomy, the four v0→v1 promotions, the one-cycle schema-publication window, and the deliberate decision not to renumber shape-unchanged envelopes. CONTRACTS.md plus the guard test become the registry.
 - **ADR-0046** — Knowledge health composition: the §14.5 component set, the weight-free composite formula, and the §51 North-Star numerator definition (verified-and-retrievable). Health is an artifact, not a check: exit 0 always; thresholds deferred.
+- **ADR-0048** — Deterministic evidence anchoring: the `hash` field on path-target source objects becomes a verified whole-file sha256 anchor checked at `adoc check` time through the `EvidenceFileReader` port; four warning codes; opt-in; the deterministic ceiling of code-vs-knowledge drift detection (semantic judgment stays human).
 
 ## Risks and Invariants
 


### PR DESCRIPTION
## Summary

Implements **V8.5.1 (ADR-0048, new)**: the previously inert `hash` field on path-target `source` objects becomes a verified **Evidence Anchor** — a whole-file `sha256:` hash of the cited file, re-checked by `adoc check`. This is the deterministic, LLM-free ceiling of code-vs-knowledge drift detection: it proves *the cited bytes changed since verification*; the semantic judgment (does the change invalidate the claim?) stays human.

Four commits, tracer-bullet order:

1. `docs(v8)` — ADR-0048, CONTEXT.md **Evidence Anchor** term, ROADMAP-V8 §V8.5 section
2. `feat(core)` — `AnchorHash` value object, `EvidenceFileReader` port + fs adapter, `application/evidence_anchor.rs` pass, four `evidence.*` warning codes, pipeline wiring
3. `feat(local)` — anchor-root resolution in `check_with_context` (discovered config dir, else context start)
4. `test(cli)` — `check_cli` end-to-end (plain + markdown) + `source-guide.md` truth-up

## Behavior

- `evidence.hash_drift` — cited file readable, content hash differs; help carries expected **and** actual (copy-paste fix)
- `evidence.hash_target_missing` — anchored path absent or unreadable
- `evidence.hash_invalid` — value not `sha256:` + 64 lowercase hex; help carries the file's actual hash (the bootstrap path)
- `evidence.hash_unverifiable` — `hash` on a url-target source
- All warnings — never gate. **Opt-in**: no `hash` ⇒ zero file reads and zero diagnostics (proven by a recording-reader test). Only the check entry threads the reader — build/review/diff/patch recompiles stay anchor-free. MCP `adoc_check` inherits for free. No envelope or schema change.

## Validation

`cargo test --workspace --locked` (14 new tests), `cargo clippy --workspace --all-targets --locked -- -D warnings`, `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`, `prek run --all-files` — all green. Expanded-pilot warning budget unchanged.

Once released and pinned by the action, `evidence.hash_drift` warnings surface in the PR comment's Validation section automatically — no action change needed.

https://claude.ai/code/session_012AbB2xas66Zfj8ex4YDpRL