### PR TITLE
feat: canonical source identity and graph v5 (V9.1.1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -68,6 +68,18 @@ _Avoid_: new consumers, compatibility shims, treating it as the current read mod
 The first compiler reads multiple `.adoc` files from a project path directly, without `@include`.
 _Avoid_: include graph, remote includes, source-map-preserving composition
 
+**Physical Source Path**:
+The canonical host-filesystem path used only to read source bytes. In a project-bound command it must resolve below both the discovered project root and configured documentation root; it is never serialized or hashed.
+_Avoid_: artifact coordinate, page identity, absolute path fallback
+
+**Identity Path**:
+The documentation-root-relative source path used to derive path-based page IDs. It remains independent from the repository-relative coordinate published in artifacts.
+_Avoid_: repository-qualified ID, physical checkout path, graph source coordinate
+
+**Logical Source Path**:
+The validated project-root-relative, slash-normalized source coordinate used in diagnostics, Graph Artifact spans, diffs, hashes, and future receipts. It is non-empty UTF-8 and rejects absolute paths, drive prefixes, backslashes, dot components, controls, and edge whitespace. Standalone check/build uses an invocation-root-relative coordinate but establishes no repository identity.
+_Avoid_: host path, `<review>` prefix, permissive path normalization
+
 **V0 Block Structure**:
 The first source grammar supports only top-level typed blocks.
 _Avoid_: nested typed blocks, child object parsing
@@ -165,7 +177,7 @@ The V1 build output, `dist/docs.search.json`, with schema version `adoc.search.v
 _Avoid_: per-chunk embedding store, vectors embedded in `docs.graph.json`, binary sidecar in V1
 
 **Graph Artifact**:
-The V1/V2 build output, `dist/docs.graph.json`, now with schema version `adoc.graph.v2`. It is derived from validated AgentDoc Source and carries page, prose block, and Knowledge Object nodes plus directed `contains`, `reference`, and relation edges. Each Knowledge Object node carries a `content_hash` used for patch preconditions. It is data-only and contains no rendered HTML fields; the serialized JSON shape is public, while the Rust DTO used to build or read it is internal to `adoc-core`.
+The canonical local read model, `dist/docs.graph.json`, now with schema version `adoc.graph.v5` (ADR-0049). It is derived from validated AgentDoc Source and carries a required `repository_identity` member, page/prose/Knowledge Object nodes, and directed edges. Project-bound builds identify the local project through `agentdoc.config.yaml`; standalone builds emit an explicit `null`. Each Knowledge Object carries a `content_hash` over authored semantics and its portable **Logical Source Path**, so equal revisions hash identically across checkouts and review snapshots. It is data-only and contains no rendered HTML fields; the serialized JSON shape and JSON Schema are public, while the Rust DTO remains internal to `adoc-core`.
 _Avoid_: graph database, SQLite-first graph storage, graph as authoring source of truth, presentation HTML inside graph JSON
 
 **Base Hash**:
@@ -497,7 +509,7 @@ _Avoid_: reusing `compute_impact`'s diff projection, glob `impacts:` matching, l
 - "V1 retrieval staging" could mean shipping lexical search first and embeddings later - resolved: V1 ships **Hybrid Retrieval** with embeddings as a first-class build output, gated behind the **Embedding Provider** port.
 - "Embedding compute" could mean a hosted embeddings API in V1 - resolved: the V1 default **Embedding Provider** is local (`fastembed-rs` + `bge-small-en-v1.5`); a hosted adapter is deferred behind the same port.
 - "Vector storage shape" could mean SQLite, an embedded ANN library, or a binary sidecar in V1 - resolved: V1 uses a sidecar JSON (**Search Artifact**) with `adoc.search.v0` as schema version.
-- "Graph storage shape" could mean SQLite or a graph database - resolved: V1/V2 uses a sidecar JSON (**Graph Artifact**) with `adoc.graph.v2` as the current schema version; SQLite waits until JSON becomes limiting.
+- "Graph storage shape" could mean SQLite or a graph database - resolved: the local product uses a sidecar JSON (**Graph Artifact**), currently `adoc.graph.v5`; SQLite waits until JSON becomes limiting.
 - "Embedding granularity" could mean per-paragraph or per-chunk embeddings - resolved: V1 is one embedding per **Knowledge Object**; chunked retrieval is deferred.
 - "Search ranking" could mean a multi-factor weighted score from the PRD - resolved: V1 uses **Hybrid Retrieval** via parameter-free RRF; lifecycle, freshness, and authority remain filters, not score modifiers.
 - "Agent surface" could mean an MCP/JSON-RPC retrieval server in V1 - resolved: V1 ships only CLI commands plus a stable `--format json` envelope (`adoc.retrieval.v0`); a server is deferred.

--- a/README.md
+++ b/README.md
@@ -676,6 +676,19 @@ Current local retrieval focuses on the graph artifact:
 - prove retrieval against the billing pilot
 - build `docs.search.json` with local FastEmbed embeddings
 
+Graph artifacts use `adoc.graph.v5`. Config-backed check/build/review commands
+publish project-relative `/`-separated source paths and identify the project via
+`agentdoc.config.yaml`; explicit standalone check/build inputs publish
+invocation-relative paths with `"repository_identity": null`. The same source
+revision therefore produces the same Knowledge Object hashes in another clone
+or review worktree. The machine-readable contract is
+[`graph-artifact.v5.json`](docs/agent/v0/schema/graph-artifact.v5.json).
+
+Upgrading from graph v4 requires one rebuild. Regenerate `docs.graph.json`,
+regenerate or re-embed `docs.search.json`, and recreate any in-flight patch
+documents whose `base_hash` came from v4. Readers reject v4 explicitly instead
+of silently mixing hash domains.
+
 The shipped surface also includes Markdown migration, review/impact workflows, patch validation/application, the expanded fifteen-kind schema, MCP, the composite GitHub Action, and evidence-anchor drift checks. The next detailed cycle makes PR assessment fail-honest and reproducible before adding cited optional semantic review and governed proposals.
 
 See [docs/roadmap/ROADMAP.md](docs/roadmap/ROADMAP.md) for the full sequence and [docs/roadmap/ROADMAP-V9.md](docs/roadmap/ROADMAP-V9.md) for the implementation handoff.

--- a/crates/adoc-cli/tests/agent_instruction_cli.rs
+++ b/crates/adoc-cli/tests/agent_instruction_cli.rs
@@ -182,12 +182,12 @@ fn build_emits_agent_instruction_into_graph_and_renders_banner() {
     );
 
     // Graph: the agent_instruction node carries kind, trust, scope, and both
-    // action sets (schema stays adoc.graph.v4 — additive).
+    // action sets (schema stays adoc.graph.v5 — additive).
     let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let node = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/api_cli.rs
+++ b/crates/adoc-cli/tests/api_cli.rs
@@ -96,7 +96,7 @@ fn build_accepts_prd_example_and_emits_api_into_graph_v4() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let api = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/billing_pilot.rs
+++ b/crates/adoc-cli/tests/billing_pilot.rs
@@ -18,13 +18,10 @@ fn repo_root() -> PathBuf {
 
 fn is_billing_pilot_adoc_path(path: &str) -> bool {
     let path = Path::new(path);
-
-    path.extension()
-        .is_some_and(|extension| extension == "adoc")
+    path.is_relative()
         && path
-            .parent()
-            .and_then(Path::file_name)
-            .is_some_and(|directory| directory == "billing-pilot")
+            .extension()
+            .is_some_and(|extension| extension == "adoc")
 }
 
 #[test]
@@ -81,7 +78,7 @@ fn billing_pilot_checks_builds_and_exposes_useful_artifacts() {
         .expect("billing pilot graph JSON is written");
     let graph_json: Value =
         serde_json::from_str(&graph_json_text).expect("graph JSON is valid JSON");
-    assert_eq!(graph_json["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph_json["schema_version"], "adoc.graph.v5");
     let nodes = graph_json["nodes"]
         .as_array()
         .expect("graph JSON nodes is an array");

--- a/crates/adoc-cli/tests/check_cli.rs
+++ b/crates/adoc-cli/tests/check_cli.rs
@@ -178,7 +178,7 @@ fn read_graph_artifact(path: &Path) -> Value {
 
 fn assert_graph_artifact(text: &str) -> Value {
     let graph: Value = serde_json::from_str(text).expect("graph artifact is valid JSON");
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
     assert!(graph["nodes"].as_array().is_some());
     assert!(graph["edges"].as_array().is_some());
     assert_eq!(
@@ -266,9 +266,9 @@ fn check_unclosed_fence_diagnostic_surfaces_all_six_fields() {
 
     // Issue #3 acceptance: the diagnostic must carry file, line, column,
     // severity, code, and a fix-oriented message.
-    let prefix = format!("{}:5:1:", source.to_str().expect("source path is utf-8"));
+    let prefix = "unclosed_fence.adoc:5:1:";
     assert!(
-        stdout.contains(&prefix),
+        stdout.contains(prefix),
         "expected diagnostic to start with `path:line:column:` prefix `{prefix}`, got:\n{stdout}"
     );
     assert!(
@@ -2175,9 +2175,9 @@ fn build_renders_v0_6_multi_file_project_to_graph_json() {
     );
 
     assert!(
-        actual.contains("\"source_path\": \"project/01-glossary.adoc\"")
-            && actual.contains("\"source_path\": \"project/02-policy.adoc\"")
-            && actual.contains("\"source_path\": \"project/nested/03-ledger.adoc\""),
+        actual.contains("\"source_path\": \"01-glossary.adoc\"")
+            && actual.contains("\"source_path\": \"02-policy.adoc\"")
+            && actual.contains("\"source_path\": \"nested/03-ledger.adoc\""),
         "expected deterministic recursive .adoc source paths"
     );
     assert!(
@@ -2203,7 +2203,7 @@ fn check_rejects_v0_6_duplicate_id_across_files() {
     );
     let stdout = String::from_utf8_lossy(&output.stdout);
     assert!(
-        stdout.contains("duplicate_id/02-refunds.adoc:3:1"),
+        stdout.contains("02-refunds.adoc:3:1"),
         "expected duplicate diagnostic on second file, got:\n{stdout}"
     );
     assert!(
@@ -2211,7 +2211,7 @@ fn check_rejects_v0_6_duplicate_id_across_files() {
         "expected id.duplicate diagnostic, got:\n{stdout}"
     );
     assert!(
-        stdout.contains("previously defined as claim at duplicate_id/01-refunds.adoc:3:1"),
+        stdout.contains("previously defined as claim at 01-refunds.adoc:3:1"),
         "expected first definition location, got:\n{stdout}"
     );
 }

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -30,7 +30,8 @@ fn copy_valid_artifact(workspace: &TestWorkspace, relative_path: &str) {
     workspace.write(
         relative_path,
         r#"{
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [
     {
       "type": "page",
@@ -364,8 +365,8 @@ fn config_build_explicit_path_and_out_ignore_config_outputs() {
 }
 
 #[test]
-fn config_build_fully_explicit_no_embeddings_ignores_malformed_config() {
-    let workspace = TestWorkspace::new("config-build-explicit-malformed-ignored");
+fn config_build_fully_explicit_no_embeddings_rejects_malformed_config() {
+    let workspace = TestWorkspace::new("config-build-explicit-malformed-rejected");
     write_valid_source(&workspace, "explicit/source.adoc");
     workspace.write("agentdoc.config.yaml", "version: [\n");
 
@@ -381,25 +382,9 @@ fn config_build_fully_explicit_no_embeddings_ignores_malformed_config() {
         .output()
         .expect("adoc build runs");
 
-    assert!(
-        output.status.success(),
-        "expected fully explicit build to ignore malformed config\nstdout:\n{}\nstderr:\n{}",
-        stdout(&output),
-        stderr(&output)
-    );
-    assert!(workspace.root.join("explicit-dist/docs.html").is_file());
-    assert!(
-        workspace
-            .root
-            .join("explicit-dist/docs.graph.json")
-            .is_file()
-    );
-    assert!(
-        !workspace
-            .root
-            .join("explicit-dist/docs.search.json")
-            .exists()
-    );
+    assert!(!output.status.success());
+    assert!(stderr(&output).contains("error[config.parse]"));
+    assert!(!workspace.root.join("explicit-dist").exists());
 }
 
 #[test]

--- a/crates/adoc-cli/tests/constraint_cli.rs
+++ b/crates/adoc-cli/tests/constraint_cli.rs
@@ -71,7 +71,7 @@ fn build_emits_constraint_into_graph_v4() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let constraint = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/contradiction_cli.rs
+++ b/crates/adoc-cli/tests/contradiction_cli.rs
@@ -218,7 +218,7 @@ fn build_emits_contradiction_graph_node_with_expected_fields() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let node = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/diff_cli.rs
+++ b/crates/adoc-cli/tests/diff_cli.rs
@@ -1,5 +1,6 @@
 mod support;
 
+use std::fs;
 use std::process::Command;
 
 use support::{TestWorkspace, adoc_command, stderr, stdout};
@@ -95,6 +96,10 @@ fn build_two_commit_fixture(name: &str) -> TestWorkspace {
     run_git(&workspace, &["config", "user.name", "adoc tests"]);
     run_git(&workspace, &["config", "commit.gpgsign", "false"]);
 
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\n",
+    );
     workspace.write("docs/billing.adoc", BASE_BILLING_ADOC);
     run_git(&workspace, &["add", "-A"]);
     run_git(&workspace, &["commit", "-m", "base"]);
@@ -181,6 +186,25 @@ fn diff_unresolvable_ref_exits_nonzero_with_actionable_stderr() {
     let stderr = stderr(&output);
     assert!(stderr.contains("review"));
     assert!(stderr.contains("definitely-not-a-real-ref"));
+}
+
+#[test]
+fn diff_rejects_a_repository_without_discovered_project_config() {
+    let workspace = build_two_commit_fixture("diff-no-config");
+    fs::remove_file(workspace.root.join("agentdoc.config.yaml")).expect("remove config");
+
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["diff", "main"])
+        .output()
+        .expect("adoc diff runs");
+
+    assert!(!output.status.success());
+    assert!(
+        stderr(&output).contains("requires a discovered agentdoc.config.yaml"),
+        "stderr: {}",
+        stderr(&output)
+    );
 }
 
 #[test]

--- a/crates/adoc-cli/tests/evidence_model_cli.rs
+++ b/crates/adoc-cli/tests/evidence_model_cli.rs
@@ -141,8 +141,8 @@ fn build_records_evidence_ref_in_typed_array_and_edge() {
 
     // schema_version guard
     assert_eq!(
-        graph["schema_version"], "adoc.graph.v4",
-        "schema_version must be adoc.graph.v4"
+        graph["schema_version"], "adoc.graph.v5",
+        "schema_version must be adoc.graph.v5"
     );
 
     // ---- find the claim node -----------------------------------------------
@@ -340,7 +340,7 @@ fn build_records_evidence_edge_for_accepted_decision() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let edges = graph["edges"]
         .as_array()

--- a/crates/adoc-cli/tests/example_cli.rs
+++ b/crates/adoc-cli/tests/example_cli.rs
@@ -125,7 +125,7 @@ fn build_emits_example_into_graph_v3() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let example = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/expanded_pilot.rs
+++ b/crates/adoc-cli/tests/expanded_pilot.rs
@@ -21,7 +21,7 @@
 //! All warnings are driven by fixed past dates / wide-margin fixtures so the
 //! budget is clock-stable on any realistic future run date.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use serde_json::Value;
@@ -106,7 +106,7 @@ fn expanded_pilot_check_emits_documented_diagnostic_budget() {
     );
 }
 
-/// V5.10 acceptance: `adoc build` emits an `adoc.graph.v4` artifact carrying
+/// V5.10 acceptance: `adoc build` emits an `adoc.graph.v5` artifact carrying
 /// every V5 kind with exact per-kind node counts, the V5.8 evidence edges,
 /// V5.10 derived lifecycle fields (`effective_status`, `evidence_quality`),
 /// and pilot-scoped source spans; `docs.html` renders each kind distinctly.
@@ -140,7 +140,7 @@ fn expanded_pilot_build_emits_all_kinds_in_html_and_graph() {
     let graph_text = std::fs::read_to_string(output_directory.join("docs.graph.json"))
         .expect("pilot graph JSON is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph JSON is valid");
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let nodes = graph["nodes"]
         .as_array()
@@ -246,8 +246,8 @@ fn expanded_pilot_build_emits_all_kinds_in_html_and_graph() {
             .as_str()
             .unwrap_or_else(|| panic!("KO {} missing source_span.path", object["id"]));
         assert!(
-            path.contains("examples/expanded-pilot/"),
-            "KO {} source span must point back into the pilot, got {path}",
+            Path::new(path).is_relative() && path.ends_with(".adoc"),
+            "KO {} source span must be relative to the explicit pilot root, got {path}",
             object["id"]
         );
     }
@@ -623,6 +623,10 @@ fn expanded_pilot_diff_review_patch() {
         "--\n",
         "Credit consumption is handled by the use-case implementation.\n",
         "::\n",
+    );
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: knowledge\n",
     );
     workspace.write("knowledge/billing.adoc", base_adoc);
     run_git(&workspace, &["add", "-A"]);

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/duplicate_id.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/duplicate_id.graph.json
@@ -1,5 +1,6 @@
 {
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/malformed_artifact.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/malformed_artifact.graph.json
@@ -1,1 +1,1 @@
-{ "schema_version": "adoc.graph.v4", "nodes": [
+{ "schema_version": "adoc.graph.v5", "nodes": [

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact.graph.json
@@ -1,5 +1,6 @@
 {
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact_with_trust.graph.json
+++ b/crates/adoc-cli/tests/fixtures/v1_1_why/valid_artifact_with_trust.graph.json
@@ -1,5 +1,6 @@
 {
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-cli/tests/graph_cli.rs
+++ b/crates/adoc-cli/tests/graph_cli.rs
@@ -70,7 +70,7 @@ fn build_writes_graph_json_even_when_embeddings_are_skipped() {
         .expect("graph artifact is readable");
     let graph_json: serde_json::Value =
         serde_json::from_str(&graph_text).expect("graph artifact is JSON");
-    assert_eq!(graph_json["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph_json["schema_version"], "adoc.graph.v5");
     assert_eq!(
         graph_json["nodes"]
             .as_array()

--- a/crates/adoc-cli/tests/markdown_pilot.rs
+++ b/crates/adoc-cli/tests/markdown_pilot.rs
@@ -198,7 +198,7 @@ fn markdown_pilot_build_emits_safe_html_and_mixed_graph() {
     let graph_text = std::fs::read_to_string(output_directory.join("docs.graph.json"))
         .expect("pilot graph JSON is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph JSON is valid");
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let nodes = graph["nodes"]
         .as_array()
@@ -377,6 +377,10 @@ fn markdown_pilot_diff_and_review_handle_mixed_mode_change() {
         "\n",
         "Refunds settle within five business days. See the verified claim\n",
         "for the canonical audit-trail contract.\n",
+    );
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: .\n",
     );
     workspace.write("knowledge/billing.adoc", base_adoc);
     workspace.write("api/refunds.md", prose_md);

--- a/crates/adoc-cli/tests/observation_cli.rs
+++ b/crates/adoc-cli/tests/observation_cli.rs
@@ -86,7 +86,7 @@ fn build_accepts_prd_example_and_emits_observation_into_graph_v4() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let observation = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/policy_cli.rs
+++ b/crates/adoc-cli/tests/policy_cli.rs
@@ -166,7 +166,7 @@ fn build_renders_approval_block_and_emits_policy_into_graph_v3() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let policy = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/procedure_cli.rs
+++ b/crates/adoc-cli/tests/procedure_cli.rs
@@ -95,12 +95,12 @@ fn build_renders_ordered_steps_and_emits_procedure_into_graph_v3() {
         "first step text with marker stripped\n{html}"
     );
 
-    // Graph: the procedure node is emitted into adoc.graph.v4 with verified metadata.
+    // Graph: the procedure node is emitted into adoc.graph.v5 with verified metadata.
     let graph_text = fs::read_to_string(workspace.root.join("dist").join("docs.graph.json"))
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let procedure = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/review_cli.rs
+++ b/crates/adoc-cli/tests/review_cli.rs
@@ -134,6 +134,10 @@ fn build_billing_pilot_with_impacts(name: &str) -> TestWorkspace {
     run_git(&workspace, &["config", "user.name", "adoc tests"]);
     run_git(&workspace, &["config", "commit.gpgsign", "false"]);
 
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\n",
+    );
     workspace.write("docs/billing.adoc", BASE_BILLING_ADOC);
     workspace.write("crates/billing/src/refund.rs", BASE_REFUND_SRC);
     run_git(&workspace, &["add", "-A"]);
@@ -358,6 +362,10 @@ fn review_main_json_emits_owner_reassert_for_changed_unresolved_contradiction() 
     run_git(&workspace, &["config", "user.name", "adoc tests"]);
     run_git(&workspace, &["config", "commit.gpgsign", "false"]);
 
+    workspace.write(
+        "agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\n",
+    );
     workspace.write("docs/contradictions.adoc", BASE_CONTRADICTION_ADOC);
     run_git(&workspace, &["add", "-A"]);
     run_git(&workspace, &["commit", "-m", "base"]);

--- a/crates/adoc-cli/tests/source_cli.rs
+++ b/crates/adoc-cli/tests/source_cli.rs
@@ -111,7 +111,7 @@ fn build_emits_source_graph_node_with_expected_fields() {
         .expect("graph artifact is written");
     let graph: Value = serde_json::from_str(&graph_text).expect("graph json parses");
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let node = graph["nodes"]
         .as_array()

--- a/crates/adoc-cli/tests/why_cli.rs
+++ b/crates/adoc-cli/tests/why_cli.rs
@@ -533,66 +533,67 @@ fn why_styled_shows_contradicted_chip_on_relation_target() {
     // Build the fixture JSON inline — same schema_version as the existing
     // valid_artifact.graph.json fixture.
     let fixture = serde_json::json!({
-        "schema_version": "adoc.graph.v4",
-        "nodes": [
-            {
-                "type": "page",
-                "id": "slice7.page",
-                "order": 0,
-                "title": "Slice 7",
-                "source_path": "docs/slice7.adoc"
-            },
-            {
-                "type": "knowledge_object",
-                "id": "slice7.primary",
-                "kind": "claim",
-                "content_hash": "sha256:slice7.primary",
-                "status": "verified",
-                "body": "Slice 7 primary.",
-                "page_id": "slice7.page",
-                "source_span": {
-                    "path": "docs/slice7.adoc",
-                    "line": 1,
-                    "column": 1
-                },
-                "fields": {},
-                "relations": {
-                    "depends_on": [],
-                    "supersedes": ["slice7.contradicted"],
-                    "related_to": []
-                }
-            },
-            {
-                "type": "knowledge_object",
-                "id": "slice7.contradicted",
-                "kind": "claim",
-                "content_hash": "sha256:slice7.contradicted",
-                "status": "contradicted",
-                "body": "Slice 7 contradicted.",
-                "page_id": "slice7.page",
-                "source_span": {
-                    "path": "docs/slice7.adoc",
-                    "line": 2,
-                    "column": 1
-                },
-                "fields": {},
-                "relations": {
-                    "depends_on": [],
-                    "supersedes": [],
-                    "related_to": []
-                }
-            }
-        ],
-        "edges": [
-            {
-                "kind": "relation",
-                "source": "slice7.primary",
-                "target": "slice7.contradicted",
-                "relation": "supersedes"
-            }
-        ],
-        "diagnostics": []
-    });
+          "schema_version": "adoc.graph.v5",
+    "repository_identity": null,
+          "nodes": [
+              {
+                  "type": "page",
+                  "id": "slice7.page",
+                  "order": 0,
+                  "title": "Slice 7",
+                  "source_path": "docs/slice7.adoc"
+              },
+              {
+                  "type": "knowledge_object",
+                  "id": "slice7.primary",
+                  "kind": "claim",
+                  "content_hash": "sha256:slice7.primary",
+                  "status": "verified",
+                  "body": "Slice 7 primary.",
+                  "page_id": "slice7.page",
+                  "source_span": {
+                      "path": "docs/slice7.adoc",
+                      "line": 1,
+                      "column": 1
+                  },
+                  "fields": {},
+                  "relations": {
+                      "depends_on": [],
+                      "supersedes": ["slice7.contradicted"],
+                      "related_to": []
+                  }
+              },
+              {
+                  "type": "knowledge_object",
+                  "id": "slice7.contradicted",
+                  "kind": "claim",
+                  "content_hash": "sha256:slice7.contradicted",
+                  "status": "contradicted",
+                  "body": "Slice 7 contradicted.",
+                  "page_id": "slice7.page",
+                  "source_span": {
+                      "path": "docs/slice7.adoc",
+                      "line": 2,
+                      "column": 1
+                  },
+                  "fields": {},
+                  "relations": {
+                      "depends_on": [],
+                      "supersedes": [],
+                      "related_to": []
+                  }
+              }
+          ],
+          "edges": [
+              {
+                  "kind": "relation",
+                  "source": "slice7.primary",
+                  "target": "slice7.contradicted",
+                  "relation": "supersedes"
+              }
+          ],
+          "diagnostics": []
+      });
 
     let artifact_path = workspace.write(
         "slice7.graph.json",

--- a/crates/adoc-core/src/application/artifact_inspection.rs
+++ b/crates/adoc-core/src/application/artifact_inspection.rs
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn graph_schema_constants_match_readers() {
-        assert_eq!(SUPPORTED_GRAPH_SCHEMA_VERSION, "adoc.graph.v4");
+        assert_eq!(SUPPORTED_GRAPH_SCHEMA_VERSION, "adoc.graph.v5");
         assert_eq!(SUPPORTED_SEARCH_SCHEMA_VERSION, "adoc.search.v1");
     }
 }

--- a/crates/adoc-core/src/application/compile.rs
+++ b/crates/adoc-core/src/application/compile.rs
@@ -43,6 +43,12 @@ pub struct BuildInput {
     pub prior_search_artifact_path: Option<PathBuf>,
 }
 
+#[derive(Debug, Clone)]
+pub struct LocalProjectContext {
+    pub project_root: PathBuf,
+    pub docs_root: PathBuf,
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BuildEmbeddingMode {
     Enabled,
@@ -137,6 +143,7 @@ fn run_compile_pipeline<P: SourceProvider>(
     today: NaiveDate,
     anchor: Option<&dyn EvidenceFileReader>,
 ) -> CompileResult {
+    let repository_identity = provider.repository_identity();
     // Pipeline stages: load → validate-source-pages → resolve-KOs →
     // resolve-object-references → validate-resolved-pages → assemble →
     // validate-workspace → build. Each stage is a separate function below so
@@ -172,6 +179,7 @@ fn run_compile_pipeline<P: SourceProvider>(
         &diagnostics,
         build_options.as_mut(),
         Some(today),
+        repository_identity,
     );
     let artifacts = artifact_result.artifacts;
     diagnostics.extend(artifact_result.diagnostics);
@@ -244,6 +252,14 @@ pub(crate) fn load_error_diagnostic(load_error: SourceLoadError) -> Diagnostic {
                 load_error.path.display(),
             ),
         ),
+        SourceLoadErrorKind::UnsafeSourcePath => Diagnostic::error(
+            DiagnosticCode::IoSourcePathUnsafe,
+            format!(
+                "unsafe AgentDoc Source path {}: {}",
+                load_error.path.display(),
+                load_error.message,
+            ),
+        ),
     }
 }
 
@@ -285,7 +301,14 @@ fn assemble_workspace(parsed: Vec<(SourceFile, PageAst)>) -> WorkspaceAst {
 /// statically dispatched per ADR-0006.
 #[cfg(test)]
 fn build_artifacts(workspace: &WorkspaceAst, diagnostics: &[Diagnostic]) -> Option<BuildArtifacts> {
-    build_artifacts_for_build(workspace, diagnostics, None, None).artifacts
+    build_artifacts_for_build(
+        workspace,
+        diagnostics,
+        None,
+        None,
+        crate::domain::graph::GraphRepositoryIdentity::standalone(),
+    )
+    .artifacts
 }
 
 struct ArtifactBuildResult {
@@ -298,6 +321,7 @@ fn build_artifacts_for_build(
     diagnostics: &[Diagnostic],
     mut build_options: Option<&mut BuildOptions<'_>>,
     today: Option<NaiveDate>,
+    repository_identity: crate::domain::graph::GraphRepositoryIdentity,
 ) -> ArtifactBuildResult {
     if diagnostics
         .iter()
@@ -314,7 +338,12 @@ fn build_artifacts_for_build(
         .filter(|diagnostic| diagnostic.code != DiagnosticCode::BuildEmbeddingsSkipped)
         .cloned()
         .collect::<Vec<_>>();
-    let graph_document = GraphJsonArtifact.build_for_date(workspace, &graph_diagnostics, today);
+    let graph_document = GraphJsonArtifact.build_for_date_and_repository(
+        workspace,
+        &graph_diagnostics,
+        today,
+        repository_identity,
+    );
     let graph_json = graph_document
         .to_pretty_json()
         .expect("graph artifact serialization should not fail");
@@ -552,7 +581,7 @@ mod tests {
                 span.start.line,
                 span.start.column
             )),
-            Some((std::path::Path::new("/work/guide.adoc"), 3, 1))
+            Some((std::path::Path::new("guide.adoc"), 3, 1))
         );
         assert!(
             diagnostic.message.contains("billing.credits")
@@ -615,7 +644,7 @@ mod tests {
                 span.start.line,
                 span.start.column
             )),
-            Some((std::path::Path::new("/work/guide.adoc"), 3, 1))
+            Some((std::path::Path::new("guide.adoc"), 3, 1))
         );
         assert!(
             diagnostic.message.contains("billing.invalid")

--- a/crates/adoc-core/src/application/migrate.rs
+++ b/crates/adoc-core/src/application/migrate.rs
@@ -249,7 +249,7 @@ pub(crate) fn migrate_with_provider<P: SourceProvider>(
             Ok(source) => match source.mode() {
                 SourceMode::Compat => compat_sources.push(source),
                 SourceMode::Strict => {
-                    strict_paths.insert(normalize_path(&source.path));
+                    strict_paths.insert(normalize_path(&source.physical_path));
                 }
             },
             Err(load_error) => diagnostics.push(load_error_diagnostic(load_error)),
@@ -258,7 +258,7 @@ pub(crate) fn migrate_with_provider<P: SourceProvider>(
 
     let migration_set: BTreeSet<PathBuf> = compat_sources
         .iter()
-        .map(|source| normalize_path(&source.path))
+        .map(|source| normalize_path(&source.physical_path))
         .collect();
 
     let mut files = Vec::with_capacity(compat_sources.len());
@@ -272,7 +272,7 @@ pub(crate) fn migrate_with_provider<P: SourceProvider>(
                     format!(
                         "front matter dropped from {}; strict .adoc has no front-matter \
                          concept — git history and `adoc migrate --export` cover recovery",
-                        source.path.display()
+                        source.physical_path.display()
                     ),
                 )
                 .with_span(source.span_for_line(1, first_line)),
@@ -291,7 +291,7 @@ pub(crate) fn migrate_with_provider<P: SourceProvider>(
             MigrateDirection::Import,
         ));
 
-        let target_path = source.path.with_extension("adoc");
+        let target_path = source.physical_path.with_extension("adoc");
         if strict_paths.contains(&normalize_path(&target_path)) {
             diagnostics.push(Diagnostic::error(
                 DiagnosticCode::MigrateTargetExists,
@@ -299,12 +299,12 @@ pub(crate) fn migrate_with_provider<P: SourceProvider>(
                     "migration target {} already exists; refusing the run — leaving \
                      {} beside it would compile duplicate page IDs",
                     target_path.display(),
-                    source.path.display()
+                    source.physical_path.display()
                 ),
             ));
         }
         files.push(MigratedFile {
-            source_path: source.path.clone(),
+            source_path: source.physical_path.clone(),
             target_path,
             target_text: adoc_text,
             prose_blocks,
@@ -337,7 +337,7 @@ pub(crate) fn export_with_provider<P: SourceProvider>(
             Ok(source) => match source.mode() {
                 SourceMode::Strict => strict_sources.push(source),
                 SourceMode::Compat => {
-                    compat_paths.insert(normalize_path(&source.path));
+                    compat_paths.insert(normalize_path(&source.physical_path));
                 }
             },
             Err(load_error) => diagnostics.push(load_error_diagnostic(load_error)),
@@ -346,7 +346,7 @@ pub(crate) fn export_with_provider<P: SourceProvider>(
 
     let export_set: BTreeSet<PathBuf> = strict_sources
         .iter()
-        .map(|source| normalize_path(&source.path))
+        .map(|source| normalize_path(&source.physical_path))
         .collect();
 
     let mut files = Vec::with_capacity(strict_sources.len());
@@ -367,7 +367,7 @@ pub(crate) fn export_with_provider<P: SourceProvider>(
                 format!(
                     "{} contains typed Knowledge Object blocks; exporting typed knowledge \
                      to Markdown is lossy by definition — the run is refused",
-                    source.path.display()
+                    source.physical_path.display()
                 ),
             ));
             continue;
@@ -382,7 +382,7 @@ pub(crate) fn export_with_provider<P: SourceProvider>(
             MigrateDirection::Export,
         ));
 
-        let target_path = source.path.with_extension("md");
+        let target_path = source.physical_path.with_extension("md");
         if compat_paths.contains(&normalize_path(&target_path)) {
             diagnostics.push(Diagnostic::error(
                 DiagnosticCode::MigrateTargetExists,
@@ -390,12 +390,12 @@ pub(crate) fn export_with_provider<P: SourceProvider>(
                     "export target {} already exists; refusing the run — leaving \
                      {} beside it would compile duplicate page IDs",
                     target_path.display(),
-                    source.path.display()
+                    source.physical_path.display()
                 ),
             ));
         }
         files.push(MigratedFile {
-            source_path: source.path.clone(),
+            source_path: source.physical_path.clone(),
             target_path,
             target_text: markdown_text,
             prose_blocks,
@@ -455,7 +455,7 @@ fn broken_link_diagnostics<P: SourceProvider>(
         MigrateDirection::Export => "exported to .md",
     };
     let mut diagnostics = Vec::new();
-    let source_dir = source.path.parent().unwrap_or(Path::new(""));
+    let source_dir = source.physical_path.parent().unwrap_or(Path::new(""));
     for block in &page.blocks {
         walk_block_links(block, &mut |url: &str, span| {
             if has_url_scheme(url) {
@@ -477,7 +477,7 @@ fn broken_link_diagnostics<P: SourceProvider>(
                         format!(
                             "link target {target} is {converted_away} by this run; \
                              update the link in {}",
-                            source.path.display()
+                            source.physical_path.display()
                         ),
                     )
                     .with_span(span.clone()),
@@ -488,7 +488,7 @@ fn broken_link_diagnostics<P: SourceProvider>(
                         DiagnosticCode::MigrateBrokenLink,
                         format!(
                             "link target {target} does not exist (referenced from {})",
-                            source.path.display()
+                            source.physical_path.display()
                         ),
                     )
                     .with_span(span.clone()),
@@ -948,7 +948,7 @@ mod tests {
         assert_eq!(suggestion.suggested_kind, "task");
         assert_eq!(suggestion.matched_rule, "todo_line");
         assert_eq!(suggestion.excerpt, "TODO: rotate the signing key.");
-        assert_eq!(suggestion.span.file, PathBuf::from("/work/a/tasks.md"));
+        assert_eq!(suggestion.span.file, PathBuf::from("a/tasks.md"));
         assert_eq!(suggestion.span.start.line, 5);
     }
 

--- a/crates/adoc-core/src/application/patch.rs
+++ b/crates/adoc-core/src/application/patch.rs
@@ -229,7 +229,8 @@ mod tests {
 
     fn graph_document(objects: Vec<GraphKnowledgeObjectNode>) -> GraphArtifactDocument {
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: std::iter::once(GraphNode::Page(GraphPageNode {
                 id: "team.page".to_string(),
                 order: 0,

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -1045,7 +1045,8 @@ mod tests {
         edges: Vec<GraphEdge>,
     ) -> GraphArtifactDocument {
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: objects
                 .into_iter()
                 .map(GraphNode::KnowledgeObject)
@@ -1088,7 +1089,8 @@ mod tests {
             },
         }));
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),

--- a/crates/adoc-core/src/application/review.rs
+++ b/crates/adoc-core/src/application/review.rs
@@ -23,7 +23,6 @@ use crate::domain::ports::changed_files::{ChangedFilesError, ChangedFilesProvide
 use crate::domain::ports::snapshot_workspace::{
     SnapshotError, SnapshotSelector, SnapshotWorkspaceProvider,
 };
-use crate::domain::ports::source_provider::SourceProvider;
 use crate::domain::review::impact::{ImpactedObject, compute_impact};
 use crate::domain::review::object_diff::ObjectDiff;
 use crate::domain::review::obligation_rules::{obligations_for_change, obligations_for_impact};
@@ -38,6 +37,9 @@ pub struct ReviewInput {
     /// Project root used to construct the git-CLI adapter. The directory must
     /// be inside a git repository when `base` or `head` is a [`SnapshotSelector::GitRef`].
     pub project_root: PathBuf,
+    /// Project-root-relative configured documentation directory compiled in
+    /// both snapshots.
+    pub docs_path: PathBuf,
     pub base: SnapshotSelector,
     pub head: SnapshotSelector,
 }
@@ -169,24 +171,26 @@ pub(crate) fn load_review_with_providers<S: SnapshotWorkspaceProvider>(
     input: ReviewInput,
     snapshot_provider: &S,
 ) -> Result<ReviewLoadResult, ReviewError> {
-    let base = compile_snapshot(snapshot_provider, &input.base).map_err(|source| {
-        ReviewError::BaseSnapshot {
-            selector: input.base.clone(),
-            source,
-        }
-    })?;
+    let base =
+        compile_snapshot(snapshot_provider, &input.base, &input.docs_path).map_err(|source| {
+            ReviewError::BaseSnapshot {
+                selector: input.base.clone(),
+                source,
+            }
+        })?;
     if base.has_errors() {
         return Err(ReviewError::BaseCompileBlocked {
             diagnostics: base.diagnostics,
         });
     }
 
-    let head = compile_snapshot(snapshot_provider, &input.head).map_err(|source| {
-        ReviewError::HeadSnapshot {
-            selector: input.head.clone(),
-            source,
-        }
-    })?;
+    let head =
+        compile_snapshot(snapshot_provider, &input.head, &input.docs_path).map_err(|source| {
+            ReviewError::HeadSnapshot {
+                selector: input.head.clone(),
+                source,
+            }
+        })?;
     if head.has_errors() {
         return Err(ReviewError::HeadCompileBlocked {
             diagnostics: head.diagnostics,
@@ -263,20 +267,15 @@ pub fn proof_obligations(diff: &ObjectDiff, impact: &[ImpactedObject]) -> Vec<Pr
     ProofObligation::merge_dedup_sorted(from_diff.chain(from_impact))
 }
 
-/// Constant identity prefix used to rebase both base- and head-side source
-/// paths onto the same logical root. Without this rebase, `content_hash`
-/// values would carry the temporary worktree path on one side and the
-/// project workdir path on the other, and every unchanged Knowledge Object
-/// would appear in the diff's `changed[]` array.
-const REVIEW_IDENTITY_PREFIX: &str = "<review>";
-
 fn compile_snapshot<S: SnapshotWorkspaceProvider>(
     snapshot_provider: &S,
     selector: &SnapshotSelector,
+    docs_path: &std::path::Path,
 ) -> Result<CompileResult, SnapshotError> {
     let workspace = snapshot_provider.checkout(selector)?;
-    let source_provider = FsSourceProvider::new(workspace.path().to_path_buf())
-        .with_identity_prefix(PathBuf::from(REVIEW_IDENTITY_PREFIX));
+    let docs_root = workspace.path().join(docs_path);
+    let source_provider =
+        FsSourceProvider::for_project(docs_root.clone(), workspace.path().to_path_buf(), docs_root);
     let result = compile_with_provider(&source_provider);
     Ok(result)
 }
@@ -442,6 +441,7 @@ mod tests {
         let result = load_review_with_providers(
             ReviewInput {
                 project_root: head_root.path().to_path_buf(),
+                docs_path: std::path::PathBuf::from("docs"),
                 base: SnapshotSelector::GitRef(GitRef::new("main")),
                 head: SnapshotSelector::Workdir,
             },
@@ -455,6 +455,58 @@ mod tests {
         assert!(matches!(recorded[1], SnapshotSelector::Workdir));
         assert!(result.session.base().artifacts.is_some());
         assert!(result.session.head().artifacts.is_some());
+    }
+
+    #[test]
+    fn review_compiles_only_configured_docs_with_portable_project_paths() {
+        let base_root = fresh_workspace("configured-docs-base");
+        write_billing_source(base_root.path(), "Credits are stable.");
+        fs::write(
+            base_root.path().join("outside.adoc"),
+            "<div>ignored</div>\n",
+        )
+        .expect("outside source");
+        let head_root = fresh_workspace("configured-docs-head");
+        write_billing_source(head_root.path(), "Credits are stable.");
+        fs::write(
+            head_root.path().join("outside.adoc"),
+            "<div>ignored</div>\n",
+        )
+        .expect("outside source");
+        let provider = InMemorySnapshotWorkspaceProvider::new(head_root.path().to_path_buf())
+            .with_ref("main", base_root.path().to_path_buf());
+
+        let result = load_review_with_providers(
+            ReviewInput {
+                project_root: head_root.path().to_path_buf(),
+                docs_path: std::path::PathBuf::from("docs"),
+                base: SnapshotSelector::GitRef(GitRef::new("main")),
+                head: SnapshotSelector::Workdir,
+            },
+            &provider,
+        )
+        .expect("configured docs compile");
+        let base = &result
+            .session
+            .base()
+            .artifacts
+            .as_ref()
+            .expect("base")
+            .graph_json;
+        let head = &result
+            .session
+            .head()
+            .artifacts
+            .as_ref()
+            .expect("head")
+            .graph_json;
+        let base: serde_json::Value = serde_json::from_str(base).expect("base JSON");
+        let head: serde_json::Value = serde_json::from_str(head).expect("head JSON");
+
+        assert_eq!(base["nodes"], head["nodes"]);
+        assert!(base.to_string().contains("docs/billing.adoc"));
+        assert!(!base.to_string().contains("<review>"));
+        assert!(diff_objects(&result.session).changed().is_empty());
     }
 
     #[test]
@@ -476,6 +528,7 @@ mod tests {
         let error = load_review_with_providers(
             ReviewInput {
                 project_root: head_root.path().to_path_buf(),
+                docs_path: std::path::PathBuf::from("docs"),
                 base: SnapshotSelector::GitRef(GitRef::new("main")),
                 head: SnapshotSelector::Workdir,
             },
@@ -504,6 +557,7 @@ mod tests {
         let error = load_review_with_providers(
             ReviewInput {
                 project_root: head_root.path().to_path_buf(),
+                docs_path: std::path::PathBuf::from("docs"),
                 base: SnapshotSelector::GitRef(GitRef::new("unseeded")),
                 head: SnapshotSelector::Workdir,
             },
@@ -575,6 +629,7 @@ mod tests {
         let load = load_review_with_providers(
             ReviewInput {
                 project_root: head_root.path().to_path_buf(),
+                docs_path: std::path::PathBuf::from("docs"),
                 base: SnapshotSelector::GitRef(GitRef::new("main")),
                 head: SnapshotSelector::Workdir,
             },
@@ -832,6 +887,7 @@ mod tests {
             let load = load_review_with_providers(
                 ReviewInput {
                     project_root: head_root.path().to_path_buf(),
+                    docs_path: std::path::PathBuf::from("docs"),
                     base: SnapshotSelector::GitRef(GitRef::new("main")),
                     head: SnapshotSelector::Workdir,
                 },

--- a/crates/adoc-core/src/application/search_artifact.rs
+++ b/crates/adoc-core/src/application/search_artifact.rs
@@ -380,7 +380,8 @@ mod tests {
         })];
         all_nodes.extend(nodes);
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: all_nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),

--- a/crates/adoc-core/src/application/signals.rs
+++ b/crates/adoc-core/src/application/signals.rs
@@ -658,7 +658,8 @@ mod tests {
         })];
         all_nodes.extend(nodes);
         let document = GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: all_nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -123,6 +123,8 @@ diagnostic_codes! {
         "Check that the source directory exists and can be read by the current user.";
     IoUnsupportedSourceExtension = "io.unsupported_source_extension" =>
         "Use supported source files with the `.adoc` or `.md` extension.";
+    IoSourcePathUnsafe = "io.source_path_unsafe" =>
+        "Keep source paths inside the configured documentation root and use portable relative path components.";
     IoArtifactMissing = "io.artifact_missing" =>
         "Build docs.graph.json before loading the retrieval artifact.";
     IoArtifactUnreadable = "io.artifact_unreadable" =>

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -6,6 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
 use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId};
+use crate::domain::source::LogicalPath;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -69,9 +70,46 @@ impl fmt::Display for GraphDirection {
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub(crate) struct GraphArtifactDocument {
     pub(crate) schema_version: String,
+    #[serde(deserialize_with = "deserialize_repository_identity")]
+    pub(crate) repository_identity: GraphRepositoryIdentity,
     pub(crate) nodes: Vec<GraphNode>,
     pub(crate) edges: Vec<GraphEdge>,
     pub(crate) diagnostics: Vec<Diagnostic>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(transparent)]
+pub(crate) struct GraphRepositoryIdentity(pub(crate) Option<RepositoryIdentity>);
+
+impl GraphRepositoryIdentity {
+    pub(crate) fn standalone() -> Self {
+        Self(None)
+    }
+
+    pub(crate) fn local_project(config_path: String) -> Self {
+        Self(Some(RepositoryIdentity::LocalProject { config_path }))
+    }
+}
+
+impl Default for GraphRepositoryIdentity {
+    fn default() -> Self {
+        Self::standalone()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub(crate) enum RepositoryIdentity {
+    LocalProject { config_path: String },
+}
+
+fn deserialize_repository_identity<'de, D>(
+    deserializer: D,
+) -> Result<GraphRepositoryIdentity, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<RepositoryIdentity>::deserialize(deserializer).map(GraphRepositoryIdentity)
 }
 
 impl GraphArtifactDocument {
@@ -82,7 +120,7 @@ impl GraphArtifactDocument {
 
 // `GraphKnowledgeObjectNode` is large by design (carries all graph-node fields
 // inline for zero-copy serde). Boxing here would add indirection on every graph
-// traversal; the size asymmetry is acceptable per the `adoc.graph.v4` contract.
+// traversal; the size asymmetry is acceptable per the `adoc.graph.v5` contract.
 #[allow(clippy::large_enum_variant)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -189,7 +227,7 @@ impl ProseBlockKind {
 /// Carries the artifact-authored `GraphBlockNode` payload plus two derived
 /// fields: the variant discriminant (`kind`) and the nearest-ancestor-heading
 /// breadcrumb (`heading_context`), both computed at artifact-load time and
-/// never serialized back — `adoc.graph.v4` node shapes are untouched.
+/// never serialized back — `adoc.graph.v5` node shapes are untouched.
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) struct GraphProseBlock {
     pub(crate) id: String,
@@ -443,6 +481,23 @@ impl GraphIndex {
         let mut has_markdown_pages = false;
 
         for node in document.nodes {
+            let source_path = match &node {
+                GraphNode::Page(page) => &page.source_path,
+                GraphNode::Heading(block)
+                | GraphNode::Paragraph(block)
+                | GraphNode::List(block)
+                | GraphNode::CodeBlock(block) => &block.source_span.path,
+                GraphNode::KnowledgeObject(object) => &object.source_span.path,
+            };
+            if LogicalPath::parse(source_path).is_err() {
+                diagnostics.push(
+                    Diagnostic::error(
+                        DiagnosticCode::IoArtifactMalformed,
+                        format!("Graph node has a non-portable source path `{source_path}`."),
+                    )
+                    .with_help("Rebuild docs.graph.json from validated AgentDoc Source."),
+                );
+            }
             if let GraphNode::Page(page) = &node {
                 page_ids.insert(page.id.clone());
                 if page.source_path.ends_with(".md") {
@@ -906,7 +961,8 @@ mod tests {
 
     fn graph_document(content_hash: Option<&str>) -> GraphArtifactDocument {
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: vec![
                 GraphNode::Page(GraphPageNode {
                     id: "team.page".to_string(),
@@ -986,6 +1042,30 @@ mod tests {
         assert!(graph.contains_object(&ObjectId::new_unchecked("billing.credits".to_string())));
     }
 
+    #[test]
+    fn from_document_rejects_non_portable_source_paths() {
+        for unsafe_path in [
+            "/tmp/team.adoc",
+            "../team.adoc",
+            "docs\\team.adoc",
+            " docs/team.adoc",
+            "docs/team.adoc ",
+            "docs/team\0.adoc",
+        ] {
+            let mut document = graph_document(Some("sha256:billing.credits"));
+            let GraphNode::KnowledgeObject(node) = &mut document.nodes[1] else {
+                panic!("fixture knowledge object");
+            };
+            node.source_span.path = unsafe_path.to_string();
+
+            let diagnostics = GraphIndex::from_document(document)
+                .expect_err("non-portable graph source path must fail");
+
+            assert_eq!(diagnostics[0].code, DiagnosticCode::IoArtifactMalformed);
+            assert!(diagnostics[0].message.contains("source path"));
+        }
+    }
+
     fn prose_only_document(source_paths: &[&str]) -> GraphArtifactDocument {
         let nodes = source_paths
             .iter()
@@ -1000,7 +1080,8 @@ mod tests {
             })
             .collect();
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),
@@ -1034,7 +1115,8 @@ mod tests {
         })];
         all_nodes.extend(nodes);
         GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: all_nodes,
             edges: Vec::new(),
             diagnostics: Vec::new(),

--- a/crates/adoc-core/src/domain/inline.rs
+++ b/crates/adoc-core/src/domain/inline.rs
@@ -78,7 +78,7 @@ impl<'a> InlineOrigin<'a> {
     pub(crate) fn at(source: &'a SourceFile, line: u32, column: u32) -> Self {
         let position = source.span_for_line_columns(line, column, column).start;
         Self {
-            file: source.path.as_path(),
+            file: source.logical_path.as_path(),
             cursor: LineCursor::at(position.line, position.column),
             offset: position.offset,
         }

--- a/crates/adoc-core/src/domain/patch/mod.rs
+++ b/crates/adoc-core/src/domain/patch/mod.rs
@@ -666,7 +666,8 @@ mod tests {
 
     fn graph(objects: Vec<GraphKnowledgeObjectNode>) -> GraphIndex {
         GraphIndex::from_document(GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: std::iter::once(GraphNode::Page(GraphPageNode {
                 id: "team.page".to_string(),
                 order: 0,

--- a/crates/adoc-core/src/domain/ports/source_provider.rs
+++ b/crates/adoc-core/src/domain/ports/source_provider.rs
@@ -1,5 +1,6 @@
 use std::path::{Path, PathBuf};
 
+use crate::domain::graph::GraphRepositoryIdentity;
 use crate::domain::source::SourceFile;
 
 /// Adapter trait for the input side of the compiler.
@@ -11,6 +12,10 @@ use crate::domain::source::SourceFile;
 pub(crate) trait SourceProvider {
     fn load_sources(&self) -> Vec<Result<SourceFile, SourceLoadError>>;
 
+    fn repository_identity(&self) -> GraphRepositoryIdentity {
+        GraphRepositoryIdentity::standalone()
+    }
+
     /// Whether a source exists at `path`, in the same coordinate space as
     /// the paths this provider yields. The migrate broken-link check
     /// consults this instead of touching the filesystem from application
@@ -19,57 +24,6 @@ pub(crate) trait SourceProvider {
     /// `false` would turn every future provider's links into false-positive
     /// broken-link warnings.
     fn contains(&self, path: &Path) -> bool;
-
-    /// Wrap this provider so every yielded `SourceFile` has its `path` and
-    /// `identity_path` rebased onto `prefix`. Default impl wraps the
-    /// provider in [`IdentityRebaseDecorator`]; adapters may override for
-    /// zero-allocation behavior.
-    ///
-    /// The V3 review pipeline calls this to make `content_hash` values
-    /// stable across two snapshots of the same source tree at different
-    /// filesystem roots (the temporary git worktree vs the project
-    /// workdir). Without the rebase, every unchanged Knowledge Object
-    /// would appear in the diff's `changed[]` array because the embedded
-    /// `SourceSpan.file` would differ between sides.
-    fn with_identity_prefix(self, prefix: PathBuf) -> IdentityRebaseDecorator<Self>
-    where
-        Self: Sized,
-    {
-        IdentityRebaseDecorator {
-            inner: self,
-            prefix,
-        }
-    }
-}
-
-/// Generic decorator that rebases every yielded `SourceFile`'s `path` and
-/// `identity_path` onto a fixed prefix. Returned from
-/// [`SourceProvider::with_identity_prefix`]. Held as `pub(crate)` because
-/// only the V3 review pipeline (composed inside `adoc-core`) wires it.
-pub(crate) struct IdentityRebaseDecorator<P> {
-    inner: P,
-    prefix: PathBuf,
-}
-
-impl<P: SourceProvider> SourceProvider for IdentityRebaseDecorator<P> {
-    fn load_sources(&self) -> Vec<Result<SourceFile, SourceLoadError>> {
-        self.inner
-            .load_sources()
-            .into_iter()
-            .map(|result| result.map(|file| file.rebased_to_prefix(&self.prefix)))
-            .collect()
-    }
-
-    fn contains(&self, path: &Path) -> bool {
-        // Paths in this decorator's space carry the rebase prefix; strip it
-        // and ask the inner provider. ponytail: the stripped path is
-        // root-relative, which a wrapped `FsSourceProvider` would resolve
-        // against the cwd — root-join it there if a rebased pipeline (only
-        // review today, which never checks links) ever consults this.
-        path.strip_prefix(&self.prefix)
-            .map(|stripped| self.inner.contains(stripped))
-            .unwrap_or(false)
-    }
 }
 
 /// Reported by a [`SourceProvider`] when a single source cannot be loaded.
@@ -109,6 +63,14 @@ impl SourceLoadError {
             kind: SourceLoadErrorKind::UnsupportedSourceExtension,
         }
     }
+
+    pub(crate) fn unsafe_source_path(path: PathBuf, message: impl Into<String>) -> Self {
+        Self {
+            path,
+            message: message.into(),
+            kind: SourceLoadErrorKind::UnsafeSourcePath,
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -116,88 +78,5 @@ pub(crate) enum SourceLoadErrorKind {
     Unreadable,
     UnreadableDirectory,
     UnsupportedSourceExtension,
-}
-
-#[cfg(test)]
-mod tests {
-    use std::cell::RefCell;
-    use std::path::PathBuf;
-
-    use super::*;
-    use crate::domain::source::SourceFile;
-
-    /// Single-shot in-memory provider that yields one `SourceFile`. Lets
-    /// the rebase-decorator tests exercise the trait without dragging in
-    /// the in-memory test double from `infrastructure/source/in_memory.rs`.
-    struct OneShotProvider(RefCell<Option<SourceFile>>);
-
-    impl OneShotProvider {
-        fn new(file: SourceFile) -> Self {
-            Self(RefCell::new(Some(file)))
-        }
-    }
-
-    impl SourceProvider for OneShotProvider {
-        fn load_sources(&self) -> Vec<Result<SourceFile, SourceLoadError>> {
-            self.0
-                .borrow_mut()
-                .take()
-                .map(|file| vec![Ok(file)])
-                .unwrap_or_default()
-        }
-
-        fn contains(&self, _path: &Path) -> bool {
-            false
-        }
-    }
-
-    fn make_file(identity: &str) -> SourceFile {
-        SourceFile::new_with_identity_path(
-            PathBuf::from(format!("/tmp/wt-1234/{identity}")),
-            "# heading\n".to_string(),
-            PathBuf::from(identity),
-        )
-    }
-
-    #[test]
-    fn with_identity_prefix_rebases_path_and_identity() {
-        let provider = OneShotProvider::new(make_file("billing.adoc"));
-        let decorated = provider.with_identity_prefix(PathBuf::from("<review>"));
-
-        let sources = decorated.load_sources();
-        assert_eq!(sources.len(), 1);
-        let rebased = sources.into_iter().next().unwrap().expect("ok");
-
-        assert_eq!(rebased.path, PathBuf::from("<review>/billing.adoc"));
-        assert_eq!(
-            rebased.identity_path,
-            PathBuf::from("<review>/billing.adoc")
-        );
-        // Text preserved byte-identical.
-        assert_eq!(rebased.text, "# heading\n");
-    }
-
-    #[test]
-    fn with_identity_prefix_preserves_load_errors_unmodified() {
-        struct ErrorProvider;
-        impl SourceProvider for ErrorProvider {
-            fn load_sources(&self) -> Vec<Result<SourceFile, SourceLoadError>> {
-                vec![Err(SourceLoadError::unreadable(
-                    PathBuf::from("blocked.adoc"),
-                    "permission denied",
-                ))]
-            }
-
-            fn contains(&self, _path: &Path) -> bool {
-                false
-            }
-        }
-
-        let decorated = ErrorProvider.with_identity_prefix(PathBuf::from("<review>"));
-        let sources = decorated.load_sources();
-        assert_eq!(sources.len(), 1);
-        let error = sources.into_iter().next().unwrap().expect_err("err");
-        assert_eq!(error.path, PathBuf::from("blocked.adoc"));
-        assert_eq!(error.message, "permission denied");
-    }
+    UnsafeSourcePath,
 }

--- a/crates/adoc-core/src/domain/source.rs
+++ b/crates/adoc-core/src/domain/source.rs
@@ -3,6 +3,54 @@ use std::path::{Path, PathBuf};
 use crate::domain::diagnostic::{SourcePosition, SourceSpan};
 use crate::domain::identity::PageId;
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct LogicalPath(String);
+
+impl LogicalPath {
+    pub(crate) fn parse(value: &str) -> Result<Self, LogicalPathError> {
+        if value.is_empty()
+            || value.trim() != value
+            || value.starts_with('/')
+            || value.starts_with('\\')
+            || value.contains('\\')
+            || value.chars().any(char::is_control)
+            || has_windows_drive_prefix(value)
+        {
+            return Err(LogicalPathError);
+        }
+        if value
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+        {
+            return Err(LogicalPathError);
+        }
+        Ok(Self(value.to_string()))
+    }
+
+    pub(crate) fn from_relative_path(path: &Path) -> Result<Self, LogicalPathError> {
+        let mut components = Vec::new();
+        for component in path.components() {
+            let std::path::Component::Normal(component) = component else {
+                return Err(LogicalPathError);
+            };
+            components.push(component.to_str().ok_or(LogicalPathError)?);
+        }
+        Self::parse(&components.join("/"))
+    }
+
+    pub(crate) fn as_str(&self) -> &str {
+        &self.0
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) struct LogicalPathError;
+
+fn has_windows_drive_prefix(value: &str) -> bool {
+    let bytes = value.as_bytes();
+    bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':'
+}
+
 /// Position on a single line, expressed in 1-indexed character columns.
 ///
 /// Owns the UTF-8 column arithmetic that parser and inline scanner used to
@@ -48,8 +96,9 @@ pub(crate) fn column_offset(prefix: &str) -> u32 {
 
 #[derive(Debug, Clone)]
 pub(crate) struct SourceFile {
-    pub(crate) path: PathBuf,
+    pub(crate) physical_path: PathBuf,
     pub(crate) identity_path: PathBuf,
+    pub(crate) logical_path: PathBuf,
     pub(crate) text: String,
     pub(crate) line_index: LineIndex,
     /// Validation regime, fixed at construction from the file extension per
@@ -59,15 +108,26 @@ pub(crate) struct SourceFile {
 
 impl SourceFile {
     pub(crate) fn new_with_identity_path(
-        path: PathBuf,
+        physical_path: PathBuf,
         text: String,
         identity_path: PathBuf,
     ) -> Self {
+        let logical_path = identity_path.clone();
+        Self::new_with_coordinates(physical_path, text, identity_path, logical_path)
+    }
+
+    pub(crate) fn new_with_coordinates(
+        physical_path: PathBuf,
+        text: String,
+        identity_path: PathBuf,
+        logical_path: PathBuf,
+    ) -> Self {
         let line_index = LineIndex::new(&text);
-        let mode = mode_for_path(&path);
+        let mode = mode_for_path(&physical_path);
         Self {
-            path,
+            physical_path,
             identity_path,
+            logical_path,
             text,
             line_index,
             mode,
@@ -81,21 +141,6 @@ impl SourceFile {
         self.mode
     }
 
-    /// Return this `SourceFile` with both `path` and `identity_path`
-    /// rebased onto `prefix`. The text and line index are preserved
-    /// byte-identically — only the location metadata changes.
-    ///
-    /// Used by [`crate::domain::ports::source_provider::IdentityRebaseDecorator`]
-    /// so V3's review pipeline can compile the same source tree at two
-    /// different filesystem roots without the diff seeing every
-    /// `content_hash` change as a path change.
-    pub(crate) fn rebased_to_prefix(mut self, prefix: &Path) -> Self {
-        let rebased = prefix.join(&self.identity_path);
-        self.path = rebased.clone();
-        self.identity_path = rebased;
-        self
-    }
-
     pub(crate) fn span_for_line(&self, line_number: u32, text: &str) -> SourceSpan {
         let start = self.line_index.position_for_line(line_number);
         let end = SourcePosition {
@@ -104,7 +149,7 @@ impl SourceFile {
             offset: start.offset + text.len() as u32,
         };
         SourceSpan {
-            file: self.path.clone(),
+            file: self.logical_path.clone(),
             start,
             end,
         }
@@ -121,7 +166,7 @@ impl SourceFile {
 
     pub(crate) fn span_for_offsets(&self, start_offset: usize, end_offset: usize) -> SourceSpan {
         SourceSpan {
-            file: self.path.clone(),
+            file: self.logical_path.clone(),
             start: self.position_for_offset(start_offset),
             end: self.position_for_offset(end_offset),
         }
@@ -140,7 +185,7 @@ impl SourceFile {
             self.line_index
                 .offset_for_line_column(&self.text, line_number, end_column);
         SourceSpan {
-            file: self.path.clone(),
+            file: self.logical_path.clone(),
             start: SourcePosition {
                 line: line_number,
                 column: start_column,
@@ -170,7 +215,7 @@ impl SourceFile {
             .line_index
             .offset_for_line_column(&self.text, end_line, end_column);
         SourceSpan {
-            file: self.path.clone(),
+            file: self.logical_path.clone(),
             start,
             end: SourcePosition {
                 line: end_line,
@@ -451,5 +496,55 @@ mod tests {
         assert_eq!(span.start.offset, 5);
         assert_eq!(span.end.column, 10);
         assert_eq!(span.end.offset, 11);
+    }
+
+    #[test]
+    fn source_coordinates_keep_physical_identity_and_logical_paths_distinct() {
+        let source = SourceFile::new_with_coordinates(
+            PathBuf::from("/tmp/checkout/docs/guide.adoc"),
+            "# Guide\n".to_string(),
+            PathBuf::from("guide.adoc"),
+            PathBuf::from("docs/guide.adoc"),
+        );
+
+        assert_eq!(
+            source.physical_path,
+            PathBuf::from("/tmp/checkout/docs/guide.adoc")
+        );
+        assert_eq!(source.identity_path, PathBuf::from("guide.adoc"));
+        assert_eq!(source.logical_path, PathBuf::from("docs/guide.adoc"));
+        assert_eq!(
+            source.span_for_line(1, "# Guide").file,
+            PathBuf::from("docs/guide.adoc")
+        );
+    }
+
+    #[test]
+    fn logical_path_rejects_non_portable_coordinates() {
+        for unsafe_path in [
+            "",
+            "/docs/guide.adoc",
+            "C:/docs/guide.adoc",
+            "docs//guide.adoc",
+            "docs/./guide.adoc",
+            "docs/../guide.adoc",
+            "docs\\guide.adoc",
+            " docs/guide.adoc",
+            "docs/guide.adoc ",
+            "docs/guide\0.adoc",
+            "docs/guide\n.adoc",
+        ] {
+            assert!(
+                LogicalPath::parse(unsafe_path).is_err(),
+                "unsafe path accepted: {unsafe_path:?}"
+            );
+        }
+
+        assert_eq!(
+            LogicalPath::parse("docs/guide.adoc")
+                .expect("portable path")
+                .as_str(),
+            "docs/guide.adoc"
+        );
     }
 }

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -12,7 +12,7 @@ use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, SourceSpan};
 use crate::domain::graph::{
     GraphArtifactDocument, GraphBlockNode, GraphEdge, GraphEdgeKind, GraphEvidence,
     GraphKnowledgeObjectNode, GraphNode, GraphPageNode, GraphRelationKind, GraphRelations,
-    GraphSourceSpan,
+    GraphRepositoryIdentity, GraphSourceSpan,
 };
 use crate::domain::inline::{InlineSegment, to_source};
 use crate::domain::knowledge_object::{
@@ -25,7 +25,7 @@ use crate::domain::value_objects::evidence_kind::EvidenceKind;
 #[derive(Debug, Default, Clone, Copy)]
 pub(crate) struct GraphJsonArtifact;
 
-pub(crate) const SUPPORTED_GRAPH_SCHEMA_VERSION: &str = "adoc.graph.v4";
+pub(crate) const SUPPORTED_GRAPH_SCHEMA_VERSION: &str = "adoc.graph.v5";
 
 pub(crate) fn read_graph_artifact_document(
     path: &Path,
@@ -34,7 +34,38 @@ pub(crate) fn read_graph_artifact_document(
         Ok(contents) => contents,
         Err(error) => return Err(vec![read_error_diagnostic(path, error)]),
     };
-    let document = match serde_json::from_str::<GraphArtifactDocument>(&contents) {
+    let value = match serde_json::from_str::<serde_json::Value>(&contents) {
+        Ok(value) => value,
+        Err(error) => {
+            return Err(vec![
+                Diagnostic::error(
+                    DiagnosticCode::IoArtifactMalformed,
+                    format!("Artifact '{}' is malformed: {error}", path.display()),
+                )
+                .with_help("Rebuild docs.graph.json from the source workspace."),
+            ]);
+        }
+    };
+    if let Some(schema_version) = value.get("schema_version").and_then(|value| value.as_str())
+        && schema_version != SUPPORTED_GRAPH_SCHEMA_VERSION
+    {
+        return Err(vec![
+            Diagnostic::error(
+                DiagnosticCode::SchemaUnsupportedVersion,
+                format!(
+                    "Artifact '{}' uses unsupported schema_version '{}'.",
+                    path.display(),
+                    schema_version
+                ),
+            )
+            .with_help(format!(
+                "Expected schema_version '{}'.",
+                SUPPORTED_GRAPH_SCHEMA_VERSION
+            )),
+        ]);
+    }
+
+    let document = match serde_json::from_value::<GraphArtifactDocument>(value) {
         Ok(document) => document,
         Err(error) => {
             return Err(vec![
@@ -46,23 +77,6 @@ pub(crate) fn read_graph_artifact_document(
             ]);
         }
     };
-
-    if document.schema_version != SUPPORTED_GRAPH_SCHEMA_VERSION {
-        return Err(vec![
-            Diagnostic::error(
-                DiagnosticCode::SchemaUnsupportedVersion,
-                format!(
-                    "Artifact '{}' uses unsupported schema_version '{}'.",
-                    path.display(),
-                    document.schema_version
-                ),
-            )
-            .with_help(format!(
-                "Expected schema_version '{}'.",
-                SUPPORTED_GRAPH_SCHEMA_VERSION
-            )),
-        ]);
-    }
 
     Ok(document)
 }
@@ -84,6 +98,21 @@ impl GraphJsonArtifact {
         workspace: &WorkspaceAst,
         diagnostics: &[Diagnostic],
         today: Option<NaiveDate>,
+    ) -> GraphArtifactDocument {
+        self.build_for_date_and_repository(
+            workspace,
+            diagnostics,
+            today,
+            GraphRepositoryIdentity::standalone(),
+        )
+    }
+
+    pub(crate) fn build_for_date_and_repository(
+        &self,
+        workspace: &WorkspaceAst,
+        diagnostics: &[Diagnostic],
+        today: Option<NaiveDate>,
+        repository_identity: GraphRepositoryIdentity,
     ) -> GraphArtifactDocument {
         let mut nodes = Vec::new();
         let mut edges = Vec::new();
@@ -209,6 +238,7 @@ impl GraphJsonArtifact {
 
         GraphArtifactDocument {
             schema_version: SUPPORTED_GRAPH_SCHEMA_VERSION.to_string(),
+            repository_identity,
             nodes,
             edges,
             diagnostics: diagnostics.to_vec(),

--- a/crates/adoc-core/src/infrastructure/artifact/mod.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/mod.rs
@@ -58,7 +58,7 @@ mod tests {
 
         let graph_document = GraphJsonArtifact.build(&workspace, &[]);
 
-        assert_eq!(graph_document.schema_version, "adoc.graph.v4");
+        assert_eq!(graph_document.schema_version, "adoc.graph.v5");
         assert!(graph_document.nodes.is_empty());
         assert!(graph_document.edges.is_empty());
     }

--- a/crates/adoc-core/src/infrastructure/artifact/patch_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/patch_json.rs
@@ -637,7 +637,8 @@ mod tests {
         };
 
         GraphIndex::from_document(GraphArtifactDocument {
-            schema_version: "adoc.graph.v4".to_string(),
+            schema_version: "adoc.graph.v5".to_string(),
+            repository_identity: Default::default(),
             nodes: vec![GraphNode::Page(GraphPageNode {
                 id: "team.page".to_string(),
                 order: 0,

--- a/crates/adoc-core/src/infrastructure/parser/markdown/mod.rs
+++ b/crates/adoc-core/src/infrastructure/parser/markdown/mod.rs
@@ -103,7 +103,7 @@ pub(crate) fn parse_markdown_page(source: &SourceFile) -> (PageAst, Vec<Diagnost
     let page = PageAst {
         id: page_id,
         title,
-        source_path: source.path.clone(),
+        source_path: source.logical_path.clone(),
         blocks,
     };
     (page, diagnostics)

--- a/crates/adoc-core/src/infrastructure/parser/mod.rs
+++ b/crates/adoc-core/src/infrastructure/parser/mod.rs
@@ -40,7 +40,7 @@ pub(crate) fn parse_page(source: &SourceFile) -> (PageAst, Vec<Diagnostic>) {
     let mut page = PageAst {
         id: PageId::untitled_fallback(),
         title: None,
-        source_path: source.path.clone(),
+        source_path: source.logical_path.clone(),
         blocks: Vec::new(),
     };
     let mut diagnostics = Vec::new();

--- a/crates/adoc-core/src/infrastructure/render/adoc_source.rs
+++ b/crates/adoc-core/src/infrastructure/render/adoc_source.rs
@@ -76,7 +76,7 @@ impl Serializer<'_> {
                             format!(
                                 "empty prose block dropped from {}; it carries no content \
                                  and has no strict .adoc form",
-                                self.source.path.display()
+                                self.source.physical_path.display()
                             ),
                         )
                         .with_span(paragraph.span.clone()),
@@ -147,7 +147,7 @@ impl Serializer<'_> {
                     format!(
                         "internal: typed Knowledge Object block in Markdown source {}; \
                          Compatibility Mode parsing must never produce one (ADR-0023)",
-                        self.source.path.display()
+                        self.source.physical_path.display()
                     ),
                 ));
             }
@@ -192,7 +192,7 @@ impl Serializer<'_> {
                         format!(
                             "task-list checkbox marker dropped from a list item in {}; \
                              the item text is preserved",
-                            self.source.path.display()
+                            self.source.physical_path.display()
                         ),
                     )
                     .with_span(item.span.clone()),
@@ -304,7 +304,7 @@ impl Serializer<'_> {
                 code,
                 format!(
                     "{construct} {QUARANTINE_PHRASE} in {}",
-                    self.source.path.display()
+                    self.source.physical_path.display()
                 ),
             )
             .with_span(span.clone()),
@@ -324,7 +324,7 @@ impl Serializer<'_> {
                     format!(
                         "cannot represent content containing a bare ``` fence line in strict \
                          .adoc ({}); resolve the nested fence by hand before migrating",
-                        self.source.path.display()
+                        self.source.physical_path.display()
                     ),
                 )
                 .with_span(span.clone()),

--- a/crates/adoc-core/src/infrastructure/render/markdown_export.rs
+++ b/crates/adoc-core/src/infrastructure/render/markdown_export.rs
@@ -88,7 +88,7 @@ impl Exporter<'_> {
                             format!(
                                 "list with continuation content in {} cannot be exported; \
                                  the strict grammar has flat lists only",
-                                self.source.path.display()
+                                self.source.physical_path.display()
                             ),
                         )
                         .with_span(list.span.clone()),
@@ -129,7 +129,7 @@ impl Exporter<'_> {
                             code,
                             format!(
                                 "```{language} fence {UNWRAP_PHRASE} in {}",
-                                self.source.path.display()
+                                self.source.physical_path.display()
                             ),
                         )
                         .with_span(code_block.span.clone()),
@@ -152,7 +152,7 @@ impl Exporter<'_> {
                     format!(
                         "{} contains a typed Knowledge Object block; exporting typed \
                          knowledge to Markdown is lossy by definition and the run is refused",
-                        self.source.path.display()
+                        self.source.physical_path.display()
                     ),
                 ));
             }
@@ -169,7 +169,7 @@ impl Exporter<'_> {
                     format!(
                         "internal: Compatibility Mode block variant in strict source {}; \
                          the .adoc parser must never produce one",
-                        self.source.path.display()
+                        self.source.physical_path.display()
                     ),
                 ));
             }

--- a/crates/adoc-core/src/infrastructure/source/fs.rs
+++ b/crates/adoc-core/src/infrastructure/source/fs.rs
@@ -1,31 +1,58 @@
+use std::collections::BTreeSet;
 use std::path::{Path, PathBuf};
 use std::{fs, io};
 
+use crate::domain::graph::GraphRepositoryIdentity;
 use crate::domain::ports::source_provider::{SourceLoadError, SourceProvider};
-use crate::domain::source::{SOURCE_EXTENSIONS, SourceFile};
+use crate::domain::source::{LogicalPath, SOURCE_EXTENSIONS, SourceFile};
 
 /// Reads `.adoc` files from a directory tree (or a single file) on disk.
 ///
 /// Iteration order is the lexicographic ordering of paths so that compilation
 /// is deterministic across platforms.
 ///
-/// Callers that need identity-rebased paths (the V3 review pipeline, which
-/// compares two snapshots of the same source tree at different filesystem
-/// roots) wrap this provider via the trait-level
-/// [`SourceProvider::with_identity_prefix`] decorator — there is no
-/// inherent rebase constructor on `FsSourceProvider`.
+/// Project-bound callers supply the discovered project and documentation
+/// roots explicitly. Standalone callers use [`Self::new`] and publish paths
+/// relative to the selected file or directory.
 #[derive(Debug, Clone)]
 pub(crate) struct FsSourceProvider {
     root: PathBuf,
+    project_roots: Option<ProjectRoots>,
+}
+
+#[derive(Debug, Clone)]
+struct ProjectRoots {
+    project: PathBuf,
+    docs: PathBuf,
 }
 
 impl FsSourceProvider {
     pub(crate) fn new(root: PathBuf) -> Self {
-        Self { root }
+        Self {
+            root,
+            project_roots: None,
+        }
+    }
+
+    pub(crate) fn for_project(root: PathBuf, project_root: PathBuf, docs_root: PathBuf) -> Self {
+        Self {
+            root,
+            project_roots: Some(ProjectRoots {
+                project: project_root,
+                docs: docs_root,
+            }),
+        }
     }
 }
 
 impl SourceProvider for FsSourceProvider {
+    fn repository_identity(&self) -> GraphRepositoryIdentity {
+        match self.project_roots {
+            Some(_) => GraphRepositoryIdentity::local_project("agentdoc.config.yaml".to_string()),
+            None => GraphRepositoryIdentity::standalone(),
+        }
+    }
+
     fn contains(&self, path: &Path) -> bool {
         // Yielded paths share the coordinate space of `root` as given
         // (absolute or cwd-relative), so the resolved link path probes
@@ -34,6 +61,28 @@ impl SourceProvider for FsSourceProvider {
     }
 
     fn load_sources(&self) -> Vec<Result<SourceFile, SourceLoadError>> {
+        let project_roots = match self.resolved_project_roots() {
+            Ok(roots) => roots,
+            Err(error) => return vec![Err(error)],
+        };
+        if let Some(roots) = &project_roots {
+            let selected_root = match self.root.canonicalize() {
+                Ok(root) => root,
+                Err(error) => {
+                    return vec![Err(SourceLoadError::unreadable(
+                        self.root.clone(),
+                        error.to_string(),
+                    ))];
+                }
+            };
+            if !selected_root.starts_with(&roots.docs) {
+                return vec![Err(SourceLoadError::unsafe_source_path(
+                    self.root.clone(),
+                    "selected source root resolves outside the configured documentation root",
+                ))];
+            }
+        }
+
         if self.root.is_file() && !is_source_path(&self.root) {
             return vec![Err(SourceLoadError::unsupported_source_extension(
                 self.root.clone(),
@@ -41,26 +90,87 @@ impl SourceProvider for FsSourceProvider {
         }
 
         let mut results = Vec::new();
-        for source_path in source_paths(&self.root) {
+        for source_path in source_paths(
+            &self.root,
+            project_roots.as_ref().map(|roots| roots.docs.as_path()),
+        ) {
             match source_path {
-                Ok(source_path) => match fs::read_to_string(&source_path.path) {
-                    Ok(text) => {
-                        results.push(Ok(SourceFile::new_with_identity_path(
-                            source_path.path,
-                            text,
-                            source_path.identity_path,
-                        )));
-                    }
-                    Err(error) => results.push(Err(SourceLoadError::unreadable(
-                        source_path.path,
-                        error.to_string(),
-                    ))),
-                },
+                Ok(source_path) => {
+                    results.push(self.load_source(source_path, project_roots.as_ref()))
+                }
                 Err(error) => results.push(Err(error)),
             }
         }
         results
     }
+}
+
+impl FsSourceProvider {
+    fn resolved_project_roots(&self) -> Result<Option<ProjectRoots>, SourceLoadError> {
+        let Some(roots) = &self.project_roots else {
+            return Ok(None);
+        };
+        let project = canonical_root(&roots.project)?;
+        let docs = canonical_root(&roots.docs)?;
+        if !docs.starts_with(&project) {
+            return Err(SourceLoadError::unsafe_source_path(
+                roots.docs.clone(),
+                "configured documentation root resolves outside the project root",
+            ));
+        }
+        Ok(Some(ProjectRoots { project, docs }))
+    }
+
+    fn load_source(
+        &self,
+        source_path: SourcePath,
+        project_roots: Option<&ProjectRoots>,
+    ) -> Result<SourceFile, SourceLoadError> {
+        let physical_path = source_path.path.canonicalize().map_err(|error| {
+            SourceLoadError::unreadable(source_path.path.clone(), error.to_string())
+        })?;
+        let (identity_path, logical_path) = match project_roots {
+            Some(roots) => {
+                if !physical_path.starts_with(&roots.docs) {
+                    return Err(SourceLoadError::unsafe_source_path(
+                        source_path.path,
+                        "source resolves outside the configured project documentation root",
+                    ));
+                }
+                let identity = physical_path.strip_prefix(&roots.docs).map_err(|_| {
+                    SourceLoadError::unsafe_source_path(
+                        source_path.path.clone(),
+                        "source is outside the configured documentation root",
+                    )
+                })?;
+                let logical = physical_path.strip_prefix(&roots.project).map_err(|_| {
+                    SourceLoadError::unsafe_source_path(
+                        source_path.path.clone(),
+                        "source is outside the configured project root",
+                    )
+                })?;
+                (identity.to_path_buf(), logical.to_path_buf())
+            }
+            None => (source_path.identity_path.clone(), source_path.identity_path),
+        };
+        let logical_path = LogicalPath::from_relative_path(&logical_path).map_err(|_| {
+            SourceLoadError::unsafe_source_path(logical_path, "logical source path is not portable")
+        })?;
+        let text = fs::read_to_string(&physical_path).map_err(|error| {
+            SourceLoadError::unreadable(physical_path.clone(), error.to_string())
+        })?;
+        Ok(SourceFile::new_with_coordinates(
+            physical_path,
+            text,
+            identity_path,
+            PathBuf::from(logical_path.as_str()),
+        ))
+    }
+}
+
+fn canonical_root(root: &Path) -> Result<PathBuf, SourceLoadError> {
+    root.canonicalize()
+        .map_err(|error| SourceLoadError::unreadable(root.to_path_buf(), error.to_string()))
 }
 
 #[derive(Debug, Clone)]
@@ -69,7 +179,10 @@ struct SourcePath {
     identity_path: PathBuf,
 }
 
-fn source_paths(root: &Path) -> Vec<Result<SourcePath, SourceLoadError>> {
+fn source_paths(
+    root: &Path,
+    containment_root: Option<&Path>,
+) -> Vec<Result<SourcePath, SourceLoadError>> {
     if root.is_file() {
         return vec![Ok(SourcePath {
             path: root.to_path_buf(),
@@ -91,7 +204,8 @@ fn source_paths(root: &Path) -> Vec<Result<SourcePath, SourceLoadError>> {
     }
 
     let mut paths = Vec::new();
-    collect_source_files(root, root, &mut paths);
+    let mut visited = BTreeSet::new();
+    collect_source_files(root, root, containment_root, &mut visited, &mut paths);
     paths.sort_by(|left, right| source_path_result_path(left).cmp(source_path_result_path(right)));
     paths
 }
@@ -99,8 +213,28 @@ fn source_paths(root: &Path) -> Vec<Result<SourcePath, SourceLoadError>> {
 fn collect_source_files(
     root: &Path,
     directory: &Path,
+    containment_root: Option<&Path>,
+    visited: &mut BTreeSet<PathBuf>,
     paths: &mut Vec<Result<SourcePath, SourceLoadError>>,
 ) {
+    let canonical_directory = match directory.canonicalize() {
+        Ok(path) => path,
+        Err(error) => {
+            paths.push(source_path_for_unreadable_directory(root, directory, error));
+            return;
+        }
+    };
+    if containment_root.is_some_and(|root| !canonical_directory.starts_with(root)) {
+        paths.push(Err(SourceLoadError::unsafe_source_path(
+            directory.to_path_buf(),
+            "source directory resolves outside the configured documentation root",
+        )));
+        return;
+    }
+    if !visited.insert(canonical_directory) {
+        return;
+    }
+
     let entries = match fs::read_dir(directory) {
         Ok(entries) => entries,
         Err(error) => {
@@ -112,7 +246,7 @@ fn collect_source_files(
     for entry in entries.flatten() {
         let path = entry.path();
         if path.is_dir() {
-            collect_source_files(root, &path, paths);
+            collect_source_files(root, &path, containment_root, visited, paths);
         } else if is_source_path(&path) {
             let identity_path = path
                 .strip_prefix(root)
@@ -174,6 +308,119 @@ mod tests {
         assert_eq!(load_error.path, blocked);
         assert_eq!(load_error.kind, SourceLoadErrorKind::UnreadableDirectory);
         assert!(load_error.message.contains("permission denied"));
+    }
+
+    #[test]
+    fn project_provider_assigns_docs_relative_identity_and_project_relative_logical_path() {
+        let temp_root = tempfile::tempdir().expect("temp project");
+        let docs_root = temp_root.path().join("knowledge");
+        fs::create_dir_all(docs_root.join("billing")).expect("create docs");
+        let physical_path = docs_root.join("billing/guide.adoc");
+        fs::write(&physical_path, "# Billing\n").expect("write source");
+
+        let sources = FsSourceProvider::for_project(
+            docs_root.clone(),
+            temp_root.path().to_path_buf(),
+            docs_root,
+        )
+        .load_sources();
+        let source = sources
+            .into_iter()
+            .next()
+            .expect("one source")
+            .expect("load");
+
+        assert_eq!(
+            source.physical_path,
+            physical_path.canonicalize().expect("canonical")
+        );
+        assert_eq!(source.identity_path, PathBuf::from("billing/guide.adoc"));
+        assert_eq!(
+            source.logical_path,
+            PathBuf::from("knowledge/billing/guide.adoc")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_provider_rejects_source_symlink_that_escapes_docs_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp_root = tempfile::tempdir().expect("temp project");
+        let docs_root = temp_root.path().join("docs");
+        fs::create_dir(&docs_root).expect("create docs");
+        let outside = temp_root.path().join("outside.adoc");
+        fs::write(&outside, "# Secret\n").expect("write outside source");
+        symlink(&outside, docs_root.join("inside.adoc")).expect("create symlink");
+
+        let results = FsSourceProvider::for_project(
+            docs_root.clone(),
+            temp_root.path().to_path_buf(),
+            docs_root,
+        )
+        .load_sources();
+
+        assert!(matches!(
+            results.as_slice(),
+            [Err(SourceLoadError {
+                kind: SourceLoadErrorKind::UnsafeSourcePath,
+                ..
+            })]
+        ));
+    }
+
+    #[test]
+    fn project_provider_rejects_selected_root_outside_docs_even_when_empty() {
+        let temp_root = tempfile::tempdir().expect("temp project");
+        let docs_root = temp_root.path().join("docs");
+        let outside_root = temp_root.path().join("outside");
+        fs::create_dir(&docs_root).expect("create docs");
+        fs::create_dir(&outside_root).expect("create outside root");
+
+        let results = FsSourceProvider::for_project(
+            outside_root.clone(),
+            temp_root.path().to_path_buf(),
+            docs_root,
+        )
+        .load_sources();
+
+        assert!(matches!(
+            results.as_slice(),
+            [Err(SourceLoadError {
+                kind: SourceLoadErrorKind::UnsafeSourcePath,
+                path,
+                ..
+            })] if path == &outside_root
+        ));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn project_provider_rejects_source_directory_symlink_that_escapes_docs_root() {
+        use std::os::unix::fs::symlink;
+
+        let temp_root = tempfile::tempdir().expect("temp project");
+        let docs_root = temp_root.path().join("docs");
+        let outside_root = temp_root.path().join("outside");
+        fs::create_dir(&docs_root).expect("create docs");
+        fs::create_dir(&outside_root).expect("create outside root");
+        fs::write(outside_root.join("secret.adoc"), "# Secret\n").expect("write secret");
+        symlink(&outside_root, docs_root.join("linked")).expect("create directory symlink");
+
+        let results = FsSourceProvider::for_project(
+            docs_root.clone(),
+            temp_root.path().to_path_buf(),
+            docs_root,
+        )
+        .load_sources();
+
+        assert!(matches!(
+            results.as_slice(),
+            [Err(SourceLoadError {
+                kind: SourceLoadErrorKind::UnsafeSourcePath,
+                ..
+            })]
+        ));
     }
 
     #[cfg(unix)]

--- a/crates/adoc-core/src/infrastructure/source/in_memory.rs
+++ b/crates/adoc-core/src/infrastructure/source/in_memory.rs
@@ -34,6 +34,6 @@ impl SourceProvider for InMemorySourceProvider {
     fn contains(&self, path: &Path) -> bool {
         self.results
             .iter()
-            .any(|result| matches!(result, Ok(source) if source.path == path))
+            .any(|result| matches!(result, Ok(source) if source.physical_path == path))
     }
 }

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -12,6 +12,7 @@ pub use application::artifact_inspection::{
 };
 pub use application::compile::{
     BuildArtifacts, BuildEmbeddingMode, BuildInput, CompileInput, CompileResult,
+    LocalProjectContext,
 };
 pub use application::graph::{
     GRAPH_TRAVERSAL_SCHEMA_VERSION, GraphInput, GraphLoadResult, GraphSession,
@@ -131,6 +132,32 @@ pub fn compile_workspace(input: CompileInput) -> CompileResult {
     application::compile::compile_with_provider(&provider)
 }
 
+pub fn compile_project_workspace(
+    input: CompileInput,
+    project: LocalProjectContext,
+) -> CompileResult {
+    let provider = infrastructure::source::fs::FsSourceProvider::for_project(
+        input.root,
+        project.project_root,
+        project.docs_root,
+    );
+    application::compile::compile_with_provider(&provider)
+}
+
+pub fn compile_project_workspace_with_anchor_root(
+    input: CompileInput,
+    project: LocalProjectContext,
+    anchor_root: std::path::PathBuf,
+) -> CompileResult {
+    let provider = infrastructure::source::fs::FsSourceProvider::for_project(
+        input.root,
+        project.project_root,
+        project.docs_root,
+    );
+    let reader = infrastructure::source::evidence_fs::FsEvidenceFileReader::new(anchor_root);
+    application::compile::compile_with_provider_anchored(&provider, &reader)
+}
+
 /// V8.5.1 (ADR-0048): [`compile_workspace`] plus Evidence Anchor
 /// verification — anchored `source` paths are re-hashed against
 /// `anchor_root`. `None` behaves exactly like [`compile_workspace`]; only
@@ -172,6 +199,24 @@ pub fn export_workspace(root: std::path::PathBuf, mode: MigrateMode) -> MigrateR
 
 pub fn build_workspace(input: BuildInput) -> CompileResult {
     build_workspace_with_embedding_provider(input, EmbeddingProviderSelection::Local)
+}
+
+pub fn build_project_workspace(input: BuildInput, project: LocalProjectContext) -> CompileResult {
+    build_project_workspace_with_embedding_provider(
+        input,
+        project,
+        EmbeddingProviderSelection::Local,
+    )
+}
+
+pub fn build_project_workspace_with_embedding_provider(
+    input: BuildInput,
+    project: LocalProjectContext,
+    provider: EmbeddingProviderSelection,
+) -> CompileResult {
+    build_workspace_with_embedding_provider_factory_and_context(input, Some(project), || {
+        embedding_provider(provider)
+    })
 }
 
 #[tracing::instrument(level = "debug", skip_all)]
@@ -389,7 +434,11 @@ pub struct PatchApplyInput {
 /// `applied: false`; this function never panics on user input.
 #[tracing::instrument(level = "debug", skip_all)]
 pub fn apply_patch(input: PatchApplyInput, patch: PatchDocument) -> PatchApplyResult {
-    let provider = infrastructure::source::fs::FsSourceProvider::new(input.docs_root);
+    let provider = infrastructure::source::fs::FsSourceProvider::for_project(
+        input.docs_root.clone(),
+        input.project_root.clone(),
+        input.docs_root,
+    );
     let writer = infrastructure::source::fs_writer::FsWorkspaceWriter::new(input.project_root);
     application::apply::apply_patch_with_ports(
         &input.graph_artifact_path,
@@ -484,6 +533,20 @@ fn use_force_load_fail_test_embedding_provider() -> bool {
 
 fn build_workspace_with_embedding_provider_factory<F>(
     input: BuildInput,
+    provider_factory: F,
+) -> CompileResult
+where
+    F: FnMut() -> Result<
+        Box<dyn domain::ports::embedding_provider::EmbeddingProvider>,
+        domain::ports::embedding_provider::EmbeddingError,
+    >,
+{
+    build_workspace_with_embedding_provider_factory_and_context(input, None, provider_factory)
+}
+
+fn build_workspace_with_embedding_provider_factory_and_context<F>(
+    input: BuildInput,
+    project: Option<LocalProjectContext>,
     mut provider_factory: F,
 ) -> CompileResult
 where
@@ -492,7 +555,14 @@ where
         domain::ports::embedding_provider::EmbeddingError,
     >,
 {
-    let provider = infrastructure::source::fs::FsSourceProvider::new(input.root);
+    let provider = match project {
+        Some(project) => infrastructure::source::fs::FsSourceProvider::for_project(
+            input.root,
+            project.project_root,
+            project.docs_root,
+        ),
+        None => infrastructure::source::fs::FsSourceProvider::new(input.root),
+    };
     match input.embeddings {
         BuildEmbeddingMode::Enabled => application::compile::build_with_provider(
             &provider,

--- a/crates/adoc-core/tests/artifact_inspection.rs
+++ b/crates/adoc-core/tests/artifact_inspection.rs
@@ -21,38 +21,39 @@ fn valid_source() -> &'static str {
 
 fn valid_graph_json() -> String {
     serde_json::to_string_pretty(&json!({
-        "schema_version": "adoc.graph.v4",
-        "nodes": [
-            {
-                "type": "page",
-                "id": "team.billing",
-                "order": 0,
-                "source_path": "docs/billing.adoc"
-            },
-            {
-                "type": "knowledge_object",
-                "id": "billing.ready",
-                "kind": "claim",
-                "content_hash": "sha256:billing.ready",
-                "status": "draft",
-                "body": "Billing docs are ready.",
-                "page_id": "team.billing",
-                "source_span": {
-                    "path": "docs/billing.adoc",
-                    "line": 3,
-                    "column": 1
-                },
-                "fields": {},
-                "relations": {
-                    "depends_on": [],
-                    "supersedes": [],
-                    "related_to": []
-                }
-            }
-        ],
-        "edges": [],
-        "diagnostics": []
-    }))
+          "schema_version": "adoc.graph.v5",
+    "repository_identity": null,
+          "nodes": [
+              {
+                  "type": "page",
+                  "id": "team.billing",
+                  "order": 0,
+                  "source_path": "docs/billing.adoc"
+              },
+              {
+                  "type": "knowledge_object",
+                  "id": "billing.ready",
+                  "kind": "claim",
+                  "content_hash": "sha256:billing.ready",
+                  "status": "draft",
+                  "body": "Billing docs are ready.",
+                  "page_id": "team.billing",
+                  "source_span": {
+                      "path": "docs/billing.adoc",
+                      "line": 3,
+                      "column": 1
+                  },
+                  "fields": {},
+                  "relations": {
+                      "depends_on": [],
+                      "supersedes": [],
+                      "related_to": []
+                  }
+              }
+          ],
+          "edges": [],
+          "diagnostics": []
+      }))
     .expect("graph json serializes")
 }
 
@@ -107,7 +108,7 @@ fn graph_artifact_inspector_reports_missing_malformed_and_unsupported() {
     );
 
     let unsupported_path = root.join("unsupported.graph.json");
-    let unsupported_json = valid_graph_json().replace("adoc.graph.v4", "adoc.graph.v99");
+    let unsupported_json = valid_graph_json().replace("adoc.graph.v5", "adoc.graph.v99");
     write(&unsupported_path, &unsupported_json);
     let unsupported = inspect_graph_artifact(GraphArtifactInspectionInput {
         graph_artifact_path: unsupported_path,
@@ -133,7 +134,7 @@ fn graph_artifact_inspector_rejects_invalid_object_ids_and_counts_valid_objects(
         graph_artifact_path: valid_path,
     });
     assert_eq!(valid.load_status, ArtifactLoadStatus::Readable);
-    assert_eq!(valid.schema_version.as_deref(), Some("adoc.graph.v4"));
+    assert_eq!(valid.schema_version.as_deref(), Some("adoc.graph.v5"));
     assert_eq!(valid.object_count, Some(1));
 
     let invalid_path = root.join("invalid.graph.json");

--- a/crates/adoc-core/tests/clean_artifact_fixtures.rs
+++ b/crates/adoc-core/tests/clean_artifact_fixtures.rs
@@ -49,7 +49,7 @@ impl CleanFixture {
 
         let graph_json: serde_json::Value =
             serde_json::from_str(&artifacts.graph_json).expect("graph JSON is valid");
-        assert_eq!(graph_json["schema_version"], "adoc.graph.v4");
+        assert_eq!(graph_json["schema_version"], "adoc.graph.v5");
         assert!(
             graph_json["nodes"]
                 .as_array()

--- a/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim/duplicate_id_across_pages/expected.diagnostics.json
@@ -2,9 +2,9 @@
   {
     "code": "id.duplicate",
     "severity": "error",
-    "message": "duplicate claim id `billing.credits.foo`; previously defined at tests/fixtures/claim/duplicate_id_across_pages/input/01-billing.adoc:5:1",
+    "message": "duplicate claim id `billing.credits.foo`; previously defined at 01-billing.adoc:5:1",
     "span": {
-      "file": "tests/fixtures/claim/duplicate_id_across_pages/input/02-billing-extra.adoc",
+      "file": "02-billing-extra.adoc",
       "start": {
         "line": 5,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/duplicate_same_page/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/duplicate_same_page/expected.diagnostics.json
@@ -2,9 +2,9 @@
   {
     "code": "id.duplicate",
     "severity": "error",
-    "message": "duplicate claim id `billing.credits`; previously defined at tests/fixtures/claim_id_invalid/duplicate_same_page/input/billing.adoc:3:1",
+    "message": "duplicate claim id `billing.credits`; previously defined at billing.adoc:3:1",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/duplicate_same_page/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 9,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/empty_segment/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/empty_segment/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `billing..credits`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/empty_segment/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/leading_hyphen/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/leading_hyphen/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `-billing.credits`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/leading_hyphen/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/single_segment/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/single_segment/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `billing`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/single_segment/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/slash/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/slash/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `billing/credits.foo`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/slash/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/trailing_hyphen/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/trailing_hyphen/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `billing-.credits`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/trailing_hyphen/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/underscore/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/underscore/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `billing_credits.limit`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/underscore/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_id_invalid/uppercase/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_id_invalid/uppercase/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid claim id `Billing.Credits`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/claim_id_invalid/uppercase/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/claim_verified/missing_matrix/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/claim_verified/missing_matrix/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-owner` is missing required field `owner`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 3,
         "column": 1,
@@ -24,7 +24,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-verified-at` is missing required field `verified_at`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 11,
         "column": 1,
@@ -44,7 +44,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-evidence` requires at least one evidence field: `source`, `test`, `reviewed_by`, `external_url`, or `evidence_ref`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 19,
         "column": 1,
@@ -64,7 +64,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-owner-verified-at` is missing required field `owner`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 27,
         "column": 1,
@@ -84,7 +84,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-owner-verified-at` is missing required field `verified_at`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 27,
         "column": 1,
@@ -104,7 +104,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-owner-evidence` is missing required field `owner`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 34,
         "column": 1,
@@ -124,7 +124,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-owner-evidence` requires at least one evidence field: `source`, `test`, `reviewed_by`, `external_url`, or `evidence_ref`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 34,
         "column": 1,
@@ -144,7 +144,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-verified-at-evidence` is missing required field `verified_at`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 41,
         "column": 1,
@@ -164,7 +164,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-verified-at-evidence` requires at least one evidence field: `source`, `test`, `reviewed_by`, `external_url`, or `evidence_ref`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 41,
         "column": 1,
@@ -184,7 +184,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-all` is missing required field `owner`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 48,
         "column": 1,
@@ -204,7 +204,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-all` is missing required field `verified_at`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 48,
         "column": 1,
@@ -224,7 +224,7 @@
     "severity": "error",
     "message": "verified claim `billing.missing-all` requires at least one evidence field: `source`, `test`, `reviewed_by`, `external_url`, or `evidence_ref`",
     "span": {
-      "file": "tests/fixtures/claim_verified/missing_matrix/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 48,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/diagnostics/broken_object_reference/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/broken_object_reference/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "object reference `missing.object` does not resolve to a declared Knowledge Object",
     "span": {
-      "file": "tests/fixtures/diagnostics/broken_object_reference/input/team/bad.adoc",
+      "file": "team/bad.adoc",
       "start": {
         "line": 1,
         "column": 5,

--- a/crates/adoc-core/tests/fixtures/diagnostics/broken_relation/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/broken_relation/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "depends_on target `missing.object` does not resolve to a declared Knowledge Object",
     "span": {
-      "file": "tests/fixtures/diagnostics/broken_relation/input/team/bad.adoc",
+      "file": "team/bad.adoc",
       "start": {
         "line": 3,
         "column": 13,

--- a/crates/adoc-core/tests/fixtures/diagnostics/invalid_relation_id/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/invalid_relation_id/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "invalid relation id `Missing.Object` in `depends_on` for `billing.refunds`: Object ID must be at least two lowercase kebab-case segments separated by '.'",
     "span": {
-      "file": "tests/fixtures/diagnostics/invalid_relation_id/input/team/bad.adoc",
+      "file": "team/bad.adoc",
       "start": {
         "line": 3,
         "column": 13,

--- a/crates/adoc-core/tests/fixtures/diagnostics/malformed_open_fence/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/malformed_open_fence/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "::claim block is missing a required id token",
     "span": {
-      "file": "tests/fixtures/diagnostics/malformed_open_fence/input/team/bad.adoc",
+      "file": "team/bad.adoc",
       "start": {
         "line": 1,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/diagnostics/raw_html/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/raw_html/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "Raw HTML is not allowed in strict mode; write AgentDoc Source prose instead",
     "span": {
-      "file": "tests/fixtures/diagnostics/raw_html/input/team/bad.adoc",
+      "file": "team/bad.adoc",
       "start": {
         "line": 1,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/diagnostics/unknown_kind/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "unknown typed-block kind `fact`",
     "span": {
-      "file": "tests/fixtures/diagnostics/unknown_kind/input/team/bad.adoc",
+      "file": "team/bad.adoc",
       "start": {
         "line": 1,
         "column": 3,

--- a/crates/adoc-core/tests/fixtures/page_id_invalid/annotation/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/page_id_invalid/annotation/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "Object ID must use lowercase dot-separated kebab-case segments with at least two segments",
     "span": {
-      "file": "tests/fixtures/page_id_invalid/annotation/input/billing.adoc",
+      "file": "billing.adoc",
       "start": {
         "line": 1,
         "column": 24,

--- a/crates/adoc-core/tests/fixtures/page_id_invalid/path_derived/expected.diagnostics.json
+++ b/crates/adoc-core/tests/fixtures/page_id_invalid/path_derived/expected.diagnostics.json
@@ -4,7 +4,7 @@
     "severity": "error",
     "message": "Path-derived page ID `notes` is invalid; add a valid @doc(id) annotation or rename the source path",
     "span": {
-      "file": "tests/fixtures/page_id_invalid/path_derived/input/notes.adoc",
+      "file": "notes.adoc",
       "start": {
         "line": 1,
         "column": 1,

--- a/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.graph.json
+++ b/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.graph.json
@@ -1,5 +1,6 @@
 {
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [
     {
       "type": "page",

--- a/crates/adoc-core/tests/graph.rs
+++ b/crates/adoc-core/tests/graph.rs
@@ -2,7 +2,8 @@ use std::path::PathBuf;
 
 use adoc_core::{
     BuildEmbeddingMode, BuildInput, DiagnosticCode, GraphDirection, GraphInput, GraphRelationKind,
-    GraphTraversalQuery, load_graph_session, traverse_graph,
+    GraphTraversalQuery, LocalProjectContext, build_project_workspace, load_graph_session,
+    traverse_graph,
 };
 use serde_json::{Value, json};
 
@@ -58,11 +59,12 @@ fn relation_edge(source: &str, relation: GraphRelationKind, target: &str) -> Val
 
 fn graph_document(nodes: Vec<Value>, edges: Vec<Value>) -> String {
     serde_json::to_string_pretty(&json!({
-        "schema_version": "adoc.graph.v4",
-        "nodes": nodes,
-        "edges": edges,
-        "diagnostics": []
-    }))
+          "schema_version": "adoc.graph.v5",
+    "repository_identity": null,
+          "nodes": nodes,
+          "edges": edges,
+          "diagnostics": []
+      }))
     .expect("graph fixture serializes")
 }
 
@@ -165,7 +167,7 @@ fn graph_artifact_serializes_with_v2_shape() {
 
     let value: Value = serde_json::from_str(&artifact).expect("graph artifact serializes");
 
-    assert_eq!(value["schema_version"], "adoc.graph.v4");
+    assert_eq!(value["schema_version"], "adoc.graph.v5");
     assert_eq!(value.get("graph_artifact_hash"), None);
     assert!(
         !artifact.contains("\"html\""),
@@ -214,6 +216,106 @@ fn graph_content_hash_is_stable_for_same_source() {
 
     assert!(first.starts_with("sha256:"));
     assert_eq!(first, second);
+}
+
+#[test]
+fn standalone_build_emits_graph_v5_without_repository_identity() {
+    let graph = build_graph_value(
+        "# Graph @doc(team.graph)\n\n::claim billing.credits\nstatus: draft\n--\nCredits.\n::\n",
+    );
+
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
+    assert!(graph.get("repository_identity").is_some());
+    assert!(graph["repository_identity"].is_null());
+    assert_eq!(graph["nodes"][0]["source_path"], "graph.adoc");
+}
+
+#[test]
+fn project_build_emits_repository_identity_and_project_relative_source_paths() {
+    let workspace = TestWorkspace::new("graph-project-identity");
+    let docs_root = workspace.root().join("knowledge");
+    std::fs::create_dir_all(&docs_root).expect("docs directory");
+    let source_path = docs_root.join("graph.adoc");
+    std::fs::write(
+        &source_path,
+        "# Graph @doc(team.graph)\n\n::claim billing.credits\nstatus: draft\n--\nCredits.\n::\n",
+    )
+    .expect("source");
+
+    let result = build_project_workspace(
+        BuildInput {
+            root: docs_root.clone(),
+            embeddings: BuildEmbeddingMode::Skipped,
+            prior_search_artifact_path: None,
+        },
+        LocalProjectContext {
+            project_root: workspace.root().to_path_buf(),
+            docs_root,
+        },
+    );
+    let graph: Value =
+        serde_json::from_str(&result.artifacts.expect("artifacts").graph_json).expect("graph JSON");
+
+    assert_eq!(
+        graph["repository_identity"],
+        json!({"kind": "local_project", "config_path": "agentdoc.config.yaml"})
+    );
+    assert_eq!(graph["nodes"][0]["source_path"], "knowledge/graph.adoc");
+}
+
+#[test]
+fn project_graph_objects_are_portable_across_checkout_locations() {
+    fn build_clone(workspace: &TestWorkspace) -> Value {
+        let docs_root = workspace.root().join("knowledge");
+        let source_path = docs_root.join("billing/credits.adoc");
+        std::fs::create_dir_all(source_path.parent().expect("source parent"))
+            .expect("docs directory");
+        std::fs::write(
+            &source_path,
+            "# Credits\n\n::claim billing.credits\nstatus: draft\n--\nCredits.\n::\n",
+        )
+        .expect("source");
+        let result = build_project_workspace(
+            BuildInput {
+                root: docs_root.clone(),
+                embeddings: BuildEmbeddingMode::Skipped,
+                prior_search_artifact_path: None,
+            },
+            LocalProjectContext {
+                project_root: workspace.root().to_path_buf(),
+                docs_root,
+            },
+        );
+        serde_json::from_str(&result.artifacts.expect("artifacts").graph_json).expect("graph JSON")
+    }
+
+    let first = build_clone(&TestWorkspace::new("portable-clone-a"));
+    let second = build_clone(&TestWorkspace::new("portable-clone-b"));
+
+    assert_eq!(first["nodes"], second["nodes"]);
+    assert_eq!(first["repository_identity"], second["repository_identity"]);
+    assert_eq!(
+        object_hash(&first, "billing.credits"),
+        object_hash(&second, "billing.credits")
+    );
+    assert_eq!(first["nodes"][0]["id"], "billing.credits");
+}
+
+#[test]
+fn graph_v5_reader_requires_repository_identity_member() {
+    let graph_json =
+        graph_document(Vec::new(), Vec::new()).replace("  \"repository_identity\": null,\n", "");
+    let artifact = write_temp_artifact("missing-repository-identity", ".graph.json", &graph_json);
+
+    let result = load_graph_session(GraphInput {
+        graph_artifact_path: artifact.path().to_path_buf(),
+    });
+
+    assert!(result.session.is_none());
+    assert_eq!(
+        result.diagnostics[0].code,
+        DiagnosticCode::IoArtifactMalformed
+    );
 }
 
 #[test]
@@ -331,7 +433,7 @@ fn build_workspace_emits_graph_artifact_with_deterministic_order_when_embeddings
     );
     let artifacts = result.artifacts.expect("artifacts are produced");
     let graph: Value = serde_json::from_str(&artifacts.graph_json).expect("graph artifact is JSON");
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
     assert!(
         !artifacts.graph_json.contains("\"html\""),
         "graph artifact must not serialize HTML fragments: {}",
@@ -507,7 +609,7 @@ fn graph_traversal_applies_direction_and_relation_filters() {
 
 // ── V6.5.1: v4 golden api node ───────────────────────────────────────────────
 
-/// Pins the `adoc.graph.v4` api node shape: lifecycle-only `status`, method
+/// Pins the `adoc.graph.v5` api node shape: lifecycle-only `status`, method
 /// and path in the hashed `fields` map, and no `severity`/`trust` carriers —
 /// api is born under the ADR-0039 lifecycle-only rule.
 #[test]
@@ -527,7 +629,7 @@ fn built_api_node_is_lifecycle_only_with_method_and_path_fields() {
          ::\n",
     );
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let api = graph["nodes"]
         .as_array()
@@ -575,7 +677,7 @@ fn built_observation_node_is_lifecycle_only_with_sample_size_and_observed_at_fie
          ::\n",
     );
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let observation = graph["nodes"]
         .as_array()
@@ -653,7 +755,7 @@ fn built_answered_question_emits_resolved_by_edge_to_answering_claim() {
 
 // ── V6.5.4: v4 golden task node ──────────────────────────────────────────────
 
-/// Pins the `adoc.graph.v4` task node shape: lifecycle-only `status`, owner
+/// Pins the `adoc.graph.v5` task node shape: lifecycle-only `status`, owner
 /// and due in the hashed `fields` map, and no `severity`/`trust` carriers —
 /// task is born under the ADR-0039 lifecycle-only rule. The PRD §13.11
 /// `depends_on` relation emits a graph edge.
@@ -678,7 +780,7 @@ fn built_task_node_is_lifecycle_only_with_owner_and_due_fields() {
          ::\n",
     );
 
-    assert_eq!(graph["schema_version"], "adoc.graph.v4");
+    assert_eq!(graph["schema_version"], "adoc.graph.v5");
 
     let task = graph["nodes"]
         .as_array()

--- a/crates/adoc-core/tests/patch_apply.rs
+++ b/crates/adoc-core/tests/patch_apply.rs
@@ -6,8 +6,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use adoc_core::{
-    CompileInput, DiagnosticCode, PatchApplyInput, PatchApplyResult, compile_workspace,
-    parse_patch_from_value,
+    BuildEmbeddingMode, BuildInput, DiagnosticCode, LocalProjectContext, PatchApplyInput,
+    PatchApplyResult, build_project_workspace, parse_patch_from_value,
 };
 
 const PAGE_RELATIVE: &str = "docs/billing/claims.adoc";
@@ -49,9 +49,17 @@ impl Workspace {
     /// The in-test analogue of `adoc build`: compile and persist the graph
     /// artifact, returning its path.
     fn build(&self) -> PathBuf {
-        let result = compile_workspace(CompileInput {
-            root: self.docs_root(),
-        });
+        let result = build_project_workspace(
+            BuildInput {
+                root: self.docs_root(),
+                embeddings: BuildEmbeddingMode::Skipped,
+                prior_search_artifact_path: None,
+            },
+            LocalProjectContext {
+                project_root: self.root.path().to_path_buf(),
+                docs_root: self.docs_root(),
+            },
+        );
         assert!(
             !result
                 .diagnostics

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -131,11 +131,12 @@ fn sha256_prefixed(bytes: &[u8]) -> String {
 
 fn graph_json_from_objects(objects: Vec<Value>, edges: Vec<Value>) -> String {
     let document = json!({
-        "schema_version": "adoc.graph.v4",
-        "nodes": objects,
-        "edges": edges,
-        "diagnostics": []
-    });
+          "schema_version": "adoc.graph.v5",
+    "repository_identity": null,
+          "nodes": objects,
+          "edges": edges,
+          "diagnostics": []
+      });
     let canonical: CanonicalGraphDocument =
         serde_json::from_value(document).expect("graph fixture has canonical shape");
     serde_json::to_string_pretty(&canonical).expect("search fixture serializes to graph JSON")
@@ -144,6 +145,7 @@ fn graph_json_from_objects(objects: Vec<Value>, edges: Vec<Value>) -> String {
 #[derive(Debug, Serialize, Deserialize)]
 struct CanonicalGraphDocument {
     schema_version: String,
+    repository_identity: Option<Value>,
     nodes: Vec<CanonicalGraphNode>,
     edges: Vec<CanonicalGraphEdge>,
     diagnostics: Vec<Value>,
@@ -1898,7 +1900,8 @@ fn load_retrieval_session_rejects_invalid_object_ids_inside_artifact() {
     let artifact = write_temp_artifact(
         "invalid-object-id",
         r#"{
-          "schema_version": "adoc.graph.v4",
+          "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
           "nodes": [
             {
               "type": "knowledge_object",
@@ -1934,7 +1937,8 @@ fn load_retrieval_session_rejects_duplicate_object_ids_inside_artifact() {
     let artifact = write_temp_artifact(
         "duplicate",
         r#"{
-          "schema_version": "adoc.graph.v4",
+          "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
           "nodes": [
             {
               "type": "knowledge_object",
@@ -2011,11 +2015,12 @@ fn prose_only_graph_artifact(prose_blocks: usize) -> tempfile::NamedTempFile {
         }));
     }
     let document = json!({
-        "schema_version": "adoc.graph.v4",
-        "nodes": nodes,
-        "edges": [],
-        "diagnostics": []
-    });
+          "schema_version": "adoc.graph.v5",
+    "repository_identity": null,
+          "nodes": nodes,
+          "edges": [],
+          "diagnostics": []
+      });
     write_temp_artifact(
         "prose-only",
         &serde_json::to_string_pretty(&document).expect("prose-only fixture serializes"),
@@ -2024,11 +2029,12 @@ fn prose_only_graph_artifact(prose_blocks: usize) -> tempfile::NamedTempFile {
 
 fn empty_graph_artifact() -> tempfile::NamedTempFile {
     let document = json!({
-        "schema_version": "adoc.graph.v4",
-        "nodes": [],
-        "edges": [],
-        "diagnostics": []
-    });
+          "schema_version": "adoc.graph.v5",
+    "repository_identity": null,
+          "nodes": [],
+          "edges": [],
+          "diagnostics": []
+      });
     write_temp_artifact(
         "empty-graph",
         &serde_json::to_string_pretty(&document).expect("empty graph fixture serializes"),
@@ -2353,7 +2359,8 @@ fn task_object_is_lexically_findable_with_owner_and_due_fields() {
 fn prose_symmetry_graph_json(extension: &str) -> String {
     let path = format!("docs/guide.{extension}");
     serde_json::to_string_pretty(&json!({
-        "schema_version": "adoc.graph.v4",
+        "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
         "nodes": [
             {
                 "type": "page",

--- a/crates/adoc-local/src/config.rs
+++ b/crates/adoc-local/src/config.rs
@@ -134,6 +134,13 @@ impl RawProjectConfig {
             });
         }
 
+        if !is_portable_project_relative_path(&self.docs_path) {
+            return Err(LocalError::ConfigInvalid {
+                path: path.to_path_buf(),
+                message: "docs_path must be a portable project-relative path".to_string(),
+            });
+        }
+
         let config_dir = path.parent().unwrap_or_else(|| Path::new("."));
         let outputs = self.outputs.unwrap_or_default().resolve(config_dir);
         let embeddings_provider = match self.embeddings {
@@ -207,6 +214,26 @@ fn resolve_config_path(config_dir: &Path, path: PathBuf) -> PathBuf {
     }
 }
 
+fn is_portable_project_relative_path(path: &Path) -> bool {
+    let Some(value) = path.to_str() else {
+        return false;
+    };
+    if value == "." {
+        return true;
+    }
+    let bytes = value.as_bytes();
+    !value.is_empty()
+        && value.trim() == value
+        && !path.is_absolute()
+        && !value.starts_with('\\')
+        && !value.contains('\\')
+        && !value.chars().any(char::is_control)
+        && !(bytes.len() >= 2 && bytes[0].is_ascii_alphabetic() && bytes[1] == b':')
+        && !value
+            .split('/')
+            .any(|component| component.is_empty() || component == "." || component == "..")
+}
+
 fn is_git_boundary(path: &Path) -> bool {
     path.join(".git").exists()
 }
@@ -236,6 +263,28 @@ mod tests {
     }
 
     const BASE_CONFIG: &str = "version: 1\nmode: strict\ndocs_path: docs\n";
+
+    #[test]
+    fn docs_path_must_be_a_portable_project_relative_path() {
+        for docs_path in [
+            "../docs",
+            "/tmp/docs",
+            "docs\\knowledge",
+            " docs",
+            "docs ",
+            "C:/docs",
+        ] {
+            let contents = format!("version: 1\nmode: strict\ndocs_path: '{docs_path}'\n");
+            let (_dir, result) = config_in_tempdir(&contents);
+
+            match result {
+                Err(LocalError::ConfigInvalid { message, .. }) => {
+                    assert!(message.contains("docs_path"), "message: {message}");
+                }
+                other => panic!("unsafe docs_path {docs_path:?} must fail, got {other:?}"),
+            }
+        }
+    }
 
     #[test]
     fn mcp_patch_apply_defaults_to_disabled_when_block_absent() {

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -11,13 +11,14 @@ use adoc_core::{
     DiagnosticCode, EmbeddingProviderSelection, GitRef, GraphArtifactInspectionInput,
     GraphDirection, GraphInput as CoreGraphInput, GraphRelationKind, GraphSession,
     GraphTraversalEnvelope, GraphTraversalQuery, GraphTraversalResult, ImpactedEnvelope,
-    ObjectDiffEnvelope, PatchApplyInput as CorePatchApplyInput, PatchApplyResult, PatchCheckResult,
-    PatchInput, ProseRecord, RelPath, RetrievalEntry, RetrievalEnvelope, RetrievalInput,
-    RetrievalLoadResult, RetrievalRecord, ReviewEnvelope, ReviewError,
-    ReviewInput as CoreReviewInput, SearchArtifactInspectionInput, SearchFilters, SearchMode,
-    SearchQuery, SearchRecordScope, Severity, SnapshotSelector, StaleEnvelope,
-    apply_patch as core_apply_patch, build_workspace_with_embedding_provider,
-    changed_files_from_git, changed_paths_strings, check_patch as core_check_patch,
+    LocalProjectContext, ObjectDiffEnvelope, PatchApplyInput as CorePatchApplyInput,
+    PatchApplyResult, PatchCheckResult, PatchInput, ProseRecord, RelPath, RetrievalEntry,
+    RetrievalEnvelope, RetrievalInput, RetrievalLoadResult, RetrievalRecord, ReviewEnvelope,
+    ReviewError, ReviewInput as CoreReviewInput, SearchArtifactInspectionInput, SearchFilters,
+    SearchMode, SearchQuery, SearchRecordScope, Severity, SnapshotSelector, StaleEnvelope,
+    apply_patch as core_apply_patch, build_project_workspace_with_embedding_provider,
+    build_workspace_with_embedding_provider, changed_files_from_git, changed_paths_strings,
+    check_patch as core_check_patch, compile_project_workspace_with_anchor_root,
     compile_workspace_with_anchor_root, diff_objects, embed_query_with_embedding_provider,
     empty_contradictions_envelope, empty_impacted_envelope, empty_stale_envelope,
     evaluate_contradictions, evaluate_impacted, evaluate_stale, export_workspace,
@@ -512,7 +513,17 @@ where
         .unwrap_or_else(|| context.config_start().to_path_buf());
     let path = resolve_docs_path_with_config(path, config.as_ref())?;
     let path = context.path_policy().resolve_read_path(&path)?;
-    let result = compile_workspace_with_anchor_root(CompileInput { root: path }, Some(anchor_root));
+    let project = config
+        .as_ref()
+        .and_then(|config| project_context_for_selected_path(config, &path));
+    let result = match project {
+        Some(project) => compile_project_workspace_with_anchor_root(
+            CompileInput { root: path },
+            project,
+            anchor_root,
+        ),
+        None => compile_workspace_with_anchor_root(CompileInput { root: path }, Some(anchor_root)),
+    };
     let exit_code = if result.has_errors() { 1 } else { 0 };
 
     Ok(CheckOutcome {
@@ -617,19 +628,27 @@ where
         .as_deref()
         .map(|path| context.path_policy().resolve_write_path(path))
         .transpose()?;
-    let needs_config = path.is_none() || out.is_none() || !input.no_embeddings;
-    let config = discover_project_config_if(needs_config, context.config_start())?;
+    let config = discover_project_config_if(true, context.config_start())?;
     let path = resolve_docs_path_with_config(path, config.as_ref())?;
     let path = context.path_policy().resolve_read_path(&path)?;
     let embedding_mode = resolve_embedding_mode(config.as_ref(), input.no_embeddings);
     let embedding_provider = resolve_embedding_provider_selection(config.as_ref());
+    let project = config
+        .as_ref()
+        .and_then(|config| project_context_for_selected_path(config, &path));
 
     match out {
-        Some(out) => build_to_dir(path, out, embedding_mode, embedding_provider),
+        Some(out) => build_to_dir(path, out, embedding_mode, embedding_provider, project),
         None => {
             let output_paths = resolve_build_output_paths(config.as_ref(), embedding_mode)?;
             let output_paths = resolve_build_output_paths_with_policy(&output_paths, context)?;
-            build_to_paths(path, output_paths, embedding_mode, embedding_provider)
+            build_to_paths(
+                path,
+                output_paths,
+                embedding_mode,
+                embedding_provider,
+                project,
+            )
         }
     }
 }
@@ -1017,9 +1036,10 @@ fn diff_with_context<P>(
 where
     P: PathPolicy,
 {
-    let project_root = context.config_start().to_path_buf();
+    let (project_root, docs_path) = review_project_context(context.config_start())?;
     let review_input = CoreReviewInput {
         project_root,
+        docs_path,
         base: SnapshotSelector::GitRef(GitRef::new(input.base_ref)),
         head: snapshot_selector_from_head_ref(input.head_ref),
     };
@@ -1040,7 +1060,7 @@ fn review_with_context<P>(
 where
     P: PathPolicy,
 {
-    let project_root = context.config_start().to_path_buf();
+    let (project_root, docs_path) = review_project_context(context.config_start())?;
     // V3.7: parse the patch source before snapshotting so a malformed patch
     // doesn't pay the cost of a worktree checkout. Path-policy resolution
     // happens here at the orchestration boundary; adoc-core never sees a
@@ -1064,6 +1084,7 @@ where
 
     let review_input = CoreReviewInput {
         project_root,
+        docs_path,
         base: SnapshotSelector::GitRef(GitRef::new(input.base_ref)),
         head: snapshot_selector_from_head_ref(input.head_ref),
     };
@@ -1403,15 +1424,19 @@ fn build_to_dir(
     out: PathBuf,
     embedding_mode: BuildEmbeddingMode,
     embedding_provider: EmbeddingProviderSelection,
+    project: Option<LocalProjectContext>,
 ) -> Result<BuildOutcome, LocalError> {
-    let result = build_workspace_with_embedding_provider(
-        CoreBuildInput {
-            root: path,
-            embeddings: embedding_mode,
-            prior_search_artifact_path: Some(out.join("docs.search.json")),
-        },
-        embedding_provider,
-    );
+    let input = CoreBuildInput {
+        root: path,
+        embeddings: embedding_mode,
+        prior_search_artifact_path: Some(out.join("docs.search.json")),
+    };
+    let result = match project {
+        Some(project) => {
+            build_project_workspace_with_embedding_provider(input, project, embedding_provider)
+        }
+        None => build_workspace_with_embedding_provider(input, embedding_provider),
+    };
     finish_build_result(result, &out)
 }
 
@@ -1420,15 +1445,19 @@ fn build_to_paths(
     output_paths: BuildOutputs,
     embedding_mode: BuildEmbeddingMode,
     embedding_provider: EmbeddingProviderSelection,
+    project: Option<LocalProjectContext>,
 ) -> Result<BuildOutcome, LocalError> {
-    let result = build_workspace_with_embedding_provider(
-        CoreBuildInput {
-            root: path,
-            embeddings: embedding_mode,
-            prior_search_artifact_path: output_paths.search.clone(),
-        },
-        embedding_provider,
-    );
+    let input = CoreBuildInput {
+        root: path,
+        embeddings: embedding_mode,
+        prior_search_artifact_path: output_paths.search.clone(),
+    };
+    let result = match project {
+        Some(project) => {
+            build_project_workspace_with_embedding_provider(input, project, embedding_provider)
+        }
+        None => build_workspace_with_embedding_provider(input, embedding_provider),
+    };
     finish_build_result_at_paths(result, &output_paths)
 }
 
@@ -1643,6 +1672,49 @@ fn discover_project_config_if(
     } else {
         Ok(None)
     }
+}
+
+fn local_project_context(config: &ProjectConfig) -> LocalProjectContext {
+    LocalProjectContext {
+        project_root: config
+            .path
+            .parent()
+            .unwrap_or_else(|| Path::new("."))
+            .to_path_buf(),
+        docs_root: config.docs_path.clone(),
+    }
+}
+
+fn project_context_for_selected_path(
+    config: &ProjectConfig,
+    selected_path: &Path,
+) -> Option<LocalProjectContext> {
+    let selected = selected_path.canonicalize().ok()?;
+    let docs = config.docs_path.canonicalize().ok()?;
+    selected
+        .starts_with(docs)
+        .then(|| local_project_context(config))
+}
+
+fn review_project_context(start: &Path) -> Result<(PathBuf, PathBuf), LocalError> {
+    let config = ProjectConfig::discover_from(start)?.ok_or_else(|| LocalError::ConfigMissing {
+        message: "adoc diff/review requires a discovered agentdoc.config.yaml".to_string(),
+        config_path: None,
+    })?;
+    let project_root = config
+        .path
+        .parent()
+        .unwrap_or_else(|| Path::new("."))
+        .to_path_buf();
+    let docs_path = config
+        .docs_path
+        .strip_prefix(&project_root)
+        .map(Path::to_path_buf)
+        .map_err(|_| LocalError::PathOutsideProject {
+            path: config.docs_path,
+            project_root: project_root.clone(),
+        })?;
+    Ok((project_root, docs_path))
 }
 
 fn resolve_docs_path_with_config(

--- a/crates/adoc-local/tests/local_workflow.rs
+++ b/crates/adoc-local/tests/local_workflow.rs
@@ -259,6 +259,32 @@ fn build_writes_artifacts_and_reports_written_paths() {
 }
 
 #[test]
+fn configured_build_emits_project_identity_and_project_relative_source_paths() {
+    let workspace = tempfile::tempdir().expect("workspace");
+    let root = workspace.path();
+    write(&root.join("knowledge/index.adoc"), &valid_source());
+    write_config(
+        root,
+        "version: 1\nmode: strict\ndocs_path: knowledge\noutputs:\n  dir: dist\nembeddings:\n  provider: none\n",
+    );
+
+    build_with_config(root);
+
+    let graph: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(root.join("dist/docs.graph.json")).expect("graph artifact"),
+    )
+    .expect("graph JSON");
+    assert_eq!(
+        graph["repository_identity"],
+        serde_json::json!({
+            "kind": "local_project",
+            "config_path": "agentdoc.config.yaml"
+        })
+    );
+    assert_eq!(graph["nodes"][0]["source_path"], "knowledge/index.adoc");
+}
+
+#[test]
 fn lexical_search_returns_retrieval_records_and_exit_code() {
     let workspace = tempfile::tempdir().expect("workspace");
     let root = workspace.path();
@@ -595,7 +621,7 @@ fn project_status_build_refresh_writes_artifacts_and_reports_readiness() {
     assert!(outcome.artifacts.graph.exists);
     assert_eq!(
         outcome.artifacts.graph.schema_version.as_deref(),
-        Some("adoc.graph.v4")
+        Some("adoc.graph.v5")
     );
     assert_eq!(outcome.artifacts.graph.object_count, Some(1));
     assert_eq!(

--- a/crates/adoc-mcp/src/resources.rs
+++ b/crates/adoc-mcp/src/resources.rs
@@ -350,6 +350,14 @@ const RESOURCES: &[AgentResource] = &[
         mime_type: JSON_SCHEMA,
         contents: include_str!("../../../docs/agent/v0/schema/search-artifact.json"),
     },
+    AgentResource {
+        uri: "adoc://agent/v0/schema/graph-artifact.v5.json",
+        name: "schema-graph-artifact-v5-json",
+        title: "Graph Artifact v5 JSON Schema",
+        description: "JSON Schema for adoc.graph.v5, including portable source coordinates and repository identity.",
+        mime_type: JSON_SCHEMA,
+        contents: include_str!("../../../docs/agent/v0/schema/graph-artifact.v5.json"),
+    },
 ];
 
 pub fn list() -> Vec<Resource> {

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -88,7 +88,14 @@ fn project_with_built_graph() -> (tempfile::TempDir, AgentDocMcpServer, String) 
 
 #[test]
 fn validates_representative_serialized_agent_envelopes_against_contract_schemas() {
-    let (_workspace, server, base_hash) = project_with_built_graph();
+    let (workspace, server, base_hash) = project_with_built_graph();
+
+    let graph_artifact: serde_json::Value = serde_json::from_str(
+        &fs::read_to_string(workspace.path().join("dist/docs.graph.json"))
+            .expect("graph artifact reads"),
+    )
+    .expect("graph artifact parses");
+    assert_valid("graph-artifact.v5.json", &graph_artifact);
 
     let retrieval = server
         .run_search(SearchParams {
@@ -605,6 +612,7 @@ fn run_git(cwd: &Path, args: &[&str]) {
 fn run_review_diff(root: &Path) -> ObjectDiffEnvelope {
     let load = load_review_from_git(ReviewInput {
         project_root: root.to_path_buf(),
+        docs_path: PathBuf::from("docs"),
         base: SnapshotSelector::GitRef(GitRef::new("main")),
         head: SnapshotSelector::Workdir,
     })
@@ -616,6 +624,7 @@ fn run_review_diff(root: &Path) -> ObjectDiffEnvelope {
 fn run_review(root: &Path) -> ReviewEnvelope {
     let load = load_review_with_changed_files_from_git(ReviewInput {
         project_root: root.to_path_buf(),
+        docs_path: PathBuf::from("docs"),
         base: SnapshotSelector::GitRef(GitRef::new("main")),
         head: SnapshotSelector::Workdir,
     })
@@ -659,6 +668,7 @@ fn validates_adoc_review_v0_envelope_with_patch_check_against_schema() {
 
     let load = load_review_with_changed_files_from_git(ReviewInput {
         project_root: root.to_path_buf(),
+        docs_path: PathBuf::from("docs"),
         base: SnapshotSelector::GitRef(GitRef::new("main")),
         head: SnapshotSelector::Workdir,
     })
@@ -750,10 +760,10 @@ fn adoc_review_mcp_tool_accepts_optional_patch_parameter() {
     assert_eq!(envelope["patch_check"]["valid"], json!(true));
 }
 
-/// V3.6 contract: MCP must serve the V3 schema files verbatim (no transformation,
-/// no drift between the bundled `include_str!` and the source-of-truth file).
+/// MCP serves published schema files verbatim (no transformation and no drift
+/// between the bundled `include_str!` and the source-of-truth file).
 #[test]
-fn mcp_serves_v3_schema_resources_byte_equal_to_on_disk_files() {
+fn mcp_serves_schema_resources_byte_equal_to_on_disk_files() {
     let workspace = tempfile::tempdir().expect("workspace");
     let server = AgentDocMcpServer::new(workspace.path().to_path_buf());
 
@@ -785,6 +795,10 @@ fn mcp_serves_v3_schema_resources_byte_equal_to_on_disk_files() {
         (
             "adoc://agent/v0/schema/search-artifact.json",
             "search-artifact.json",
+        ),
+        (
+            "adoc://agent/v0/schema/graph-artifact.v5.json",
+            "graph-artifact.v5.json",
         ),
     ] {
         let result = server
@@ -1235,6 +1249,10 @@ fn retrieval_schema_ids_match_their_published_uris() {
         (
             "search-artifact.json",
             "adoc://agent/v0/schema/search-artifact.json",
+        ),
+        (
+            "graph-artifact.v5.json",
+            "adoc://agent/v0/schema/graph-artifact.v5.json",
         ),
     ] {
         assert_eq!(

--- a/crates/adoc-mcp/tests/mcp_adapter.rs
+++ b/crates/adoc-mcp/tests/mcp_adapter.rs
@@ -221,7 +221,7 @@ fn project_status_tool_can_refresh_with_check_or_build() {
     assert_eq!(build["refresh"]["exit_code"], 0);
     assert_eq!(
         build["artifacts"]["graph"]["schema_version"],
-        "adoc.graph.v4"
+        "adoc.graph.v5"
     );
     assert_eq!(build["artifacts"]["graph"]["object_count"], 1);
     assert_eq!(build["readiness"]["patch_validation"], true);
@@ -301,6 +301,7 @@ fn lists_and_reads_all_stable_agent_resources() {
         "adoc://agent/v0/schema/adoc.patch.apply.v0.schema.json",
         "adoc://agent/v0/schema/adoc.migrate.report.v0.schema.json",
         "adoc://agent/v0/schema/search-artifact.json",
+        "adoc://agent/v0/schema/graph-artifact.v5.json",
     ];
 
     let resources = server.list_agent_resources();

--- a/docs/adr/0049-canonical-source-identity-and-portable-hashes.md
+++ b/docs/adr/0049-canonical-source-identity-and-portable-hashes.md
@@ -1,0 +1,118 @@
+# ADR-0049: Canonical Source Identity and Portable Hashes
+
+**Status:** Accepted
+**Date:** 2026-07-21
+**Slice:** V9.1.1
+
+## Context
+
+AgentDoc currently uses one path for three different concerns: reading source
+bytes, deriving path-based page identity, and publishing source coordinates.
+`FsSourceProvider` therefore lets checkout-specific absolute paths reach
+diagnostics and Graph Artifact spans. Those spans participate in Knowledge
+Object `content_hash` values. Review hides the absolute path by rebasing it to
+the synthetic `<review>` prefix, but that produces a second identity instead
+of the same portable identity as a normal build. Review also compiles an
+entire temporary worktree rather than the configured documentation tree.
+
+Consequently, identical repository revisions can produce different graph
+objects and hashes in another clone or a review worktree. Patch base hashes
+from normal builds are not reliably interchangeable with assessment hashes,
+and serialized paths can be mistaken for host paths during patch placement.
+
+## Decision
+
+1. A loaded source carries three explicit coordinates:
+   - **physical path**: canonical host path used only for filesystem access;
+   - **identity path**: documentation-root-relative path used for path-derived
+     page IDs;
+   - **logical path**: validated project-relative path used in diagnostics,
+     Graph Artifact spans, diffs, hashes, and later receipts.
+2. Logical paths are non-empty relative UTF-8 paths serialized with `/`.
+   Absolute paths, drive prefixes, empty components, `.`, `..`, backslashes,
+   NUL/control characters, and leading or trailing whitespace are rejected.
+   Failure is explicit; no absolute-path fallback exists.
+3. Project-bound `check` and `build` discover `agentdoc.config.yaml`. Their
+   physical documentation root is the configured `docs_path`, identity paths
+   are relative to that root, and logical paths are relative to the discovered
+   project root. A caller-selected file or directory inside that configured
+   tree remains project-bound and receives the same coordinates as the
+   configuration default.
+4. Standalone explicit directory input uses that directory as both invocation
+   root and coordinate root. Standalone explicit file input uses its parent;
+   the file name is its identity and logical path. Standalone builds publish
+   no repository identity.
+5. Repository review, diff, and assessment require a discovered project
+   configuration. Each snapshot compiles `<snapshot>/<docs_path>` physically
+   while retaining the same project-relative logical prefix. The synthetic
+   `<review>` coordinate is removed.
+6. Patch check/apply resolves serialized logical coordinates beneath the
+   validated physical project snapshot. Logical text is never accepted as an
+   arbitrary host path, and canonical containment is checked before reads or
+   writes.
+7. The Graph Artifact contract becomes `adoc.graph.v5`. Every document has a
+   required `repository_identity` member:
+
+   ```json
+   {
+     "repository_identity": {
+       "kind": "local_project",
+       "config_path": "agentdoc.config.yaml"
+     }
+   }
+   ```
+
+   Project-bound invocations emit that object. Standalone invocations emit
+   `"repository_identity": null`. Repository identity describes the artifact
+   but does not enter individual Knowledge Object content hashes. Logical
+   source path, line, and column remain hash-bearing.
+8. Readers exact-match v5. No v4/v5 overlap reader is introduced. Existing
+   graph and search artifacts are rebuilt, embeddings are regenerated because
+   their graph artifact hash changes, and in-flight patch documents must be
+   regenerated when their base hashes no longer match.
+
+## Rejected
+
+- **Hashing absolute paths** — binds otherwise identical knowledge to one
+  checkout.
+- **Keeping `<review>` rebasing** — hides host paths but still makes review a
+  different identity domain.
+- **Removing line and column from hashes now** — portability does not require
+  it; pilot evidence should justify that separate semantic change.
+- **Inferring a repository root in the filesystem adapter** — command
+  semantics decide whether an invocation is project-bound or standalone.
+- **Treating `\\` as a path separator** — caller-authored logical paths have
+  one portable grammar on every platform.
+- **Embedding repository identity in each object hash** — it would make equal
+  objects differ by invocation family without improving object provenance.
+- **A tolerant v4 reader or migration layer** — no current external consumer
+  requires an overlap window, and the existing exact-version failure makes
+  the one-time rebuild unambiguous.
+
+## Consequences
+
+- Moving a checkout or compiling an unchanged snapshot in a review worktree
+  leaves graph objects and Knowledge Object hashes unchanged.
+- Moving a source within a repository deliberately changes its source
+  coordinate and affected hashes while preserving docs-root-relative page ID
+  behavior.
+- Configuration and snapshot orchestration must provide coordinate context;
+  source adapters no longer guess it.
+- Symlinked sources whose canonical target escapes the configured root fail
+  before bytes are read. Unsafe logical or patch paths fail with a stable
+  diagnostic/error instead of being normalized permissively.
+- `adoc.graph.v4` artifacts fail through the existing unsupported-version
+  path. The release notes must call out graph rebuild, patch regeneration, and
+  re-embedding.
+
+## Relationships
+
+- **ADR-0028 and ADR-0039** define the exact-version Graph Artifact discipline
+  continued by v5.
+- **ADR-0036** defines patch source-drift behavior; this ADR makes its base
+  hashes portable between normal and review builds.
+- **ADR-0047** governs Action packaging. The Action does not change in this
+  slice and must pin a release containing v5 before publishing hash-bearing
+  receipts.
+- **ADR-0048** establishes project-root evidence anchoring. Project-bound
+  source coordinates use the same discovered configuration root.

--- a/docs/agent/v0/agent-instruction-guide.md
+++ b/docs/agent/v0/agent-instruction-guide.md
@@ -25,4 +25,4 @@ Treat an `agent_instruction` the way you treat any other Knowledge Object: as ci
 
 ## Wire surface
 
-`agent_instruction` nodes are emitted into the graph artifact (`adoc.graph.v4`) with `kind: "agent_instruction"`, the typed `trust` (top-level node field; these nodes carry no `status`, per ADR-0039), the `scope`, and both action sets, and fold into the retrieval surface (`adoc.retrieval.v1`) like any other Knowledge Object. No new envelope version is introduced.
+`agent_instruction` nodes are emitted into the graph artifact (`adoc.graph.v5`) with `kind: "agent_instruction"`, the typed `trust` (top-level node field; these nodes carry no `status`, per ADR-0039), the `scope`, and both action sets, and fold into the retrieval surface (`adoc.retrieval.v1`) like any other Knowledge Object. No new envelope version is introduced.

--- a/docs/agent/v0/api-guide.md
+++ b/docs/agent/v0/api-guide.md
@@ -48,7 +48,7 @@ Consumes one or more credits for a completed generation job.
 
 ## Wire surface
 
-`api` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+`api` nodes are emitted into the graph artifact (`adoc.graph.v5`) with:
 
 - `kind: "api"` — the node-level kind discriminant
 - `status` — the lifecycle status, when authored (lifecycle-only per ADR-0039)

--- a/docs/agent/v0/compat-guide.md
+++ b/docs/agent/v0/compat-guide.md
@@ -1,6 +1,6 @@
 # AgentDoc Markdown Compatibility Guide
 
-V4 introduces **Compatibility Mode**: AgentDoc accepts `.md` source alongside `.adoc`, parses it with a CommonMark + GFM parser, and emits the same `adoc.graph.v4` artifact and `dist/docs.html` as native AgentDoc Source. Compatibility Mode is selected purely by file extension; `.adoc` files always validate under Strict Mode, `.md` files always validate under Compatibility Mode. There is no flag or config block to toggle this (ADR-0022).
+V4 introduces **Compatibility Mode**: AgentDoc accepts `.md` source alongside `.adoc`, parses it with a CommonMark + GFM parser, and emits the same `adoc.graph.v5` artifact and `dist/docs.html` as native AgentDoc Source. Compatibility Mode is selected purely by file extension; `.adoc` files always validate under Strict Mode, `.md` files always validate under Compatibility Mode. There is no flag or config block to toggle this (ADR-0022).
 
 This guide tells MCP agents how to reason about `.md` content correctly.
 

--- a/docs/agent/v0/contradiction-guide.md
+++ b/docs/agent/v0/contradiction-guide.md
@@ -41,7 +41,7 @@ Only `unresolved` contradictions are **active** and must be surfaced when answer
 
 ## Wire surface
 
-`contradiction` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+`contradiction` nodes are emitted into the graph artifact (`adoc.graph.v5`) with:
 
 - `kind: "contradiction"`
 - `status`: the lifecycle status (`unresolved`, `resolved`, `dismissed`)

--- a/docs/agent/v0/observation-guide.md
+++ b/docs/agent/v0/observation-guide.md
@@ -40,7 +40,7 @@ Users often misunderstand credit usage before their first generation.
 
 ## Wire surface
 
-`observation` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+`observation` nodes are emitted into the graph artifact (`adoc.graph.v5`) with:
 
 - `kind: "observation"` — the node-level kind discriminant
 - `status: "observed"` — the lifecycle status (lifecycle-only per ADR-0039)

--- a/docs/agent/v0/question-guide.md
+++ b/docs/agent/v0/question-guide.md
@@ -45,7 +45,7 @@ Should unused trial credits expire after 30 days or remain available indefinitel
 
 ## Wire surface
 
-`question` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+`question` nodes are emitted into the graph artifact (`adoc.graph.v5`) with:
 
 - `kind: "question"` — the node-level kind discriminant
 - `status` — `open` or `answered` (lifecycle-only per ADR-0039)

--- a/docs/agent/v0/schema/graph-artifact.v5.json
+++ b/docs/agent/v0/schema/graph-artifact.v5.json
@@ -1,0 +1,147 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "adoc://agent/v0/schema/graph-artifact.v5.json",
+  "title": "AgentDoc Graph Artifact (adoc.graph.v5)",
+  "description": "Portable AgentDoc graph output. Project-bound artifacts identify the local project; standalone artifacts carry an explicit null repository identity.",
+  "type": "object",
+  "required": ["schema_version", "repository_identity", "nodes", "edges", "diagnostics"],
+  "properties": {
+    "schema_version": { "const": "adoc.graph.v5" },
+    "repository_identity": {
+      "oneOf": [
+        { "type": "null" },
+        {
+          "type": "object",
+          "required": ["kind", "config_path"],
+          "properties": {
+            "kind": { "const": "local_project" },
+            "config_path": { "const": "agentdoc.config.yaml" }
+          },
+          "additionalProperties": false
+        }
+      ]
+    },
+    "nodes": {
+      "type": "array",
+      "items": {
+        "oneOf": [
+          { "$ref": "#/$defs/page" },
+          { "$ref": "#/$defs/proseBlock" },
+          { "$ref": "#/$defs/knowledgeObject" }
+        ]
+      }
+    },
+    "edges": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "required": ["kind", "source", "target"],
+        "properties": {
+          "kind": { "enum": ["contains", "relation", "reference", "evidence", "resolved_by"] },
+          "source": { "type": "string", "minLength": 1 },
+          "target": { "type": "string", "minLength": 1 },
+          "relation": { "enum": ["depends_on", "supersedes", "related_to"] },
+          "order": { "type": "integer", "minimum": 0 }
+        },
+        "additionalProperties": false
+      }
+    },
+    "diagnostics": { "type": "array", "items": { "type": "object" } }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "logicalPath": {
+      "type": "string",
+      "minLength": 1,
+      "pattern": "^[^/\\\\].*$",
+      "description": "Project-relative UTF-8 path using forward slashes. Runtime validation additionally rejects drive prefixes, dot components, controls, and edge whitespace."
+    },
+    "sourceSpan": {
+      "type": "object",
+      "required": ["path", "line", "column"],
+      "properties": {
+        "path": { "$ref": "#/$defs/logicalPath" },
+        "line": { "type": "integer", "minimum": 1 },
+        "column": { "type": "integer", "minimum": 1 }
+      },
+      "additionalProperties": false
+    },
+    "page": {
+      "type": "object",
+      "required": ["type", "id", "order", "source_path"],
+      "properties": {
+        "type": { "const": "page" },
+        "id": { "type": "string", "minLength": 1 },
+        "order": { "type": "integer", "minimum": 0 },
+        "title": { "type": "string" },
+        "source_path": { "$ref": "#/$defs/logicalPath" }
+      },
+      "additionalProperties": false
+    },
+    "proseBlock": {
+      "type": "object",
+      "required": ["type", "id", "page_id", "order", "source_span"],
+      "properties": {
+        "type": { "enum": ["heading", "paragraph", "list", "code_block"] },
+        "id": { "type": "string", "minLength": 1 },
+        "page_id": { "type": "string", "minLength": 1 },
+        "order": { "type": "integer", "minimum": 0 },
+        "level": { "type": "integer", "minimum": 0 },
+        "text": { "type": "string" },
+        "language": { "type": "string" },
+        "code": { "type": "string" },
+        "items": { "type": "array", "items": { "type": "string" } },
+        "source_span": { "$ref": "#/$defs/sourceSpan" }
+      },
+      "additionalProperties": false
+    },
+    "relations": {
+      "type": "object",
+      "required": ["depends_on", "supersedes", "related_to"],
+      "properties": {
+        "depends_on": { "type": "array", "items": { "type": "string" } },
+        "supersedes": { "type": "array", "items": { "type": "string" } },
+        "related_to": { "type": "array", "items": { "type": "string" } }
+      },
+      "additionalProperties": false
+    },
+    "evidence": {
+      "type": "object",
+      "required": ["kind"],
+      "properties": {
+        "kind": { "type": "string", "minLength": 1 },
+        "value": { "type": "string" },
+        "reference": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "knowledgeObject": {
+      "type": "object",
+      "required": ["type", "id", "kind", "content_hash", "body", "page_id", "source_span", "fields", "relations"],
+      "properties": {
+        "type": { "const": "knowledge_object" },
+        "id": { "type": "string", "minLength": 1 },
+        "kind": { "type": "string", "minLength": 1 },
+        "content_hash": { "type": "string", "pattern": "^sha256:[0-9a-f]+$" },
+        "status": { "type": "string" },
+        "severity": { "type": "string" },
+        "trust": { "type": "string" },
+        "body": { "type": "string" },
+        "page_id": { "type": "string", "minLength": 1 },
+        "source_span": { "$ref": "#/$defs/sourceSpan" },
+        "fields": { "type": "object", "additionalProperties": { "type": "string" } },
+        "relations": { "$ref": "#/$defs/relations" },
+        "impacts": { "type": "array", "items": { "type": "string" } },
+        "approved_by": { "type": "array", "items": { "type": "string" } },
+        "allowed_actions": { "type": "array", "items": { "type": "string" } },
+        "forbidden_actions": { "type": "array", "items": { "type": "string" } },
+        "contradiction_claims": { "type": "array", "items": { "type": "string" } },
+        "evidence": { "type": "array", "items": { "$ref": "#/$defs/evidence" } },
+        "effective_status": { "type": "string" },
+        "effective_reason": { "type": "string" },
+        "evidence_quality": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/docs/agent/v0/source-guide.md
+++ b/docs/agent/v0/source-guide.md
@@ -6,7 +6,7 @@
 
 A `source` object (PRD §13.15) is a named, reusable reference to evidence outside the documentation workspace. It can point to a repo-relative file path (e.g. a source code file or test) or an absolute URL (e.g. a pull request, incident report, or external specification). Once authored, a `source` object can be cited anywhere a Knowledge Object ID is accepted.
 
-Source objects appear in `adoc.graph.v4` nodes with `kind: "source"`. Evidence kind and path or URL are projected into the node's `fields` map.
+Source objects appear in `adoc.graph.v5` nodes with `kind: "source"`. Evidence kind and path or URL are projected into the node's `fields` map.
 
 ## Required fields
 
@@ -96,7 +96,7 @@ Stripe Charges API documentation. Referenced by the payment processing claim.
 
 ## Wire surface
 
-`source` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+`source` nodes are emitted into the graph artifact (`adoc.graph.v5`) with:
 
 - `kind: "source"` — the node-level kind discriminant
 - `fields["kind"]` — the evidence kind string (e.g. `"source_code"`)

--- a/docs/agent/v0/task-guide.md
+++ b/docs/agent/v0/task-guide.md
@@ -43,7 +43,7 @@ Update the support runbook to mention refund behavior after persistence failure.
 
 ## Wire surface
 
-`task` nodes are emitted into the graph artifact (`adoc.graph.v4`) with:
+`task` nodes are emitted into the graph artifact (`adoc.graph.v5`) with:
 
 - `kind: "task"` — the node-level kind discriminant
 - `status` — the lifecycle status (`open` / `done`, lifecycle-only per ADR-0039)

--- a/docs/decisions.adoc
+++ b/docs/decisions.adoc
@@ -52,6 +52,14 @@ owner: maintainer
 ADR-0042: pilot readiness evidence definition and Later un-gating thresholds.
 ::
 
+::source docs.adr-0049
+kind: design_doc
+path: docs/adr/0049-canonical-source-identity-and-portable-hashes.md
+owner: maintainer
+--
+ADR-0049: canonical source identity separates physical, page-identity, and portable logical paths and defines adoc.graph.v5 repository identity.
+::
+
 ::decision docs.markdown-prose-only-ingestion
 status: accepted
 decided_by: maintainer
@@ -104,4 +112,13 @@ owner: maintainer
 evidence_ref: docs.adr-0042
 --
 The dogfood pilot's un-gating thresholds for Markdown migration, composition, and governance were fixed in ADR-0042 before any pilot session ran, so gate decisions cite recorded evidence against pre-committed numbers rather than recollection.
+::
+
+::decision docs.canonical-source-identity
+status: accepted
+decided_by: maintainer
+owner: maintainer
+evidence_ref: docs.adr-0049
+--
+Source coordinates have three explicit roles: canonical physical paths read bytes, docs-root-relative identity paths derive page IDs, and validated project-relative logical paths populate diagnostics, graph spans, hashes, diffs, patches, and receipts. Project-bound Graph Artifacts identify agentdoc.config.yaml; standalone artifacts explicitly carry no repository identity.
 ::

--- a/docs/roadmap/ROADMAP-V9.md
+++ b/docs/roadmap/ROADMAP-V9.md
@@ -1,8 +1,8 @@
 # AgentDoc Roadmap — V9 Cycle: Trustworthy PR Knowledge Assessment and Governed Proposals
 
-**Document version:** 0.1
-**Document status:** Draft
-**Last updated:** 2026-07-20
+**Document version:** 0.2
+**Document status:** Active
+**Last updated:** 2026-07-21
 **Product scope:** Free/local single-repository knowledge loop, with gated successor plans for managed and on-prem delivery
 **Repositories:** `agentdoc-dev/adoc` and `agentdoc-dev/action`
 **Planning baseline:** AgentDoc `v0.2.0` and AgentDoc Action `v1.4.0`
@@ -256,7 +256,7 @@ Parallelism describes merge conflicts and dependencies, not required staffing.
 
 | Slice | Status | User outcome | Repositories | Depends on | Completion evidence |
 | --- | --- | --- | --- | --- | --- |
-| V9.1.1 | Planned | Portable source coordinates and hashes | `adoc` | — | — |
+| V9.1.1 | Implemented | Portable source coordinates and hashes | `adoc` | — | ADR-0049; core/local/CLI/MCP contract tests |
 | V9.1.2 | Planned | Code-only PRs report unchanged affected knowledge | `adoc` | V9.1.1 | — |
 | V9.1.3 | Planned | Failed analysis cannot appear covered | `action` | — | — |
 | V9.1.4 | Planned | Proposal execution has a defensible trust boundary | `action` | — | — |
@@ -296,13 +296,13 @@ V9.1 removes correctness and trust-boundary failures that would otherwise contam
 
 ### V9.1.1: Canonical Source Identity and Portable Hash Slice
 
-**Status:** Planned
+**Status:** Implemented
 **Repositories:** `adoc`
 **Depends on:** —
 **User touchpoint:** `adoc build`, `adoc diff`, `adoc review`, `adoc patch --check`
 **Contract impact:** Breaking `adoc.graph.v5` artifact-semantic correction
 **Gate posture:** Not applicable
-**Completion evidence:** —
+**Completion evidence:** ADR-0049; clone-portability, review-parity, standalone/project identity, path-containment, CLI, patch, and published-schema contract tests; workspace quality gates
 
 #### Goal
 

--- a/docs/roadmap/ROADMAP.md
+++ b/docs/roadmap/ROADMAP.md
@@ -298,7 +298,7 @@ Implemented product surface:
 Implemented build and retrieval rules:
 
 - Retrieval is read-only over compiled artifacts. `adoc why`, `adoc graph`, and `adoc search` do not compile source.
-- The graph artifact uses current schema version `adoc.graph.v3` and carries page, prose block, and Knowledge Object nodes plus directed `contains`, `reference`, and relation edges.
+- The graph artifact uses current schema version `adoc.graph.v5`, carries explicit repository identity and portable source coordinates, and includes page, prose block, and Knowledge Object nodes plus directed `contains`, `reference`, and relation edges.
 - The search artifact uses schema version `adoc.search.v0`, carries a model header, stores `graph_artifact_hash`, and contains one `{ id, content_hash, vector }` entry per Knowledge Object.
 - The default embedding provider is local FastEmbed with `bge-small-en-v1.5`; `embeddings.provider: deterministic` supports repeatable offline vectors, while `--no-embeddings` and config `embeddings.provider: none` keep graph-only builds cheap.
 - Graph retrieval remains an explicit candidate filter. There is no default graph proximity boost.

--- a/examples/expanded-pilot/meta/REVIEW-CHECKLIST.md
+++ b/examples/expanded-pilot/meta/REVIEW-CHECKLIST.md
@@ -21,7 +21,7 @@ vocabulary by V6.5.5).
 
 ## Graph JSON
 
-- `schema_version` is `adoc.graph.v4`.
+- `schema_version` is `adoc.graph.v5`.
 - 27 Knowledge Object nodes: 8 claim, 1 decision, 2 glossary, 1 constraint, 1 procedure, 2 example, 1 policy, 1 agent_instruction, 1 contradiction, 3 source, 1 api, 1 observation, 2 question, 2 task.
 - Three `evidence` edges: `billing.credits.consume` and `billing.credits.use-ledger` → `billing.consume-use-case`; `billing.consume-credit` → `billing.openapi-schema`.
 - The answered question emits a `resolved_by` edge to `billing.credits.use-ledger`; the open task a `depends_on` relation edge to `billing.credits.consume`.

--- a/tests/fixtures/v1_2_search/empty.graph.json
+++ b/tests/fixtures/v1_2_search/empty.graph.json
@@ -1,5 +1,6 @@
 {
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [],
   "edges": [],
   "diagnostics": []

--- a/tests/fixtures/v1_2_search/pilot_subset.graph.json
+++ b/tests/fixtures/v1_2_search/pilot_subset.graph.json
@@ -1,5 +1,6 @@
 {
-  "schema_version": "adoc.graph.v4",
+  "schema_version": "adoc.graph.v5",
+  "repository_identity": null,
   "nodes": [
     {
       "type": "page",

--- a/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
+++ b/tests/fixtures/v1_3_embed/in_memory_baseline.search.json
@@ -5,7 +5,7 @@
     "provider": "deterministic",
     "dim": 4
   },
-  "graph_artifact_hash": "sha256:55e05141fdffc8a33506635849f773d7778cab5869cc8122299c4247885da943",
+  "graph_artifact_hash": "sha256:73d2b69febb043b447ca58d3447039198606127152dccb1120e4edb0aef149a3",
   "embeddings": [
     {
       "id": "billing.credits",


### PR DESCRIPTION
## What changed

- separates physical filesystem paths, docs-relative identity paths, and project-relative logical source paths
- emits portable source coordinates and stable Knowledge Object hashes across clones and review worktrees
- bumps the graph contract to `adoc.graph.v5` with required `repository_identity`
- makes config-backed check/build and Git review compile the configured docs tree with the same coordinate model
- keeps explicit paths outside the configured docs tree standalone
- hardens config, source loading, artifact reads, and patch flows against unsafe paths and symlink escapes
- publishes and serves the graph-v5 JSON Schema
- updates fixtures, agent documentation, migration guidance, CONTEXT.md, and the V9 roadmap completion evidence

## Why

Graph hashes previously included checkout-specific or synthetic `<review>` paths. Identical source could therefore hash differently in a normal checkout, another clone, or a review worktree, making patch preconditions and future provenance receipts unreliable.

## User and developer impact

- Existing graph artifacts must be rebuilt.
- Search artifacts must be regenerated/re-embedded because their graph artifact hash changes.
- In-flight patches based on graph-v4 hashes must be regenerated.
- `adoc diff` and `adoc review` now require a discovered `agentdoc.config.yaml`.
- Fully explicit build invocations still discover config; malformed config fails loudly.
- No AgentDoc Action repository change is included in V9.1.1.

## Validation

- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo doc --workspace --no-deps --locked`
- `prek run`
- `git diff --check`

All passed.