### PR TITLE
chore: prepare exact-SHA assessment receipt release (V9.2.2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,6 +49,9 @@ jobs:
       - name: Build release binary
         run: cargo build --release --locked -p adoc-cli
 
+      - name: Verify release tag matches the binary
+        run: test "$GITHUB_REF_NAME" = "v$(./target/release/adoc --version | awk '{print $2}')"
+
       - name: Smoke-check binary against example project
         run: ./target/release/adoc check examples/expanded-pilot
 

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -24,6 +24,20 @@ _Avoid_: RAG dump, text chunks
 The initial `adoc` command-line product surface for checking, compiling, and querying AgentDoc inside a Git repository.
 _Avoid_: initial web app, SaaS-first product
 
+**Change Assessment**:
+The deterministic `adoc.change_assessment.v0` result for one requested base,
+unique comparison base, head snapshot, and evaluation date. It reports
+structural validity, changed-path classification, implicated knowledge, and
+review obligations without claiming semantic consistency.
+_Avoid_: compliance verdict, semantic review, GitHub receipt
+
+**PR Assessment Receipt**:
+The Action-owned `adoc.pr_assessment_receipt.v0` artifact that binds one
+validated Change Assessment to exact GitHub revisions, CI identity, verified
+toolchain, Action policy, final conclusion, and optional-stage status. It
+proves what CI assessed, not what a runtime agent used or acted upon.
+_Avoid_: Agent Use Receipt, immutable audit ledger, proof of agent reliance
+
 **Native Authoring**:
 The initial workflow where users write AgentDoc Source directly instead of importing existing Markdown.
 _Avoid_: Markdown migration, compatibility-first workflow

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adoc-cli"
-version = "0.1.0"
+version = "0.3.0"
 dependencies = [
  "adoc-core",
  "adoc-local",

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adoc-cli"
-version = "0.1.0"
+version = "0.3.0"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/adoc-cli/tests/help_cli.rs
+++ b/crates/adoc-cli/tests/help_cli.rs
@@ -3,6 +3,18 @@ mod support;
 use support::{adoc_command, fixture_path, stderr, stdout, workspace_fixture_path};
 
 #[test]
+fn version_matches_the_v0_3_release() {
+    let output = adoc_command()
+        .arg("--version")
+        .output()
+        .expect("adoc --version runs");
+
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(stdout(&output), "adoc 0.3.0\n");
+    assert!(output.stderr.is_empty());
+}
+
+#[test]
 fn long_top_level_help_lists_command_descriptions_and_examples() {
     let output = adoc_command()
         .arg("--help")

--- a/docs/adr/0051-exact-sha-pr-assessment-receipt.md
+++ b/docs/adr/0051-exact-sha-pr-assessment-receipt.md
@@ -1,0 +1,116 @@
+# ADR-0051: Exact-SHA PR Assessment Receipt
+
+- Status: Accepted
+- Date: 2026-07-22
+- Roadmap: V9.2.2
+
+## Context
+
+ADR-0050 made `adoc.change_assessment.v0` the deterministic local fact
+boundary. A GitHub run still needs to bind that artifact to the pull request,
+toolchain, Action policy, final conclusion, and retained evidence without
+putting GitHub concerns into `adoc-core` or reconstructing coverage in shell.
+
+The Action already has proposal and delivery behavior which predates the V9.3
+canonical patch contract. A V9.2 receipt must describe that state honestly
+without assigning a future canonical patch-set digest to legacy drafts.
+
+## Decision
+
+### Ownership and artifacts
+
+AgentDoc continues to own `adoc.change_assessment.v0`. The Action invokes it
+once with the exact pull-request base and head commit SHAs and one UTC
+evaluation date captured during preflight. It validates that the envelope
+echoes those revisions and the unique merge base before rendering or gating.
+
+The Action owns the experimental `adoc.pr_assessment_receipt.v0` schema. It
+writes two adjacent retained files:
+
+- `assessment-<invocation-id>.json`, containing the exact validated CLI bytes;
+- `receipt-<invocation-id>.json`, referencing the assessment by SHA-256.
+
+The composite Action exposes both paths and digests. Retention is caller-owned
+through a separately pinned `actions/upload-artifact` step with `if: always()`.
+The Action never uploads its whole run directory and contains no artifact
+client.
+
+### Invocation identity and limits
+
+An invocation ID contains the GitHub run ID, attempt, sanitized job ID, and
+128 random bits. Private and retained directories both use that ID, so two
+Action invocations in one job cannot alias.
+
+V9 fixes these Action limits:
+
+- at most 5,000 deterministic changed paths; larger assessments are retained
+  but conclude non-green and are never truncated-complete;
+- at most 60,000 characters in the final rendered report, with identity,
+  outcome, remediation, revisions, receipt digest, and run link preserved.
+
+Changing either value requires a reviewed contract revision.
+
+### Receipt variants
+
+The receipt schema is a closed Draft 2020-12 schema using `oneOf` on
+`run_status`.
+
+`completed` means a valid assessment was established and receipt finalization
+succeeded. It does not mean the job is green or the assessment is complete.
+Schema-valid nonzero `partial/not_evaluated`, `error/invalid`, and
+`error/not_evaluated` assessments therefore receive completed receipts.
+A complete assessment requires an available knowledge snapshot; an invalid
+assessment may record it as unavailable.
+
+`failed` means no valid assessment envelope was established. It carries a
+bounded Action diagnostic and never fabricates an assessment or snapshot
+digest. If receipt finalization itself fails, receipt outputs remain empty and
+the job concludes non-green with `action.receipt_failed`.
+
+The final receipt records exact GitHub revisions, evaluation date, CI identity,
+Action and AgentDoc provenance, normalized inputs, assessment and knowledge
+digests, final conclusion, and status-bearing knowledge-gate, semantic-review,
+proposal, and delivery sections. It does not embed raw diffs, Knowledge Object
+bodies, prompts, provider output, credentials, or proposal bodies.
+
+Before V9.3, semantic review is `disabled`. Existing legacy proposal output is
+`partial` with an exact count, no digest, and
+`legacy_proposal_not_canonical`; disabled, skipped, and error states remain
+explicit. Delivery records its actual mode and result. The knowledge gate is
+`not_applicable` until V9.4.4.
+
+### Provenance
+
+The Action records its requested ref. A full 40-hex ref is `full_sha` and may
+be recorded as the resolved commit. Tags and branches are `mutable_ref` with a
+null resolved commit; local `uses: ./` execution is `local`.
+
+AgentDoc provenance records the requested release identifier, the version
+reported by the verified binary, and the binary SHA-256. The release workflow
+requires the immutable Git tag to equal that binary version. V9.2.2 requires
+AgentDoc `v0.3.0`; older binaries and unknown future assessment schemas fail
+honestly.
+
+### Gate semantics
+
+Infrastructure, input, event, install, ref, path-set, version, contract, and
+internal failures are non-green in every mode. `partial/not_evaluated` and
+`error/not_evaluated` are also always non-green.
+
+`error/invalid` follows existing structural policy: `advisory` remains green;
+`strict/full` gates on `errors_full`; and `strict/diff` gates on
+`errors_changed + errors_unattributed`. Coverage, impact, lifecycle,
+contradiction, and knowledge-change findings remain advisory. Proposal and
+delivery state never changes deterministic assessment bytes.
+
+Only the final enforcement step exits nonzero. Earlier expected failures are
+recorded so a safe report, outputs, and receipt can still be finalized.
+
+## Consequences
+
+The Action becomes a delivery adapter over one AgentDoc assessment instead of
+a second knowledge-policy implementation. GitHub artifacts provide bounded
+free/local retention, but they are policy-bound and deletable rather than an
+organization-wide audit store. Receipt signing, central retention, semantic
+classification, and canonical proposal digests remain in their named later
+slices.

--- a/docs/agent/v0/change-assessment-workflow.md
+++ b/docs/agent/v0/change-assessment-workflow.md
@@ -8,6 +8,25 @@ adoc assess-changes --base main --as-of 2026-07-22 --format json
 
 Use `--head <commit>` for an immutable comparison, as a CI adapter will. Omit it for local worktree assessment; the envelope records the current HEAD and `worktree_state: clean|dirty`.
 
+A pull-request adapter must use the event's exact base and head commit SHAs,
+not branch names or GitHub's synthetic merge checkout, and must capture one UTC
+date for the whole run:
+
+```text
+adoc assess-changes \
+  --base 0123456789abcdef0123456789abcdef01234567 \
+  --head 89abcdef0123456789abcdef0123456789abcdef \
+  --as-of 2026-07-22 \
+  --format json
+```
+
+Hash the exact JSON bytes only after validating the schema, legal
+completeness/outcome tuple, evaluation date, and requested/comparison/head
+commits. Keep GitHub metadata outside this envelope. The AgentDoc GitHub Action
+places the validated assessment beside an `adoc.pr_assessment_receipt.v0`
+wrapper and exposes both paths and SHA-256 digests; the consuming workflow
+chooses whether and how long to retain them.
+
 The command resolves the requested refs, requires one merge base, materializes immutable snapshots, loads each snapshot's own `agentdoc.config.yaml`, and compiles with the same explicit evaluation date. The comparison-base configuration is effective for the current change. Head exclusions and output changes are prospective, reported in `policy_changes`, and cannot hide code introduced by the same pull request.
 
 Missing Git repository context or an unavailable mutable-worktree status emits a structured `error/not_evaluated` envelope with `assessment.snapshot_failed` and exits 2.

--- a/docs/roadmap/ROADMAP-V9.md
+++ b/docs/roadmap/ROADMAP-V9.md
@@ -261,7 +261,7 @@ Parallelism describes merge conflicts and dependencies, not required staffing.
 | V9.1.3 | Planned | Failed analysis cannot appear covered | `action` | — | — |
 | V9.1.4 | Planned | Proposal execution has a defensible trust boundary | `action` | — | — |
 | V9.2.1 | Implemented | One deterministic local change-assessment command | `adoc` | V9.1.1–V9.1.2 | ADR-0050; core/local/CLI/MCP schema and failure-envelope tests |
-| V9.2.2 | Planned | Exact-SHA GitHub assessment and retained receipt | `adoc`, `action` | V9.2.1 | — |
+| V9.2.2 | In progress | Exact-SHA GitHub assessment and retained receipt | `adoc`, `action` | V9.2.1 | ADR-0051; implementation/release evidence pending |
 | V9.2.3 | Planned | Clear advisory PR disposition without false review claims | `action` | V9.2.2 | — |
 | V9.3.1 | Planned | Optional cited semantic classification | `action` | V9.2.3 | — |
 | V9.3.2 | Planned | Canonical AgentDoc patch proposals | `adoc`, `action` | V9.3.1 | — |
@@ -642,7 +642,7 @@ Tests live in the existing Action CI workflow and use fixture repositories/mocke
 
 ### V9.1.4: Proposal Trust-Boundary Hardening Slice
 
-**Status:** Planned
+**Status:** In progress
 **Repositories:** `action`
 **Depends on:** —
 **User touchpoint:** Proposed Knowledge section and proposal delivery

--- a/docs/roadmap/ROADMAP-V9.md
+++ b/docs/roadmap/ROADMAP-V9.md
@@ -642,7 +642,7 @@ Tests live in the existing Action CI workflow and use fixture repositories/mocke
 
 ### V9.1.4: Proposal Trust-Boundary Hardening Slice
 
-**Status:** In progress
+**Status:** Planned
 **Repositories:** `action`
 **Depends on:** —
 **User touchpoint:** Proposed Knowledge section and proposal delivery
@@ -1089,7 +1089,7 @@ Exact fields are fixed in the slice-start decision record before implementation.
 
 ### V9.2.2: Exact-SHA GitHub Assessment and Receipt Slice
 
-**Status:** Planned
+**Status:** In progress
 **Repositories:** `adoc`, `action`
 **Depends on:** V9.2.1 release
 **User touchpoint:** PR report, job summary, Action outputs, workflow artifact


### PR DESCRIPTION
## What changed

- aligns `adoc --version` with the planned immutable `v0.3.0` release and blocks mismatched release tags
- freezes the exact-SHA Action receipt boundary in ADR-0051
- adds Change Assessment and PR Assessment Receipt vocabulary plus exact-ref adapter guidance
- marks V9.2.2 in progress while implementation and release evidence are pending

## Why

The Action cannot consume V9.2.1 truthfully until an immutable AgentDoc release exists with matching binary provenance. This is the prerequisite release unit; GitHub-specific receipt construction remains in the Action repository.

## Validation

- `cargo build --workspace --locked`
- `cargo test --workspace --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo fmt --all -- --check`
- `prek run --all-files`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`