### PR TITLE
fix(core): support nested exact-SHA assessments (V9.2.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adoc-cli"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "adoc-core",
  "adoc-local",

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adoc-cli"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/adoc-cli/tests/assess_changes_cli.rs
+++ b/crates/adoc-cli/tests/assess_changes_cli.rs
@@ -51,7 +51,7 @@ fn repo() -> TestWorkspace {
 }
 
 #[test]
-fn exact_ref_assessment_supports_a_project_below_the_repository_root() {
+fn assessment_supports_a_project_below_the_repository_root() {
     let workspace = TestWorkspace::new("assess-changes-nested-project");
     git(&workspace, &["init", "--initial-branch=main"]);
     git(&workspace, &["config", "user.email", "test@agentdoc.dev"]);
@@ -87,7 +87,7 @@ fn exact_ref_assessment_supports_a_project_below_the_repository_root() {
     let head = git(&workspace, &["rev-parse", "HEAD"]);
 
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
-        .current_dir(workspace.root.join("service"))
+        .current_dir(workspace.root.join("service/src"))
         .args([
             "assess-changes",
             "--base",
@@ -115,6 +115,50 @@ fn exact_ref_assessment_supports_a_project_below_the_repository_root() {
     assert_eq!(paths.len(), 1);
     assert_eq!(paths[0]["path"], "src/billing.rs");
     assert_eq!(paths[0]["classification"], "covered");
+
+    workspace.write("outside.txt", "uncommitted outside project\n");
+    let assess_workdir = || {
+        Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .current_dir(workspace.root.join("service/src"))
+            .args([
+                "assess-changes",
+                "--base",
+                &head,
+                "--as-of",
+                "2026-07-22",
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("adoc assess-changes runs")
+    };
+
+    let output = assess_workdir();
+    assert!(
+        output.status.success(),
+        "assessment failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("assessment JSON");
+    assert_eq!(value["completeness"], "complete");
+    assert_eq!(value["outcome"], "pass");
+    assert_eq!(value["snapshots"]["head"]["worktree_state"], "clean");
+    assert_eq!(value["paths"]["value"], serde_json::json!([]));
+
+    workspace.write("service/src/new.rs", "pub fn new_behavior() {}\n");
+    let output = assess_workdir();
+    assert!(
+        output.status.success(),
+        "assessment failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("assessment JSON");
+    assert_eq!(value["completeness"], "complete");
+    assert_eq!(value["outcome"], "uncovered");
+    assert_eq!(value["snapshots"]["head"]["worktree_state"], "dirty");
+    assert_eq!(value["paths"]["value"][0]["path"], "src/new.rs");
 }
 
 #[test]

--- a/crates/adoc-cli/tests/assess_changes_cli.rs
+++ b/crates/adoc-cli/tests/assess_changes_cli.rs
@@ -51,6 +51,73 @@ fn repo() -> TestWorkspace {
 }
 
 #[test]
+fn exact_ref_assessment_supports_a_project_below_the_repository_root() {
+    let workspace = TestWorkspace::new("assess-changes-nested-project");
+    git(&workspace, &["init", "--initial-branch=main"]);
+    git(&workspace, &["config", "user.email", "test@agentdoc.dev"]);
+    git(&workspace, &["config", "user.name", "AgentDoc Test"]);
+    git(&workspace, &["config", "commit.gpgsign", "false"]);
+    workspace.write(
+        "service/agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nembeddings:\n  provider: none\n",
+    );
+    workspace.write(
+        "service/docs/billing.adoc",
+        concat!(
+            "# Billing @doc(team.billing)\n\n",
+            "::claim billing.credits\n",
+            "status: verified\n",
+            "owner: billing-platform\n",
+            "verified_at: 2026-07-01\n",
+            "source: src/billing.rs\n",
+            "impacts: [src/billing.rs]\n",
+            "--\nCredits settle after payment.\n::\n",
+        ),
+    );
+    workspace.write("service/src/billing.rs", "pub fn settle() {}\n");
+    workspace.write("outside.txt", "base\n");
+    git(&workspace, &["add", "-A"]);
+    git(&workspace, &["commit", "-m", "initial"]);
+    let base = git(&workspace, &["rev-parse", "HEAD"]);
+
+    workspace.write("service/src/billing.rs", "pub fn settle() { charge(); }\n");
+    workspace.write("outside.txt", "changed outside project\n");
+    git(&workspace, &["add", "-A"]);
+    git(&workspace, &["commit", "-m", "change service"]);
+    let head = git(&workspace, &["rev-parse", "HEAD"]);
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(workspace.root.join("service"))
+        .args([
+            "assess-changes",
+            "--base",
+            &base,
+            "--head",
+            &head,
+            "--as-of",
+            "2026-07-22",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("adoc assess-changes runs");
+
+    assert!(
+        output.status.success(),
+        "assessment failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("assessment JSON");
+    assert_eq!(value["completeness"], "complete");
+    assert_eq!(value["outcome"], "review_required");
+    let paths = value["paths"]["value"].as_array().expect("paths");
+    assert_eq!(paths.len(), 1);
+    assert_eq!(paths[0]["path"], "src/billing.rs");
+    assert_eq!(paths[0]["classification"], "covered");
+}
+
+#[test]
 fn assess_changes_emits_one_complete_body_free_record_per_changed_path() {
     let workspace = repo();
     workspace.write("src/billing.rs", "pub fn settle() { charge(); }\n");

--- a/crates/adoc-cli/tests/help_cli.rs
+++ b/crates/adoc-cli/tests/help_cli.rs
@@ -3,14 +3,14 @@ mod support;
 use support::{adoc_command, fixture_path, stderr, stdout, workspace_fixture_path};
 
 #[test]
-fn version_matches_the_v0_3_release() {
+fn version_matches_the_v0_3_1_release() {
     let output = adoc_command()
         .arg("--version")
         .output()
         .expect("adoc --version runs");
 
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(stdout(&output), "adoc 0.3.0\n");
+    assert_eq!(stdout(&output), "adoc 0.3.1\n");
     assert!(output.stderr.is_empty());
 }
 

--- a/crates/adoc-core/src/infrastructure/git/changed_files.rs
+++ b/crates/adoc-core/src/infrastructure/git/changed_files.rs
@@ -93,6 +93,7 @@ impl GitChangedFilesProvider {
                 "HEAD",
             ],
             vec!["diff", "--relative", "--name-only", "-z", "--no-renames"],
+            // `ls-files` already scopes and renders paths relative to its `-C` directory.
             vec!["ls-files", "-z", "--others", "--exclude-standard"],
         ] {
             paths.extend(self.paths_from(&args)?);

--- a/crates/adoc-core/src/infrastructure/git/changed_files.rs
+++ b/crates/adoc-core/src/infrastructure/git/changed_files.rs
@@ -60,7 +60,14 @@ impl ChangedFilesProvider for GitChangedFilesProvider {
 impl GitChangedFilesProvider {
     fn committed_changes(&self, base: &str, head: &str) -> Result<Vec<RelPath>, ChangedFilesError> {
         let range = format!("{base}..{head}");
-        self.paths_from(&["diff", "--name-only", "-z", "--no-renames", &range])
+        self.paths_from(&[
+            "diff",
+            "--relative",
+            "--name-only",
+            "-z",
+            "--no-renames",
+            &range,
+        ])
     }
 
     fn workdir_changes(&self, base: &str) -> Result<Vec<RelPath>, ChangedFilesError> {
@@ -68,16 +75,24 @@ impl GitChangedFilesProvider {
         let range = format!("{base}..{head}");
         let mut paths = BTreeSet::new();
         for args in [
-            vec!["diff", "--name-only", "-z", "--no-renames", &range],
             vec![
                 "diff",
+                "--relative",
+                "--name-only",
+                "-z",
+                "--no-renames",
+                &range,
+            ],
+            vec![
+                "diff",
+                "--relative",
                 "--cached",
                 "--name-only",
                 "-z",
                 "--no-renames",
                 "HEAD",
             ],
-            vec!["diff", "--name-only", "-z", "--no-renames"],
+            vec!["diff", "--relative", "--name-only", "-z", "--no-renames"],
             vec!["ls-files", "-z", "--others", "--exclude-standard"],
         ] {
             paths.extend(self.paths_from(&args)?);

--- a/crates/adoc-core/src/infrastructure/git/revision.rs
+++ b/crates/adoc-core/src/infrastructure/git/revision.rs
@@ -52,12 +52,12 @@ pub(crate) fn resolve_review(
     })
 }
 
-pub(crate) fn worktree_is_dirty(repo_root: &Path) -> Result<bool, SnapshotError> {
+pub(crate) fn worktree_is_dirty(project_root: &Path) -> Result<bool, SnapshotError> {
     let mut command = Command::new("git");
     command
         .arg("-C")
-        .arg(repo_root)
-        .args(["status", "--porcelain=v1", "-z"]);
+        .arg(project_root)
+        .args(["status", "--porcelain=v1", "-z", "--", "."]);
     clear_git_env(&mut command);
     let output = command.output().map_err(SnapshotError::Io)?;
     if !output.status.success() {

--- a/crates/adoc-core/src/infrastructure/git/worktree.rs
+++ b/crates/adoc-core/src/infrastructure/git/worktree.rs
@@ -55,6 +55,7 @@ impl SnapshotWorkspaceProvider for GitWorktreeProvider {
 impl GitWorktreeProvider {
     fn checkout_ref(&self, spec: &str) -> Result<SnapshotWorkspace, SnapshotError> {
         let sha = resolve_ref(&self.repo_root, spec)?;
+        let project_prefix = project_prefix(&self.repo_root)?;
 
         let tmp = generate_worktree_path();
         add_worktree(&self.repo_root, &tmp, &sha)?;
@@ -69,8 +70,25 @@ impl GitWorktreeProvider {
             let _ = fs::remove_dir_all(&tmp_for_cleanup);
         });
 
-        Ok(SnapshotWorkspace::with_cleanup(tmp, cleanup))
+        Ok(SnapshotWorkspace::with_cleanup(
+            tmp.join(project_prefix),
+            cleanup,
+        ))
     }
+}
+
+fn project_prefix(project_root: &Path) -> Result<PathBuf, SnapshotError> {
+    let output = run_git(project_root, &["rev-parse", "--show-prefix"])?;
+    if !output.status.success() {
+        return Err(SnapshotError::ProviderUnavailable {
+            reason: String::from_utf8_lossy(&output.stderr).into_owned(),
+        });
+    }
+    let value =
+        std::str::from_utf8(&output.stdout).map_err(|_| SnapshotError::ProviderUnavailable {
+            reason: "git returned a non-UTF-8 project prefix".to_string(),
+        })?;
+    Ok(PathBuf::from(value.trim_end_matches(['\r', '\n'])))
 }
 
 fn verify_head(repo_root: &Path, expected: &str) -> Result<(), SnapshotError> {

--- a/crates/adoc-core/src/infrastructure/git/worktree.rs
+++ b/crates/adoc-core/src/infrastructure/git/worktree.rs
@@ -88,6 +88,7 @@ fn project_prefix(project_root: &Path) -> Result<PathBuf, SnapshotError> {
         std::str::from_utf8(&output.stdout).map_err(|_| SnapshotError::ProviderUnavailable {
             reason: "git returned a non-UTF-8 project prefix".to_string(),
         })?;
+    // Git's empty prefix is the repository-root project; joining it preserves `tmp`.
     Ok(PathBuf::from(value.trim_end_matches(['\r', '\n'])))
 }
 

--- a/crates/adoc-local/src/config.rs
+++ b/crates/adoc-local/src/config.rs
@@ -6,7 +6,7 @@ use adoc_core::{ParsedConfigOutputs, ProjectConfigDocumentError, parse_project_c
 
 use crate::LocalError;
 
-const CONFIG_FILE_NAME: &str = "agentdoc.config.yaml";
+pub(crate) const CONFIG_FILE_NAME: &str = "agentdoc.config.yaml";
 
 #[derive(Debug, Clone)]
 pub struct ProjectConfig {

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -34,13 +34,13 @@ use adoc_core::{
 use adoc_core::{MigrateMode, MigrateReportEnvelope};
 use serde::Serialize;
 
+use crate::config::CONFIG_FILE_NAME;
 use crate::{EmbeddingsProvider, LocalContext, LocalError, PathPolicy, ProjectConfig};
 
 const DEFAULT_GRAPH_ARTIFACT_PATH: &str = "dist/docs.graph.json";
 const DEFAULT_SEARCH_ARTIFACT_PATH: &str = "dist/docs.search.json";
 const DEFAULT_HTML_ARTIFACT_PATH: &str = "dist/docs.html";
 const PROJECT_STATUS_SCHEMA_VERSION: &str = "adoc.project.status.v0";
-const INIT_CONFIG_PATH: &str = "agentdoc.config.yaml";
 const INIT_INDEX_PATH: &str = "docs/index.adoc";
 const INIT_CONFIG_TEMPLATE: &str = "\
 version: 1
@@ -509,7 +509,7 @@ where
     write_init_files(&project_root)?;
     Ok(InitOutcome {
         created: vec![
-            project_root.join(INIT_CONFIG_PATH),
+            project_root.join(CONFIG_FILE_NAME),
             project_root.join(INIT_INDEX_PATH),
         ],
         exit_code: 0,
@@ -1425,7 +1425,7 @@ fn project_status_embedding_provider(
 }
 
 fn write_init_files(project_root: &Path) -> Result<(), LocalError> {
-    let config_path = project_root.join(INIT_CONFIG_PATH);
+    let config_path = project_root.join(CONFIG_FILE_NAME);
     let index_path = project_root.join(INIT_INDEX_PATH);
 
     for target in [&config_path, &index_path] {
@@ -1818,7 +1818,7 @@ fn assessment_project_root(start: &Path) -> Option<PathBuf> {
     let repository_root = git_project_root(start)?;
     let mut current = start.canonicalize().ok()?;
     loop {
-        if current.join("agentdoc.config.yaml").is_file() {
+        if current.join(CONFIG_FILE_NAME).is_file() {
             return Some(current);
         }
         if current == repository_root || !current.pop() {

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -1151,7 +1151,7 @@ where
     P: PathPolicy,
 {
     let envelope = assess_changes_from_git(CoreChangeAssessmentInput {
-        project_root: git_project_root(context.config_start()),
+        project_root: assessment_project_root(context.config_start()),
         base_ref: input.base_ref,
         head_ref: input.head_ref,
         evaluation_date: input
@@ -1810,6 +1810,19 @@ fn git_project_root(start: &Path) -> Option<PathBuf> {
         }
         if !current.pop() {
             return None;
+        }
+    }
+}
+
+fn assessment_project_root(start: &Path) -> Option<PathBuf> {
+    let repository_root = git_project_root(start)?;
+    let mut current = start.canonicalize().ok()?;
+    loop {
+        if current.join("agentdoc.config.yaml").is_file() {
+            return Some(current);
+        }
+        if current == repository_root || !current.pop() {
+            return Some(repository_root);
         }
     }
 }

--- a/docs/adr/0051-exact-sha-pr-assessment-receipt.md
+++ b/docs/adr/0051-exact-sha-pr-assessment-receipt.md
@@ -88,7 +88,7 @@ null resolved commit; local `uses: ./` execution is `local`.
 AgentDoc provenance records the requested release identifier, the version
 reported by the verified binary, and the binary SHA-256. The release workflow
 requires the immutable Git tag to equal that binary version. V9.2.2 requires
-AgentDoc `v0.3.0`; older binaries and unknown future assessment schemas fail
+AgentDoc `v0.3.1`; older binaries and unknown future assessment schemas fail
 honestly.
 
 ### Gate semantics


### PR DESCRIPTION
## What changed

- preserve the discovered AgentDoc project subdirectory in immutable Git worktree snapshots
- make changed-file discovery project-relative with Git's native `--relative` projection
- add an exact-base/head CLI regression covering a nested AgentDoc project and an out-of-project change
- prepare the v0.3.1 CLI patch release and align the frozen V9.2.2 minimum-version contract

## Why

The V9.2.2 Action invokes `adoc assess-changes` from its configured `working-directory`. AgentDoc v0.3.0 resolved refs from that directory but materialized snapshots at the repository root, so a project below the root could not find its `agentdoc.config.yaml`. The resulting `error/invalid` envelope had no structural counters and could incorrectly leave strict enforcement green.

## Impact

Exact-SHA assessment now supports monorepo-style AgentDoc projects below the Git repository root. Paths in the assessment remain relative to that AgentDoc project, and changes outside it are excluded.

## Validation

- red/green exact-ref nested-project CLI regression
- `prek run` (format, clippy, full workspace tests, hygiene)
- reproduced the Action fixtures locally: clean is `complete/pass`; broken is `error/invalid` with structural errors

## Follow-up

After merge, publish v0.3.1 so `agentdoc-dev/action` PR #9 can pin the corrected binary and complete its live CI matrix.
