### PR TITLE
chore(cli): publish AgentDoc v0.3.2 (V9.2.3)

### DIFF
--- a/.github/workflows/adoc-pr.yml
+++ b/.github/workflows/adoc-pr.yml
@@ -28,7 +28,7 @@ jobs:
       # Flip enforcement to strict after one clean week (§24.3); record the
       # flip in this file's history.
       - id: agentdoc
-        uses: agentdoc-dev/action@9aed946ec7c6c29edb1fbd784d04833d7383c2e1 # v1.5.1
+        uses: agentdoc-dev/action@6c48dbef32d93d7e285b0e3c1919a3b562f49b1d # v1.6.1
         with:
           adoc-version: v0.3.1
           enforcement: advisory

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adoc-cli"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "adoc-core",
  "adoc-local",

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adoc-cli"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/adoc-cli/tests/help_cli.rs
+++ b/crates/adoc-cli/tests/help_cli.rs
@@ -3,14 +3,14 @@ mod support;
 use support::{adoc_command, fixture_path, stderr, stdout, workspace_fixture_path};
 
 #[test]
-fn version_matches_the_v0_3_1_release() {
+fn version_matches_the_v0_3_2_release() {
     let output = adoc_command()
         .arg("--version")
         .output()
         .expect("adoc --version runs");
 
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(stdout(&output), "adoc 0.3.1\n");
+    assert_eq!(stdout(&output), "adoc 0.3.2\n");
     assert!(output.stderr.is_empty());
 }
 


### PR DESCRIPTION
## What changed

- Pin the AgentDoc PR workflow to the exact Action v1.6.1 merge commit.
- Bump the `adoc` CLI and lockfile version to 0.3.2.
- Update the public `--version` contract test.

## Why

V9.2.3 needs a live exact-SHA consumer smoke for the corrected Marketplace Action release. The AgentDoc release workflow also requires the tag to match the binary version before it will publish x86_64 and arm64 executables.

## Impact

No AgentDoc runtime behavior or wire contract changes. Merging enables the `v0.3.2` binary release.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo run --quiet --locked -p adoc-cli -- --version` returns `adoc 0.3.2`
- `git diff --check`