### PR TITLE
chore(ci): consume AgentDoc v0.3.2 (V9.2.3)

### DIFF
--- a/.github/workflows/adoc-pr.yml
+++ b/.github/workflows/adoc-pr.yml
@@ -30,7 +30,7 @@ jobs:
       - id: agentdoc
         uses: agentdoc-dev/action@6c48dbef32d93d7e285b0e3c1919a3b562f49b1d # v1.6.1
         with:
-          adoc-version: v0.3.1
+          adoc-version: v0.3.2
           enforcement: advisory
           propose: false
 


### PR DESCRIPTION
## What changed

- Pin the AgentDoc PR workflow to the newly published `adoc v0.3.2` binaries.

## Why

This completes the release train with a live consumer smoke using Action v1.6.1 by exact commit and AgentDoc v0.3.2 by immutable release tag.

## Impact

No product behavior changes. CI downloads and verifies the latest AgentDoc executables.

## Validation

- Both v0.3.2 release jobs passed for x86_64 and arm64.
- Both published archive checksums verified locally.
- `git diff --check`