### PR TITLE
fix(mcp): align patch schema with parser contract (V9.3.2)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
 name = "adoc-cli"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "adoc-core",
  "adoc-local",

--- a/crates/adoc-cli/Cargo.toml
+++ b/crates/adoc-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "adoc-cli"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 license.workspace = true
 rust-version.workspace = true

--- a/crates/adoc-cli/tests/help_cli.rs
+++ b/crates/adoc-cli/tests/help_cli.rs
@@ -3,14 +3,14 @@ mod support;
 use support::{adoc_command, fixture_path, stderr, stdout, workspace_fixture_path};
 
 #[test]
-fn version_matches_the_v0_3_2_release() {
+fn version_matches_the_v0_3_3_release() {
     let output = adoc_command()
         .arg("--version")
         .output()
         .expect("adoc --version runs");
 
     assert_eq!(output.status.code(), Some(0));
-    assert_eq!(stdout(&output), "adoc 0.3.2\n");
+    assert_eq!(stdout(&output), "adoc 0.3.3\n");
     assert!(output.stderr.is_empty());
 }
 

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -49,6 +49,13 @@ fn assert_valid(schema_name: &str, instance: &serde_json::Value) {
     );
 }
 
+fn schema_accepts(schema_name: &str, instance: &serde_json::Value) -> bool {
+    let schema = schema(schema_name);
+    jsonschema::validator_for(&schema)
+        .expect("schema compiles")
+        .is_valid(instance)
+}
+
 fn project_with_built_graph() -> (tempfile::TempDir, AgentDocMcpServer, String) {
     let workspace = tempfile::tempdir().expect("workspace");
     let root = workspace.path();
@@ -232,6 +239,115 @@ fn validates_representative_serialized_agent_envelopes_against_contract_schemas(
     assert_valid("adoc.contradictions.v0.schema.json", &contradictions);
     assert_eq!(contradictions["contradictions"], serde_json::json!([]));
     assert_eq!(contradictions["contradicted_claims"], serde_json::json!([]));
+}
+
+#[test]
+fn patch_input_schema_matches_the_public_parser_structural_contract() {
+    let replace = json!({
+        "schema_version": "adoc.patch.v0",
+        "op": "replace_body",
+        "target": "billing.ready",
+        "base_hash": "sha256:content",
+        "changes": { "body": "Updated body." },
+        "reason": "Update body."
+    });
+    let create = json!({
+        "schema_version": "adoc.patch.v0",
+        "op": "create_object",
+        "target": "billing.created",
+        "changes": {
+            "kind": "claim",
+            "status": "draft",
+            "body": "Created claim.",
+            "fields": { "owner": "team-billing" },
+            "placement": { "page_id": "team.billing", "after": "billing.ready" }
+        },
+        "reason": "Create claim.",
+        "proposer": { "type": "agent", "id": "agentdoc-action" }
+    });
+    let update = json!({
+        "schema_version": "adoc.patch.v0",
+        "op": "update_fields",
+        "target": "billing.ready",
+        "base_hash": "sha256:content",
+        "changes": { "fields": { "owner": "team-billing" } },
+        "reason": "Set owner."
+    });
+    let supersede = json!({
+        "schema_version": "adoc.patch.v0",
+        "op": "supersede",
+        "target": "billing.ready",
+        "base_hash": "sha256:content",
+        "changes": { "supersedes": ["billing.old"] },
+        "reason": "Record supersession."
+    });
+    let revoke = json!({
+        "schema_version": "adoc.patch.v0",
+        "op": "revoke",
+        "target": "billing.ready",
+        "base_hash": "sha256:content",
+        "changes": {},
+        "reason": "Revoke stale knowledge."
+    });
+
+    let mut cases = vec![
+        ("replace_body", replace.clone()),
+        ("create_object", create.clone()),
+        ("update_fields", update.clone()),
+        ("supersede", supersede.clone()),
+        ("revoke", revoke.clone()),
+    ];
+    let mut invalid = |name: &'static str, mut value: serde_json::Value| {
+        cases.push((name, value.take()));
+    };
+
+    let mut value = replace.clone();
+    value.as_object_mut().expect("object").remove("base_hash");
+    invalid("replace_body missing base_hash", value);
+    let mut value = create.clone();
+    value["base_hash"] = json!("sha256:forbidden");
+    invalid("create_object with base_hash", value);
+    let mut value = replace.clone();
+    value["unexpected"] = json!(true);
+    invalid("unknown top-level member", value);
+    let mut value = replace.clone();
+    value["changes"]["status"] = json!("verified");
+    invalid("operation-incompatible changes member", value);
+    let mut value = create.clone();
+    value["changes"]["placement"]["unexpected"] = json!(true);
+    invalid("unknown placement member", value);
+    let mut value = create.clone();
+    value["changes"]["placement"]
+        .as_object_mut()
+        .expect("placement object")
+        .remove("page_id");
+    invalid("placement missing page_id", value);
+    let mut value = create.clone();
+    value["proposer"]["unexpected"] = json!(true);
+    invalid("unknown proposer member", value);
+    let mut value = update.clone();
+    value["changes"]["fields"] = json!({});
+    invalid("empty update_fields map", value);
+    let mut value = update;
+    value["changes"]["fields"]["owner"] = json!(7);
+    invalid("non-string metadata value", value);
+    let mut value = supersede;
+    value["changes"]["supersedes"] = json!([]);
+    invalid("empty supersedes list", value);
+    let mut value = revoke;
+    value["changes"]["body"] = json!("not accepted");
+    invalid("revoke changes member", value);
+
+    for (name, patch) in cases {
+        let parser_accepts = parse_patch_from_value(patch.clone()).is_ok();
+        let contract_accepts = schema_accepts("patch-input.json", &patch);
+        assert_eq!(
+            contract_accepts,
+            parser_accepts,
+            "schema/parser mismatch for {name}:\n{}",
+            serde_json::to_string_pretty(&patch).expect("pretty patch")
+        );
+    }
 }
 
 /// V6.1: `adoc_stale` envelopes with all three record categories validate

--- a/docs/agent/v0/schema/patch-input.json
+++ b/docs/agent/v0/schema/patch-input.json
@@ -6,12 +6,120 @@
   "required": ["schema_version", "op", "target", "changes", "reason"],
   "properties": {
     "schema_version": { "const": "adoc.patch.v0" },
-    "op": { "enum": ["replace_body", "update_fields", "create_object", "supersede", "revoke"] },
+    "op": {
+      "enum": ["replace_body", "update_fields", "create_object", "supersede", "revoke"]
+    },
     "target": { "type": "string" },
     "base_hash": { "type": "string", "pattern": "^sha256:" },
     "changes": { "type": "object" },
     "reason": { "type": "string", "minLength": 1 },
-    "proposer": { "type": "object" }
+    "proposer": { "$ref": "#/$defs/proposer" }
   },
-  "additionalProperties": false
+  "additionalProperties": false,
+  "oneOf": [
+    {
+      "required": ["base_hash"],
+      "properties": {
+        "op": { "const": "replace_body" },
+        "changes": {
+          "type": "object",
+          "required": ["body"],
+          "properties": {
+            "body": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "required": ["base_hash"],
+      "properties": {
+        "op": { "const": "update_fields" },
+        "changes": {
+          "type": "object",
+          "required": ["fields"],
+          "properties": {
+            "fields": {
+              "allOf": [
+                { "$ref": "#/$defs/fields" },
+                { "minProperties": 1 }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "not": { "required": ["base_hash"] },
+      "properties": {
+        "op": { "const": "create_object" },
+        "changes": {
+          "type": "object",
+          "required": ["kind", "body"],
+          "properties": {
+            "kind": { "type": "string" },
+            "status": { "type": "string" },
+            "body": { "type": "string" },
+            "fields": { "$ref": "#/$defs/fields" },
+            "placement": { "$ref": "#/$defs/placement" }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "required": ["base_hash"],
+      "properties": {
+        "op": { "const": "supersede" },
+        "changes": {
+          "type": "object",
+          "required": ["supersedes"],
+          "properties": {
+            "supersedes": {
+              "type": "array",
+              "minItems": 1,
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    {
+      "required": ["base_hash"],
+      "properties": {
+        "op": { "const": "revoke" },
+        "changes": {
+          "type": "object",
+          "maxProperties": 0,
+          "additionalProperties": false
+        }
+      }
+    }
+  ],
+  "$defs": {
+    "fields": {
+      "type": "object",
+      "additionalProperties": { "type": "string" }
+    },
+    "placement": {
+      "type": "object",
+      "required": ["page_id"],
+      "properties": {
+        "page_id": { "type": "string" },
+        "after": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "proposer": {
+      "type": "object",
+      "required": ["type", "id"],
+      "properties": {
+        "type": { "type": "string" },
+        "id": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
 }

--- a/docs/agent/v0/schema/patch.md
+++ b/docs/agent/v0/schema/patch.md
@@ -6,6 +6,14 @@ Patch input expresses one proposed object-level change: `replace_body`, `update_
 
 Patch validation is read-only and never applies source edits. Application is the separate `adoc.patch.apply.v0` surface — `adoc patch --apply` on the CLI, and the config-gated MCP `adoc_patch_apply` (ADR-0036/0037).
 
+The published patch-input JSON Schema mirrors the parser's structural
+operation contract. Existing-object operations require `base_hash`;
+`create_object` forbids it. Each operation accepts only its documented
+`changes` members, and placement/proposer objects reject unknown members.
+`changes.fields` remains a string-valued authored metadata map because
+kind-specific field and lifecycle validation belongs to AgentDoc's Rust patch
+validator, not a duplicate JSON Schema rules engine.
+
 ## adoc.patch.v0 placement (V6.4)
 
 `changes.placement` on `create_object` is optional on the wire: a missing placement is the WARNING `patch.create_missing_placement` on `--check` and an ERROR on `--apply` (apply must know where to insert). At apply time `placement.page_id` resolves to a file via the page node's `source_path`; `after: <id>` inserts immediately after that block's close fence; absent `after` appends at end of file. Placement pages must be `.adoc` (`patch.placement_not_adoc`); new-file creation is deferred.


### PR DESCRIPTION
## What changed

- harden `adoc.patch.v0` JSON Schema with operation-discriminated structural rules
- add public parser/schema accept-reject parity coverage
- document the parser/domain validation boundary
- bump the AgentDoc CLI release to 0.3.3

## Why

V9.3.2 canonical proposals must be validated against the same structural contract AgentDoc parses.

## Compatibility

The Rust parser and patch/check/apply wire versions are unchanged. The authored schema now rejects structures the parser already rejected.

## Validation

- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- targeted patch CLI and schema contract tests