### PR TITLE
docs(action): record configurable provider timeout

### DIFF
--- a/docs/adr/0052-action-owned-cited-semantic-review.md
+++ b/docs/adr/0052-action-owned-cited-semantic-review.md
@@ -83,8 +83,11 @@ reviewed contract revision required by Decision 7. It:
 
 ### 2026-07-27: Configurable provider wall time
 
-Later dogfood calls completed in 294 seconds and exceeded the fixed 300-second
-ceiling. The Action therefore adds `provider-timeout-seconds`, defaulting to
+Later dogfood runs surfaced provider variability against the fixed ceiling:
+one call completed in 294 seconds, while a subsequent call exceeded 300
+seconds. The Action therefore adds `provider-timeout-seconds`, defaulting to
 600 and accepting integers from 60 through 3,600. The provider still degrades
 safely with `provider_timeout`; callers must give the enclosing GitHub job
 additional time for preparation, delivery, report finalization, and cleanup.
+The implementation shipped in
+[Action PR #20](https://github.com/agentdoc-dev/action/pull/20).

--- a/docs/adr/0052-action-owned-cited-semantic-review.md
+++ b/docs/adr/0052-action-owned-cited-semantic-review.md
@@ -80,3 +80,11 @@ reviewed contract revision required by Decision 7. It:
 - raises provider wall time from 120 to 300 seconds after real provider runs
   exceeded the original ceiling; the implementation shipped in
   [Action PR #17](https://github.com/agentdoc-dev/action/pull/17).
+
+### 2026-07-27: Configurable provider wall time
+
+Later dogfood calls completed in 294 seconds and exceeded the fixed 300-second
+ceiling. The Action therefore adds `provider-timeout-seconds`, defaulting to
+600 and accepting integers from 60 through 3,600. The provider still degrades
+safely with `provider_timeout`; callers must give the enclosing GitHub job
+additional time for preparation, delivery, report finalization, and cleanup.

--- a/docs/roadmap/ROADMAP-V9.md
+++ b/docs/roadmap/ROADMAP-V9.md
@@ -2679,7 +2679,7 @@ The slice-start security/contract ADR freezes these values and executable bounda
 | Knowledge citations per semantic finding | 5 |
 | Semantic judgment headline | 120 Unicode scalar values, single line |
 | Rationale | 1,000 Unicode scalar values per finding |
-| Provider wall time | 300 seconds |
+| Provider wall time | `provider-timeout-seconds`, default `600`, minimum `60`, maximum `3,600` |
 | Per GitHub report comment | 60,000 characters before deterministic truncation between complete Markdown records |
 | Report comments per delivery | `comment-max-comments`, default `5`, or `unlimited` |
 | GitHub job summary | Below 1 MiB |


### PR DESCRIPTION
## Summary

- record the configurable provider wall-time decision in ADR-0052
- update the V9 resource ceiling to the public input's default and range

## Context

A real provider call completed in 294 seconds, and a later call exceeded the fixed 300-second ceiling. The Action now owns a configurable `provider-timeout-seconds` input with a 600-second default and a validated 60–3600-second range.

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo build --workspace --locked`
- `RUSTDOCFLAGS='-D warnings' cargo doc --workspace --no-deps --locked`
- `git diff --check`
