### PR TITLE
docs(adr): record PRD v1.0 acceptance (ADR-0055)

### DIFF
--- a/docs/adr/0055-adopt-prd-v1-product-direction.md
+++ b/docs/adr/0055-adopt-prd-v1-product-direction.md
@@ -1,0 +1,56 @@
+# ADR-0055: Adopt PRD v1.0 as the Accepted Product Direction
+
+- Status: Accepted
+- Date: 2026-08-11
+
+## Context
+
+PR #141 merged `docs/product/PRD-v1.0.md`: the v1.0 Cloud-first product
+direction (Part I, carried unchanged from the 1.0 draft) with the v0.2
+capability inventory subsumed under it (Part II, Appendices A–D). Before
+merge the document was red-teamed by seven adversarial lenses with
+refute-first verification; all twenty-four confirmed findings were
+dispositioned — accuracy defects fixed and re-verified against `adoc`
+0.3.4, governance holes closed by maintainer rulings now recorded in
+§12/§14/§15, and the remainder resolved through the document's own
+machinery (§34 risk register, §35 open decisions 16–20, §36 follow-up
+items 12–13).
+
+Seventeen plausible strategy-level findings remained: the Cloud V1 bet is
+the product's only ungated bet, typed-knowledge cold-start, Free-tier
+absorption of the wedge, absent competitive analysis, and the
+required-gate trust sequencing. These are direction-level judgment calls,
+not defects the document can self-resolve. The document's own README
+gated further work (roadmap rework, citation migration, canonical rename)
+on an explicit acceptance decision.
+
+## Decision
+
+1. The v1.0 product direction in `PRD-v1.0.md` is accepted. Part I is the
+   normative product-direction contract; the locked V1 boundary stands
+   unchanged.
+2. The seventeen strategy-level findings were reviewed at acceptance and
+   do not block it. They are standing strategy inputs, summarized in the
+   Context above, not contract content; revisiting any of them is a new
+   decision against the accepted boundary.
+3. Acceptance is recorded in the repository: the PRD status line and the
+   product README reference this ADR.
+4. The README migration plan advances past step 1. Step 2 — reworking the
+   implementation roadmap for the Cloud-first V1 boundary, including the
+   §36 item 12 restage of RET-003 permission-aware retrieval and §27.1
+   sensitive-access audit into V1 — is the next cycle of work.
+
+## Consequences
+
+- `PRD-v1.0.md` now holds precedence slot 3 (forward product direction, V1
+  scope, capability reference) as an accepted contract, no longer a
+  proposal. Shipped behavior and active roadmaps still win on conflict.
+- ROADMAP-V9 is in known contradiction with the accepted contract on
+  RET-003/§27.1 staging (V10 there, V1 here); the next roadmap must
+  resolve §36 item 12 rather than inherit the V9 staging.
+- The §36 item 13 direction claims (authored-carriers-only content
+  hashing, closed per-kind field schemas) require their own ADRs before
+  implementation.
+- `PRD.md` v0.2 remains frozen as the bare `PRD §N` citation target; the
+  canonical rename of the v1.0 document stays gated on the Appendix D
+  citation migration (README steps 3–5).

--- a/docs/product/PRD-v1.0.md
+++ b/docs/product/PRD-v1.0.md
@@ -5,7 +5,7 @@
 **Document type:** Product requirements — direction contract and capability reference
 **Version:** 1.0
 **Date:** 2026-08-11
-**Status:** Draft (pending acceptance) — current product direction, locked V1 boundary, and capability reference
+**Status:** Accepted (2026-08-11, ADR-0055) — current product direction, locked V1 boundary, and capability reference
 **Primary audience:** Product, engineering, design, developer experience, AI platform, security, infrastructure, enterprise architecture
 **Repository path:** `docs/product/PRD-v1.0.md`
 

--- a/docs/product/README.md
+++ b/docs/product/README.md
@@ -33,7 +33,7 @@ crosswalk. Internal references to old numbered sections are written
 The document is a product-direction contract, not a statement that every V1
 capability is already shipped. Current implementation truth remains defined by
 code, tests, accepted ADRs, and active implementation roadmaps. Its status is
-Draft (pending acceptance).
+Accepted (ADR-0055).
 
 ## Precedence
 
@@ -54,7 +54,7 @@ PRD, it does not retroactively redefine shipped behavior.
 
 Before `PRD-v1.0.md` can replace `PRD.md` as the unversioned canonical file:
 
-1. accept the v1.0 product direction;
+1. accept the v1.0 product direction (done — ADR-0055);
 2. update the implementation roadmap for the Cloud-first V1 boundary;
 3. migrate or version all repository references that cite numbered sections of
    `PRD.md` (Appendix D of `PRD-v1.0.md` is the mechanical input for this


### PR DESCRIPTION
Records the acceptance of the PRD v1.0 product direction as ADR-0055 and flips the status lines.

- **ADR-0055**: v1.0 direction accepted; locked V1 boundary stands; the 17 strategy-level red-team findings reviewed at acceptance and recorded as non-blocking standing inputs (themes summarized in the ADR). Consequences name the two live obligations: ROADMAP-V9's known contradiction on RET-003/§27.1 staging (§36 item 12) and the §36 item 13 ADRs required before implementing the hash / closed-schema directions.
- **PRD-v1.0.md**: Status → Accepted (2026-08-11, ADR-0055).
- **README.md**: status updated; migration-plan step 1 marked done.

Next per the README migration plan: step 2 — roadmap rework for the Cloud-first V1 boundary.

https://claude.ai/code/session_01PTH5mc92mdd9fJmB4rRT8W