### PR TITLE
CI: review every PR with both Fable 5 and Opus 5

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,7 +10,14 @@ concurrency:
 
 jobs:
   claude-review:
+    name: claude-review (${{ matrix.model }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Every PR gets two independent reviews: one from Fable 5, one from
+        # Opus 5. fail-fast off so one model's failure never cancels the other.
+        model: [claude-fable-5, claude-opus-5]
     permissions:
       contents: read
       pull-requests: read
@@ -49,5 +56,5 @@ jobs:
             actions: read
 
           claude_args: |
-            --model claude-opus-4-7
+            --model ${{ matrix.model }}
             --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"


### PR DESCRIPTION
The Claude code-review workflow ran a single job pinned to `claude-opus-4-7`. It now runs a two-model matrix — `claude-fable-5` and `claude-opus-5` — so every PR always gets two independent reviews.

- `fail-fast: false` so one model's failure never cancels the other's review.
- Job names surface the model (`claude-review (claude-fable-5)` / `claude-review (claude-opus-5)`) in checks.
- `--model` now comes from the matrix; no other behavior changed.

Validated with `actionlint` and a YAML structure check.

https://claude.ai/code/session_011EV1ddWXrshr1p8XwAgjxz