### PR TITLE
E0.2 — Four managed-product invariants

### DIFF
--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -1,11 +1,16 @@
-//! Docs-truth guard (ADR-0041, slice E0.1): ADR-0056 rule 8 forbids the
-//! roadmap from representing the B1–B6 amended Product V1 boundary as
+//! Docs-truth guard (ADR-0041, slices E0.1/E0.2): ADR-0056 rule 8 forbids
+//! the roadmap from representing the B1–B6 amended Product V1 boundary as
 //! pre-existing ADR-0055 acceptance — ADR-0056 is the accepting decision.
 //! The guard scans every current roadmap/annex document: a line naming
 //! ADR-0055 must acknowledge the amendment in the same line (name ADR-0056,
 //! or say amended/superseded) or be a pinned allow-listed rule quotation.
 //! `ROADMAP-V10-2026-08-12-original.md` and `archive/` are preserved history
 //! (see `docs/roadmap/archive/README.md`) and exempt.
+//!
+//! Slice E0.2 extends the guard to the four managed-product invariants
+//! (ADR-0057, D36–D39): the ADR's invariant statements and its verbatim
+//! authorization precedence pipeline are pinned, and no annex line may state
+//! a permissive-default authorization resolution.
 
 mod support;
 
@@ -294,6 +299,56 @@ fn template_v10_violations(doc_name: &str, content: &str) -> Vec<String> {
             )
         })
         .collect()
+}
+
+/// Reads ADR-0057 — the accepting decision the E0.2 pins run against.
+fn adr_0057() -> String {
+    let path = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join("docs/adr/0057-fix-four-managed-product-invariants.md");
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+#[test]
+fn adr_0057_states_all_four_invariants() {
+    // E0.2.T1: ADR-0057 is Accepted and states the four managed-product
+    // invariants (D36–D39) as architecture rules, each with its refuted
+    // alternative. Editing one away fails here and forces re-review — the
+    // invariant-3 pin stops at the stable sentence prefix because E0.2.T2
+    // completes that decision's pipeline wording.
+    let adr = adr_0057();
+    assert!(
+        adr.contains("- Status: Accepted"),
+        "ADR-0057 must remain Accepted"
+    );
+    for (invariant, refuted_alternative) in [
+        (
+            "**Managed Object identity is workspace-qualified.**",
+            "never auto-merge",
+        ),
+        (
+            "**Content versions are immutable; managed state changes are append-only events.**",
+            "does not create a new semantic content version",
+        ),
+        (
+            "**Authorization uses one deterministic",
+            "may narrow but never widen AgentDoc authority",
+        ),
+        (
+            "**Human semantic review can require independence.**",
+            "cannot satisfy an explicit independent-review obligation",
+        ),
+    ] {
+        assert!(
+            adr.contains(invariant),
+            "ADR-0057 lost an invariant: {invariant}"
+        );
+        assert!(
+            adr.contains(refuted_alternative),
+            "ADR-0057 lost a refuted alternative: {refuted_alternative}"
+        );
+    }
 }
 
 #[test]

--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -9,8 +9,8 @@
 //!
 //! Slice E0.2 extends the guard to the four managed-product invariants
 //! (ADR-0057, D36–D39): the ADR's invariant statements and its verbatim
-//! authorization precedence pipeline are pinned, and no annex line may state
-//! a permissive-default authorization resolution.
+//! authorization precedence pipeline are pinned, and no roadmap/annex line
+//! may state a permissive-default authorization resolution.
 
 mod support;
 
@@ -57,6 +57,14 @@ const ALLOWED_CRITERION_CLOSURE_LINES: &[(&str, &str)] = &[
          the phrasing.",
     ),
 ];
+
+/// Lines that legitimately state a permissive-default signature because
+/// they describe this guard's own seeded fixture. Same pinning discipline
+/// as `ALLOWED_ADR_0055_LINES`.
+const ALLOWED_PERMISSIVE_DEFAULT_LINES: &[(&str, &str)] = &[(
+    "docs/roadmap/v10/MILESTONES.md",
+    "- Doc guard fails on a seeded fixture stating a permissive-default resolution.",
+)];
 
 /// Reads every current roadmap/annex doc as `(repo-relative name, content)`,
 /// sorted for deterministic failure output. Asserts the parser-health floor
@@ -177,6 +185,47 @@ fn criterion_closure_violations(doc_name: &str, content: &str) -> Vec<String> {
                 format!(
                     "{doc_name}:{number}: claims criterion closure by construction \
                      (PR #143 acceptance-wording rule): {}",
+                    line.trim()
+                )
+            })
+        })
+        .collect()
+}
+
+/// One message per line stating a permissive-default authorization
+/// resolution — the ADR-0057 invariant-3 reintroduction signature.
+/// Hyphens normalize to spaces so compound forms (`permissive-default`,
+/// `allow-by-default`, `fail-open`) match; `never` or `no permissive
+/// default` on the same line marks the prohibition statements this rule
+/// exists to protect. `deny-by-default` normalizes to `deny by default`
+/// and matches no signature.
+fn permissive_default_violations(doc_name: &str, content: &str) -> Vec<String> {
+    const SIGNATURES: &[&str] = &[
+        "permissive default",
+        "permissive by default",
+        "default allow",
+        "allow by default",
+        "allowed by default",
+        "default to allow",
+        "defaults to allow",
+        "implicit allow",
+        "open by default",
+        "fail open",
+        "fails open",
+    ];
+    const PROHIBITION_MARKERS: &[&str] = &["never", "no permissive default"];
+    structural_lines(content)
+        .filter_map(|(number, line)| {
+            let lower = line.to_lowercase().replace('-', " ");
+            (SIGNATURES.iter().any(|signature| lower.contains(signature))
+                && !PROHIBITION_MARKERS
+                    .iter()
+                    .any(|marker| lower.contains(marker))
+                && !allow_listed(ALLOWED_PERMISSIVE_DEFAULT_LINES, doc_name, line))
+            .then(|| {
+                format!(
+                    "{doc_name}:{number}: states a permissive-default authorization \
+                     resolution (ADR-0057 invariant 3): {}",
                     line.trim()
                 )
             })
@@ -418,6 +467,83 @@ identity/session/grant freshness\n\
     assert!(
         result.is_err(),
         "reordered pipeline must fail the order pin"
+    );
+}
+
+#[test]
+fn annexes_cross_link_the_adr_0057_invariants() {
+    // E0.2.T3: the authorization and knowledge-model annexes defer to
+    // ADR-0057 explicitly, so no annex carries a competing precedence
+    // order. Removing a cross-link fails here. Reusing the scanned corpus
+    // inherits its fence-health floor.
+    let docs = roadmap_docs();
+    for annex in [
+        "docs/roadmap/v10/AUTHORIZATION.md",
+        "docs/roadmap/v10/KNOWLEDGE-MODEL.md",
+    ] {
+        let (_, content) = docs
+            .iter()
+            .find(|(name, _)| name == annex)
+            .unwrap_or_else(|| panic!("{annex} missing from the roadmap scan"));
+        assert!(
+            structural_lines(content).any(|(_, line)| line.contains("ADR-0057")),
+            "{annex} must cross-link ADR-0057 as the invariant authority"
+        );
+    }
+}
+
+#[test]
+fn roadmap_never_states_a_permissive_default() {
+    let violations: Vec<String> = roadmap_docs()
+        .iter()
+        .flat_map(|(name, content)| permissive_default_violations(name, content))
+        .collect();
+    assert!(
+        violations.is_empty(),
+        "roadmap text states a permissive-default authorization resolution \
+         (ADR-0057 invariant 3):\n{}",
+        violations.join("\n")
+    );
+}
+
+#[test]
+fn guard_fires_on_seeded_permissive_default() {
+    // The E0.2 acceptance fixture: a line stating a permissive-default
+    // resolution, in each written form.
+    for line in [
+        "Unknown authorization context resolves to a permissive default.\n",
+        "Unmatched scopes default to allow.\n",
+        "Ambiguous grants are allow-by-default.\n",
+        "Absent policy rows mean default allow.\n",
+        "Consequential uncertainty fails open.\n",
+        "Gate checks fail-open on timeout.\n",
+        "Retrieval scopes are allowed by default.\n",
+        "Grants are permissive by default.\n",
+        "Absent policy rows imply an implicit allow.\n",
+        "Visibility is open by default.\n",
+    ] {
+        let violations = permissive_default_violations("fixture.md", line);
+        assert_eq!(
+            violations.len(),
+            1,
+            "seeded permissive default must fire: {line:?} -> {violations:?}"
+        );
+        assert!(
+            violations[0].starts_with("fixture.md:1:"),
+            "{}",
+            violations[0]
+        );
+    }
+    // The prohibition statements the rule protects pass on their own
+    // merits, as does the deny-side compound.
+    let clean = "\
+Consequential uncertainty yields `deny` or typed `insufficient_context`, \
+never a permissive default.\n\
+Precedence matches RT-05/D38: no permissive default anywhere.\n\
+Authorization is deterministic and deny-by-default.\n";
+    assert_eq!(
+        permissive_default_violations("fixture.md", clean),
+        Vec::<String>::new()
     );
 }
 
@@ -799,11 +925,15 @@ fn scan_scope_covers_every_roadmap_subdirectory() {
 #[test]
 fn allow_lists_are_exact_and_present() {
     type RuleFn = fn(&str, &str) -> Vec<String>;
-    let lists: [(&[(&str, &str)], RuleFn); 2] = [
+    let lists: [(&[(&str, &str)], RuleFn); 3] = [
         (ALLOWED_ADR_0055_LINES, adr_0055_violations),
         (
             ALLOWED_CRITERION_CLOSURE_LINES,
             criterion_closure_violations,
+        ),
+        (
+            ALLOWED_PERMISSIVE_DEFAULT_LINES,
+            permissive_default_violations,
         ),
     ];
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");

--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -66,6 +66,28 @@ const ALLOWED_PERMISSIVE_DEFAULT_LINES: &[(&str, &str)] = &[(
     "- Doc guard fails on a seeded fixture stating a permissive-default resolution.",
 )];
 
+/// The annex deference lines, pinned exactly like the allow-lists:
+/// rewriting one into different — or contradictory — deference fails the
+/// guard and forces re-review, never silent un-anchoring. Trailing
+/// hard-break spaces are trimmed by the comparison.
+const INVARIANT_AUTHORITY_LINES: &[(&str, &str)] = &[
+    (
+        "docs/roadmap/v10/AUTHORIZATION.md",
+        "**Invariant authority:** \
+         [ADR-0057](../../adr/0057-fix-four-managed-product-invariants.md) fixes the \
+         deterministic, deny-by-default authorization precedence (invariant 3, D38) \
+         \u{2014} this annex elaborates that order and never redefines it",
+    ),
+    (
+        "docs/roadmap/v10/KNOWLEDGE-MODEL.md",
+        "**Invariant authority:** \
+         [ADR-0057](../../adr/0057-fix-four-managed-product-invariants.md) fixes \
+         workspace-qualified Object identity (D36; K6) and append-only managed state \
+         over immutable content versions (D37; K4) \u{2014} this annex elaborates those \
+         invariants and never redefines them",
+    ),
+];
+
 /// Reads every current roadmap/annex doc as `(repo-relative name, content)`,
 /// sorted for deterministic failure output. Asserts the parser-health floor
 /// here so every real-tree guard inherits it: an empty or relocated
@@ -495,20 +517,18 @@ identity/session/grant freshness\n\
 fn annexes_cross_link_the_adr_0057_invariants() {
     // E0.2.T3: the authorization and knowledge-model annexes defer to
     // ADR-0057 explicitly, so no annex carries a competing precedence
-    // order. Removing a cross-link fails here. Reusing the scanned corpus
-    // inherits its fence-health floor.
+    // order. The deference lines are pinned exactly — a removed, rewritten,
+    // or contradictory line fails here, the same footing as the allow-list
+    // pins. Reusing the scanned corpus inherits its fence-health floor.
     let docs = roadmap_docs();
-    for annex in [
-        "docs/roadmap/v10/AUTHORIZATION.md",
-        "docs/roadmap/v10/KNOWLEDGE-MODEL.md",
-    ] {
+    for (annex, pinned) in INVARIANT_AUTHORITY_LINES {
         let (_, content) = docs
             .iter()
             .find(|(name, _)| name == annex)
             .unwrap_or_else(|| panic!("{annex} missing from the roadmap scan"));
         assert!(
-            structural_lines(content).any(|(_, line)| line.contains("ADR-0057")),
-            "{annex} must cross-link ADR-0057 as the invariant authority"
+            structural_lines(content).any(|(_, line)| line.trim() == *pinned),
+            "{annex} no longer carries the pinned invariant-authority line: {pinned}"
         );
     }
 }

--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -195,9 +195,10 @@ fn criterion_closure_violations(doc_name: &str, content: &str) -> Vec<String> {
 /// One message per line stating a permissive-default authorization
 /// resolution — the ADR-0057 invariant-3 reintroduction signature.
 /// Hyphens normalize to spaces so compound forms (`permissive-default`,
-/// `allow-by-default`, `fail-open`) match; `never` or `no permissive
-/// default` on the same line marks the prohibition statements this rule
-/// exists to protect. `deny-by-default` normalizes to `deny by default`
+/// `allow-by-default`, `fail-open`) match. Prohibition markers are
+/// anchored phrases, not a bare `never`: an incidental `never` in an
+/// adjacent clause ("ACLs never widen; scopes default to allow") must not
+/// disarm the tripwire. `deny-by-default` normalizes to `deny by default`
 /// and matches no signature.
 fn permissive_default_violations(doc_name: &str, content: &str) -> Vec<String> {
     const SIGNATURES: &[&str] = &[
@@ -213,7 +214,13 @@ fn permissive_default_violations(doc_name: &str, content: &str) -> Vec<String> {
         "fail open",
         "fails open",
     ];
-    const PROHIBITION_MARKERS: &[&str] = &["never", "no permissive default"];
+    const PROHIBITION_MARKERS: &[&str] = &[
+        "never a permissive default",
+        "no permissive default",
+        "never fail open",
+        "never fails open",
+        "not allowed by default",
+    ];
     structural_lines(content)
         .filter_map(|(number, line)| {
             let lower = line.to_lowercase().replace('-', " ");
@@ -521,6 +528,8 @@ fn guard_fires_on_seeded_permissive_default() {
         "Grants are permissive by default.\n",
         "Absent policy rows imply an implicit allow.\n",
         "Visibility is open by default.\n",
+        "Source ACLs never widen AgentDoc authority; unmatched scopes default to allow.\n",
+        "Unmatched scopes default to allow and grants never expire.\n",
     ] {
         let violations = permissive_default_violations("fixture.md", line);
         assert_eq!(
@@ -535,11 +544,13 @@ fn guard_fires_on_seeded_permissive_default() {
         );
     }
     // The prohibition statements the rule protects pass on their own
-    // merits, as does the deny-side compound.
+    // merits, as do the deny-side compounds.
     let clean = "\
 Consequential uncertainty yields `deny` or typed `insufficient_context`, \
 never a permissive default.\n\
 Precedence matches RT-05/D38: no permissive default anywhere.\n\
+Forced audit-sink failure surfaces the code per policy cell, never fail-open.\n\
+Restricted fields are not allowed by default.\n\
 Authorization is deterministic and deny-by-default.\n";
     assert_eq!(
         permissive_default_violations("fixture.md", clean),

--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -449,17 +449,23 @@ const PRECEDENCE_PIPELINE: &[&str] = &[
 /// the order is D38's substance.
 fn assert_pipeline_block(doc_name: &str, content: &str) {
     let lines: Vec<&str> = content.lines().map(str::trim).collect();
+    let blocks = lines
+        .windows(PRECEDENCE_PIPELINE.len())
+        .filter(|window| *window == PRECEDENCE_PIPELINE)
+        .count();
+    // Exactly one: zero is a reordered/inserted/missing stage; two or more
+    // means a stale verbatim copy could mask drift of the normative block.
     assert!(
-        lines
-            .windows(PRECEDENCE_PIPELINE.len())
-            .any(|window| window == PRECEDENCE_PIPELINE),
-        "{doc_name}: the precedence pipeline no longer appears as a verbatim \
-         contiguous block (stage reordered, inserted, or missing)"
+        blocks == 1,
+        "{doc_name}: expected exactly one verbatim contiguous block of the \
+         precedence pipeline, found {blocks}"
     );
 }
 
 /// The `### 5.1` section only, so the pin's label stays true: stages
 /// surviving elsewhere in the PRD while §5.1 is gutted must not satisfy it.
+/// ponytail: the slice ends at the next `## ` heading — a future `### 5.2`
+/// would widen it; tighten the end marker if section 5 ever grows one.
 fn prd_section_5_1() -> String {
     let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
     let prd_path = repo_root.join("docs/product/PRD-v1.1-amendment.md");

--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -420,17 +420,35 @@ const PRECEDENCE_PIPELINE: &[&str] = &[
     "→ allow | deny | insufficient_context",
 ];
 
-/// Asserts every pipeline line appears — and in pipeline order. Plain
-/// `contains` per line would accept a reordered pipeline, and the order is
-/// D38's substance.
-fn assert_pipeline_in_order(doc_name: &str, content: &str) {
-    let mut tail = content;
-    for line in PRECEDENCE_PIPELINE {
-        let found = tail.find(line).unwrap_or_else(|| {
-            panic!("{doc_name}: precedence pipeline line missing or out of order: {line}")
-        });
-        tail = &tail[found + line.len()..];
-    }
+/// Asserts the pipeline appears as one contiguous block — trimmed lines,
+/// verbatim, in order. A per-line cursor walk would still accept a stage
+/// spliced between two canonical stages, or stages scattered in order
+/// across unrelated sections; contiguity is what "verbatim" promises, and
+/// the order is D38's substance.
+fn assert_pipeline_block(doc_name: &str, content: &str) {
+    let lines: Vec<&str> = content.lines().map(str::trim).collect();
+    assert!(
+        lines
+            .windows(PRECEDENCE_PIPELINE.len())
+            .any(|window| window == PRECEDENCE_PIPELINE),
+        "{doc_name}: the precedence pipeline no longer appears as a verbatim \
+         contiguous block (stage reordered, inserted, or missing)"
+    );
+}
+
+/// The `### 5.1` section only, so the pin's label stays true: stages
+/// surviving elsewhere in the PRD while §5.1 is gutted must not satisfy it.
+fn prd_section_5_1() -> String {
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let prd_path = repo_root.join("docs/product/PRD-v1.1-amendment.md");
+    let prd = fs::read_to_string(&prd_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", prd_path.display()));
+    let start = prd
+        .find("### 5.1 Authorization precedence")
+        .unwrap_or_else(|| panic!("PRD v1.1 lost the `### 5.1 Authorization precedence` heading"));
+    let section = &prd[start..];
+    let end = section.find("\n## ").unwrap_or(section.len());
+    section[..end].to_string()
 }
 
 #[test]
@@ -439,13 +457,12 @@ fn adr_0057_pins_the_precedence_pipeline_verbatim() {
     // deny-by-default, the equal-or-more-specific deny tie-break, and
     // fail-closed consequential uncertainty (RT-05/D38 — never a
     // permissive default).
-    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
-    let prd_path = repo_root.join("docs/product/PRD-v1.1-amendment.md");
-    let prd = fs::read_to_string(&prd_path)
-        .unwrap_or_else(|error| panic!("failed to read {}: {error}", prd_path.display()));
-    assert_pipeline_in_order("docs/product/PRD-v1.1-amendment.md §5.1", &prd);
+    assert_pipeline_block(
+        "docs/product/PRD-v1.1-amendment.md §5.1",
+        &prd_section_5_1(),
+    );
     let adr = adr_0057();
-    assert_pipeline_in_order("ADR-0057", &adr);
+    assert_pipeline_block("ADR-0057", &adr);
     for sentence in [
         "deny-by-default",
         "Hard deny wins.",
@@ -459,7 +476,8 @@ fn adr_0057_pins_the_precedence_pipeline_verbatim() {
 }
 
 #[test]
-fn pipeline_order_pin_rejects_a_reordered_pipeline() {
+#[should_panic(expected = "verbatim contiguous block")]
+fn pipeline_pin_rejects_a_reordered_pipeline() {
     // The audit fixture: swapping two stages must fail even though every
     // stage is still present as a substring.
     let reordered = "\
@@ -470,11 +488,7 @@ identity/session/grant freshness\n\
 → object/field/proposition visibility\n\
 → action-specific policy\n\
 → allow | deny | insufficient_context\n";
-    let result = std::panic::catch_unwind(|| assert_pipeline_in_order("fixture.md", reordered));
-    assert!(
-        result.is_err(),
-        "reordered pipeline must fail the order pin"
-    );
+    assert_pipeline_block("fixture.md", reordered);
 }
 
 #[test]
@@ -556,6 +570,25 @@ Authorization is deterministic and deny-by-default.\n";
         permissive_default_violations("fixture.md", clean),
         Vec::<String>::new()
     );
+}
+
+#[test]
+#[should_panic(expected = "verbatim contiguous block")]
+fn pipeline_pin_rejects_an_inserted_stage() {
+    // The review fixture: a stage spliced between two canonical stages
+    // must fail even though the canonical stages still appear in order
+    // (the per-line cursor walk this block matcher replaced stayed green
+    // here).
+    let inserted = "\
+identity/session/grant freshness\n\
+→ hard/system denies\n\
+→ model-suggested overrides\n\
+→ current source-ACL ceiling\n\
+→ scoped AgentDoc grants/denies\n\
+→ object/field/proposition visibility\n\
+→ action-specific policy\n\
+→ allow | deny | insufficient_context\n";
+    assert_pipeline_block("fixture.md", inserted);
 }
 
 #[test]

--- a/crates/adoc-mcp/tests/boundary_authority_guard.rs
+++ b/crates/adoc-mcp/tests/boundary_authority_guard.rs
@@ -351,6 +351,76 @@ fn adr_0057_states_all_four_invariants() {
     }
 }
 
+/// The authorization precedence pipeline, line by line as accepted in
+/// PRD v1.1 §5.1 (RT-05/D38). ADR-0057 must carry it verbatim, and the PRD
+/// section itself must not drift from the pinned canon.
+const PRECEDENCE_PIPELINE: &[&str] = &[
+    "identity/session/grant freshness",
+    "→ hard/system denies",
+    "→ current source-ACL ceiling",
+    "→ scoped AgentDoc grants/denies",
+    "→ object/field/proposition visibility",
+    "→ action-specific policy",
+    "→ allow | deny | insufficient_context",
+];
+
+/// Asserts every pipeline line appears — and in pipeline order. Plain
+/// `contains` per line would accept a reordered pipeline, and the order is
+/// D38's substance.
+fn assert_pipeline_in_order(doc_name: &str, content: &str) {
+    let mut tail = content;
+    for line in PRECEDENCE_PIPELINE {
+        let found = tail.find(line).unwrap_or_else(|| {
+            panic!("{doc_name}: precedence pipeline line missing or out of order: {line}")
+        });
+        tail = &tail[found + line.len()..];
+    }
+}
+
+#[test]
+fn adr_0057_pins_the_precedence_pipeline_verbatim() {
+    // E0.2.T2: ADR-0057 states the PRD v1.1 §5.1 pipeline verbatim, with
+    // deny-by-default, the equal-or-more-specific deny tie-break, and
+    // fail-closed consequential uncertainty (RT-05/D38 — never a
+    // permissive default).
+    let repo_root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let prd_path = repo_root.join("docs/product/PRD-v1.1-amendment.md");
+    let prd = fs::read_to_string(&prd_path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", prd_path.display()));
+    assert_pipeline_in_order("docs/product/PRD-v1.1-amendment.md §5.1", &prd);
+    let adr = adr_0057();
+    assert_pipeline_in_order("ADR-0057", &adr);
+    for sentence in [
+        "deny-by-default",
+        "Hard deny wins.",
+        "At equal or more-specific scope, explicit deny wins over allow.",
+        "Expired/stale grants/membership observations do not authorize.",
+        "Consequential uncertainty fails closed",
+        "never a permissive default",
+    ] {
+        assert!(adr.contains(sentence), "ADR-0057 must state: {sentence}");
+    }
+}
+
+#[test]
+fn pipeline_order_pin_rejects_a_reordered_pipeline() {
+    // The audit fixture: swapping two stages must fail even though every
+    // stage is still present as a substring.
+    let reordered = "\
+identity/session/grant freshness\n\
+→ current source-ACL ceiling\n\
+→ hard/system denies\n\
+→ scoped AgentDoc grants/denies\n\
+→ object/field/proposition visibility\n\
+→ action-specific policy\n\
+→ allow | deny | insufficient_context\n";
+    let result = std::panic::catch_unwind(|| assert_pipeline_in_order("fixture.md", reordered));
+    assert!(
+        result.is_err(),
+        "reordered pipeline must fail the order pin"
+    );
+}
+
 #[test]
 fn roadmap_never_misattributes_boundary_to_adr_0055() {
     let violations: Vec<String> = roadmap_docs()

--- a/docs/adr/0057-fix-four-managed-product-invariants.md
+++ b/docs/adr/0057-fix-four-managed-product-invariants.md
@@ -3,6 +3,7 @@
 - Status: Accepted
 - Date: 2026-08-13
 - Depends on: ADR-0056
+- Amended: 2026-08-18 — decision 3 restates the authorization precedence pipeline verbatim from PRD v1.1 §5.1 (E0.2.T2; wording completion, no substance change)
 
 ## Context
 
@@ -14,7 +15,19 @@ The V10 red-team found four implementation choices that could diverge even after
 
 2. **Content versions are immutable; managed state changes are append-only events.** Governance, verification, effectivity, freshness, integrity, and connector synchronization transitions attach to immutable content versions. A state-only transition does not create a new semantic content version. The managed graph/read model must be reproducible from immutable versions, recorded state events, and recorded policy/contract versions.
 
-3. **Authorization uses one deterministic precedence.** Validate identity/session/grant freshness first; apply system-level restrictions; enforce the current source-ACL ceiling; evaluate scoped AgentDoc grants and explicit restrictions; apply object/field visibility; then apply action-specific policy. A source ACL may narrow but never widen AgentDoc authority. More-specific explicit restriction wins over an allow. Expired grants/membership observations do not authorize. Consequential uncertainty fails closed.
+3. **Authorization uses one deterministic, deny-by-default precedence.** Every evaluation runs the pipeline accepted in PRD v1.1 §5.1, verbatim:
+
+   ```text
+   identity/session/grant freshness
+   → hard/system denies
+   → current source-ACL ceiling
+   → scoped AgentDoc grants/denies
+   → object/field/proposition visibility
+   → action-specific policy
+   → allow | deny | insufficient_context
+   ```
+
+   Hard deny wins. A source ACL may narrow but never widen AgentDoc authority. At equal or more-specific scope, explicit deny wins over allow. Expired/stale grants/membership observations do not authorize. Consequential uncertainty fails closed — `deny` or typed `insufficient_context`, never a permissive default.
 
 4. **Human semantic review can require independence.** Low-risk/advisory policy may permit author self-assessment. When policy requires independent semantic review, the change author/requesting principal and the qualifying semantic reviewer must be distinct. Human semantic review and proposal approval remain separate authorities; self-assessment cannot satisfy an explicit independent-review obligation.
 

--- a/docs/roadmap/v10/AUTHORIZATION.md
+++ b/docs/roadmap/v10/AUTHORIZATION.md
@@ -1,6 +1,7 @@
 # V10 Decision Annex — Identity, Authorization, ACLs, and Groups
 
 **Status:** Locked planning decisions from 2026-08-12  
+**Invariant authority:** [ADR-0057](../../adr/0057-fix-four-managed-product-invariants.md) fixes the deterministic, deny-by-default authorization precedence (invariant 3, D38) — this annex elaborates that order and never redefines it  
 **Parent:** [`DECISION-REGISTER.md`](DECISION-REGISTER.md)
 
 This annex is normative for V10 planning. Shipped code and accepted ADRs remain implementation truth.

--- a/docs/roadmap/v10/KNOWLEDGE-MODEL.md
+++ b/docs/roadmap/v10/KNOWLEDGE-MODEL.md
@@ -1,6 +1,7 @@
 # V10 Decision Annex — Canonical Knowledge, Migration, State, Hashing, Proof, and Retention
 
 **Status:** Locked planning decisions from 2026-08-12  
+**Invariant authority:** [ADR-0057](../../adr/0057-fix-four-managed-product-invariants.md) fixes workspace-qualified Object identity (D36; K6) and append-only managed state over immutable content versions (D37; K4) — this annex elaborates those invariants and never redefines them  
 **Parent:** [`DECISION-REGISTER.md`](DECISION-REGISTER.md)
 
 ## K1. Two first-class operating modes


### PR DESCRIPTION
## Slice

`E0.2` from `docs/roadmap/v10/EXECUTION-MAP.md` / `MILESTONES.md` (depends on E0.1, merged in #144). One slice = one PR; one commit per tracer bullet.

## Tracer bullets

- **E0.2.T1** — Verified ADR-0057 is Accepted and states all four managed-product invariants (D36–D39), each with its refuted alternative. The verification is executable: the guard pins the invariant statements, so editing one away forces re-review. No amendment decision was needed on this dimension.
- **E0.2.T2** — Red first: the pin failed on the accepted ADR text, which paraphrased the pipeline and omitted the outcome vocabulary, deny-by-default, and the equal-scope deny tie-break. Decision 3 now carries the PRD v1.1 §5.1 pipeline verbatim; the pin walks both PRD §5.1 and the ADR with a monotonic cursor so a **reordered** pipeline fails too (order is D38's substance). Wording completion of an already-accepted decision — amendment trace recorded in the ADR header, no substance change.
- **E0.2.T3** — Red first: AUTHORIZATION.md and KNOWLEDGE-MODEL.md now carry an **Invariant authority** header line deferring to ADR-0057 (precedence/D38; identity/D36 + append-only state/D37), and the E0.1 doc guard gains the reintroduction tripwire: any structural roadmap/annex line stating a permissive-default authorization resolution fails unless it carries a prohibition marker (`never`, `no permissive default`) or is the pinned MILESTONES fixture line.

## Acceptance evidence

- ADR-0057 status Accepted; all four invariants stated as architecture rules — pinned by `adr_0057_states_all_four_invariants`.
- Precedence order matches RT-05/D38 (PRD v1.1 §5.1 canon), enforced in order by `adr_0057_pins_the_precedence_pipeline_verbatim` + `pipeline_order_pin_rejects_a_reordered_pipeline`; expired/stale grants never authorize; no permissive default anywhere.
- Source ACL documented as a ceiling that narrows but never widens; explicit deny wins at equal or more-specific scope.
- Doc guard fails on seeded permissive-default fixtures in every signature form (`guard_fires_on_seeded_permissive_default`), passes on the real tree.

## Out of scope (per the slice card)

Evaluator implementation (E2.2), human-review independence mechanics (E3.6), state-event store (E1.4) — none touched.

## Gate

`cargo fmt --check` + `cargo clippy --workspace --all-targets -D warnings` + `cargo test --workspace --locked` green on every commit; guard suite 25 tests.

https://claude.ai/code/session_011EV1ddWXrshr1p8XwAgjxz