### PR TITLE
E0.3 — Canonical contract/code inventory

### DIFF
--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -284,8 +284,9 @@ fn historical_envelope_rows_are_no_longer_emitted() {
     let resurrected: Vec<_> = historical.intersection(&emitted).collect();
     assert!(
         resurrected.is_empty(),
-        "historical envelope rows are emitted again — move them back to the \
-         shipped table: {resurrected:?}"
+        "historical envelope rows appear in crates/*/src again: {resurrected:?} — \
+         if the envelope genuinely ships again, register a new version; if a \
+         back-compat test cites the id, add it to the test-fixture table"
     );
 }
 
@@ -345,15 +346,24 @@ fn fixture_ids_are_registered_and_disjoint_from_real_rows() {
         fixtures.contains("adoc.search.v99"),
         "the rejected-version fixture id lost its registry row"
     );
+    // Historical ids are excluded from the collision set: a back-compat test
+    // in crates/*/src citing e.g. adoc.retrieval.v0 registers the id in the
+    // fixture table, which must not deadlock against the historical row.
     let real: BTreeSet<String> = ANCHORS
         .iter()
-        .filter(|anchor| **anchor != "registry:test-fixture-ids")
+        .filter(|anchor| {
+            !matches!(
+                **anchor,
+                "registry:test-fixture-ids" | "registry:envelopes-historical"
+            )
+        })
         .flat_map(|anchor| anchored_ids(&registry, anchor))
         .collect();
     let colliding: Vec<_> = fixtures.intersection(&real).collect();
     assert!(
         colliding.is_empty(),
-        "a test-fixture id may never collide with a real contract row: {colliding:?}"
+        "a test-fixture id may never collide with a shipped/planned/code row \
+         (historical ids are the deliberate exception for back-compat tests): {colliding:?}"
     );
 }
 

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -819,10 +819,10 @@ fn fenced_lists_in(section: &str) -> Vec<Vec<String>> {
                 Some(block) => blocks.push(block),
                 None => current = Some(Vec::new()),
             }
-        } else if let Some(block) = current.as_mut() {
-            if !trimmed.is_empty() {
-                block.push(trimmed.to_string());
-            }
+        } else if let Some(block) = current.as_mut()
+            && !trimmed.is_empty()
+        {
+            block.push(trimmed.to_string());
         }
     }
     assert!(

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -97,6 +97,7 @@ const ANCHORS: &[&str] = &[
     "registry:diagnostic-codes",
     "registry:action-codes",
     "registry:gate-codes",
+    "registry:cloud-codes",
     "registry:attestation-codes",
     "registry:dispositions",
     "registry:untrusted-change-states",

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -93,8 +93,10 @@ const ANCHORS: &[&str] = &[
     "registry:envelopes-shipped-action",
     "registry:envelopes-historical",
     "registry:test-fixture-ids",
+    "registry:envelopes-planned",
     "registry:diagnostic-codes",
     "registry:action-codes",
+    "registry:gate-codes",
 ];
 
 /// True for `adoc.<dotted lowercase path>.v<digits>` — the envelope
@@ -397,4 +399,65 @@ fn guard_fires_on_a_malformed_registry_row() {
         result.is_err(),
         "a data row whose first cell is not backticked must fail loudly, never drop silently"
     );
+}
+
+/// The execution map's E0.3 must-include list, resolved to registered ids.
+/// One entry per item in the map's sentence, in its order; the milestone's
+/// T2 planned set adds the remaining reserved names.
+const MUST_INCLUDE_IDS: &[&str] = &[
+    "adoc.semantic_context.v0",       // semantic context
+    "adoc.semantic_assessment.v0",    // semantic assessment
+    "adoc.validation_receipt.v0",     // validation receipt
+    "adoc.lifecycle_mapping.v0",      // lifecycle mapping
+    "adoc.source_record.v0",          // source record
+    "adoc.source_assertion.v0",       // source assertion
+    "adoc.source_acl_snapshot.v0",    // ACL snapshot
+    "adoc.source_binding.v0",         // source binding
+    "adoc.sensitive_access.v0",       // sensitive-access event (RT-08, RT-21)
+    "adoc.egress_policy.v0",          // egress policy (RT-21)
+    "adoc.authorization_decision.v0", // authorization decision
+    "adoc.work_request.v0",           // work request
+    "adoc.work_result.v0",            // work result
+    "adoc.migration_request.v0",      // migration request
+    "adoc.migration_receipt.v0",      // migration receipt
+    "adoc.connector_manifest.v0",     // connector capability manifest
+    "adoc.governance_event.v0",       // governance contract
+    "adoc.proposal.v0",               // proposal contract
+    "adoc.approval.v0",               // approval contract
+    "adoc.gate_result.v0",            // gate contract
+];
+
+#[test]
+fn must_include_contracts_are_registered() {
+    let registered = all_registered_ids(&registry());
+    let missing: Vec<_> = MUST_INCLUDE_IDS
+        .iter()
+        .filter(|id| !registered.contains(**id))
+        .collect();
+    assert!(
+        missing.is_empty(),
+        "EXECUTION-MAP §E0.3 must-include items without a registry row: {missing:?}"
+    );
+}
+
+#[test]
+fn planned_rows_name_exactly_one_owner_repo() {
+    let registry = registry();
+    let open = "<!-- registry:envelopes-planned -->";
+    let close = "<!-- /registry:envelopes-planned -->";
+    let start = registry.find(open).expect("planned anchor") + open.len();
+    let end = registry[start..].find(close).expect("planned close anchor") + start;
+    let mut data_rows = 0;
+    for line in registry[start..end].lines().map(str::trim) {
+        if !line.starts_with("| `") {
+            continue; // header/separator; malformed rows already fail anchored_ids
+        }
+        data_rows += 1;
+        let owner = line.split('|').nth(2).map(str::trim).unwrap_or_default();
+        assert!(
+            matches!(owner, "adoc" | "action" | "cloud"),
+            "planned row must name exactly one owner repo (adoc|action|cloud): {line:?}"
+        );
+    }
+    assert!(data_rows > 0, "the planned table lost its rows");
 }

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -38,26 +38,11 @@ fn registry() -> String {
 /// header row, a separator row, a blank line, or a `| `id` |…` data row is
 /// legal — anything else fails loudly rather than silently dropping a row.
 fn anchored_ids(doc: &str, anchor: &str) -> BTreeSet<String> {
-    let open = format!("<!-- {anchor} -->");
-    let close = format!("<!-- /{anchor} -->");
-    let start = doc
-        .find(&open)
-        .unwrap_or_else(|| panic!("{REGISTRY} is missing the `{open}` anchor"))
-        + open.len();
-    let end = doc[start..]
-        .find(&close)
-        .unwrap_or_else(|| panic!("{REGISTRY} is missing the closing `{close}` anchor"))
-        + start;
-    // A duplicated anchor block (the classic bad merge-conflict resolution)
-    // would make every row in the later block invisible to the scan.
-    assert!(
-        doc[start..].find(&open).is_none(),
-        "{REGISTRY}: `{open}` appears more than once — rows in later blocks are invisible to the scan"
-    );
+    let block = support::doc_scan::anchored_block(doc, REGISTRY, anchor);
 
     let mut ids = BTreeSet::new();
     let mut saw_header = false;
-    for line in doc[start..end].lines().map(str::trim) {
+    for line in block.lines().map(str::trim) {
         if line.is_empty() {
             continue;
         }
@@ -514,12 +499,10 @@ fn must_include_contracts_are_registered() {
 #[test]
 fn planned_rows_name_exactly_one_owner_repo() {
     let registry = registry();
-    let open = "<!-- registry:envelopes-planned -->";
-    let close = "<!-- /registry:envelopes-planned -->";
-    let start = registry.find(open).expect("planned anchor") + open.len();
-    let end = registry[start..].find(close).expect("planned close anchor") + start;
+    let block =
+        support::doc_scan::anchored_block(&registry, REGISTRY, "registry:envelopes-planned");
     let mut data_rows = 0;
-    for line in registry[start..end].lines().map(str::trim) {
+    for line in block.lines().map(str::trim) {
         if !line.starts_with("| `") {
             continue; // header/separator; malformed rows already fail anchored_ids
         }

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -151,10 +151,50 @@ fn rust_sources_under(dir: &Path, sources: &mut Vec<PathBuf>) {
     }
 }
 
-/// Every envelope id appearing in `crates/*/src`, test modules included.
+/// One source file split at its `#[cfg(test)] mod` boundary: everything
+/// above is production scope, the module and everything after it is test
+/// scope. A `#[cfg(test)]` on a single item (a test-only `use` at the file
+/// top) does not split. An out-of-line `#[cfg(test)] mod tests;` would put
+/// production code below it into the wrong scope, so it fails loudly
+/// instead of misclassifying.
+// ponytail: tail-scope split, not brace matching — the workspace convention
+// keeps inline test modules at the file end; production code after one
+// would be counted as test scope (still registered-checked, but outside
+// the shipped equality).
+fn split_test_scope(source: &str) -> (String, String) {
+    let lines: Vec<&str> = source.lines().collect();
+    let boundary = lines.iter().enumerate().position(|(i, line)| {
+        line.trim_start().starts_with("#[cfg(test)]")
+            && lines[i + 1..]
+                .iter()
+                .find(|next| !next.trim().is_empty())
+                .is_some_and(|next| {
+                    let next = next.trim();
+                    let is_module = next.starts_with("mod ") || next.starts_with("pub mod ");
+                    assert!(
+                        !(is_module && next.ends_with(';')),
+                        "out-of-line #[cfg(test)] mod is unsupported by the scan — \
+                         production code after it would be misclassified; use an inline module"
+                    );
+                    is_module
+                })
+    });
+    let split = boundary.unwrap_or(lines.len());
+    (lines[..split].join("\n"), lines[split..].join("\n"))
+}
+
+struct EmittedIds {
+    production: BTreeSet<String>,
+    test_scoped: BTreeSet<String>,
+}
+
+/// Every envelope id appearing in `crates/*/src`, split by scope: production
+/// literals must match the shipped table exactly; test-scoped literals may
+/// additionally cite historical rows (back-compat tests) and registered
+/// fixture ids, but never an unregistered id.
 // ponytail: the walk covers crates/<name>/src only — a build.rs or a nested
 // crate would sit outside it; neither exists in this workspace.
-fn emitted_envelope_ids() -> BTreeSet<String> {
+fn emitted_envelope_ids() -> EmittedIds {
     let crates_dir = repo_root().join("crates");
     let mut sources = Vec::new();
     let entries = fs::read_dir(&crates_dir)
@@ -172,14 +212,18 @@ fn emitted_envelope_ids() -> BTreeSet<String> {
         !sources.is_empty(),
         "no Rust sources found under crates/*/src — the scan would pass vacuously"
     );
-    sources
-        .iter()
-        .flat_map(|path| {
-            let content = fs::read_to_string(path)
-                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
-            envelope_ids_in(&content)
-        })
-        .collect()
+    let mut emitted = EmittedIds {
+        production: BTreeSet::new(),
+        test_scoped: BTreeSet::new(),
+    };
+    for path in &sources {
+        let content = fs::read_to_string(path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        let (production, test) = split_test_scope(&content);
+        emitted.production.extend(envelope_ids_in(&production));
+        emitted.test_scoped.extend(envelope_ids_in(&test));
+    }
+    emitted
 }
 
 /// `Variant = "wire.string" =>` rows from one source text. Comment lines
@@ -232,23 +276,27 @@ fn all_anchors_present() {
 fn shipped_adoc_envelope_rows_match_the_source_scan() {
     let registry = registry();
     let registered = anchored_ids(&registry, "registry:envelopes-shipped-adoc");
-    let fixtures = anchored_ids(&registry, "registry:test-fixture-ids");
-    let emitted: BTreeSet<String> = emitted_envelope_ids()
-        .difference(&fixtures)
-        .cloned()
-        .collect();
+    let emitted = emitted_envelope_ids();
 
-    let unregistered: Vec<_> = emitted.difference(&registered).collect();
+    let unregistered: Vec<_> = emitted.production.difference(&registered).collect();
     assert!(
         unregistered.is_empty(),
-        "envelope ids emitted by crates/*/src without a shipped registry row \
-         in {REGISTRY}: {unregistered:?}"
+        "envelope ids emitted by production code in crates/*/src without a \
+         shipped registry row in {REGISTRY}: {unregistered:?}"
     );
-    let stale: Vec<_> = registered.difference(&emitted).collect();
+    let stale: Vec<_> = registered.difference(&emitted.production).collect();
     assert!(
         stale.is_empty(),
         "shipped adoc envelope rows in {REGISTRY} no longer appear in any \
-         crates/*/src string literal (test modules included): {stale:?}"
+         production string literal in crates/*/src: {stale:?}"
+    );
+
+    let all = all_registered_ids(&registry);
+    let rogue: Vec<_> = emitted.test_scoped.difference(&all).collect();
+    assert!(
+        rogue.is_empty(),
+        "test-scoped envelope ids in crates/*/src without any registry row \
+         (shipped, historical, or test-fixture) in {REGISTRY}: {rogue:?}"
     );
 }
 
@@ -261,17 +309,14 @@ fn historical_envelope_rows_are_no_longer_emitted() {
         "{REGISTRY}: the historical table lost its rows — adoc.retrieval.v0 \
          is a retained documented version"
     );
-    let fixtures = anchored_ids(&registry, "registry:test-fixture-ids");
-    let emitted: BTreeSet<String> = emitted_envelope_ids()
-        .difference(&fixtures)
-        .cloned()
-        .collect();
-    let resurrected: Vec<_> = historical.intersection(&emitted).collect();
+    let emitted = emitted_envelope_ids();
+    let resurrected: Vec<_> = historical.intersection(&emitted.production).collect();
     assert!(
         resurrected.is_empty(),
-        "historical envelope rows appear in crates/*/src again: {resurrected:?} — \
-         if the envelope genuinely ships again, register a new version; if a \
-         back-compat test cites the id, add it to the test-fixture table"
+        "historical envelope rows are emitted from production code again: \
+         {resurrected:?} — a genuinely re-shipped envelope registers a new \
+         version, never revives a retired one (back-compat tests belong in \
+         a test module, where the historical row already covers them)"
     );
 }
 
@@ -331,24 +376,71 @@ fn fixture_ids_are_registered_and_disjoint_from_real_rows() {
         fixtures.contains("adoc.search.v99"),
         "the rejected-version fixture id lost its registry row"
     );
-    // Historical ids are excluded from the collision set: a back-compat test
-    // in crates/*/src citing e.g. adoc.retrieval.v0 registers the id in the
-    // fixture table, which must not deadlock against the historical row.
+    // Scope does the separating now: back-compat tests cite historical rows
+    // from test scope with no fixture row at all, so a fixture id colliding
+    // with ANY real row would only ever blur the inventory.
     let real: BTreeSet<String> = ANCHORS
         .iter()
-        .filter(|anchor| {
-            !matches!(
-                **anchor,
-                "registry:test-fixture-ids" | "registry:envelopes-historical"
-            )
-        })
+        .filter(|anchor| **anchor != "registry:test-fixture-ids")
         .flat_map(|anchor| anchored_ids(&registry, anchor))
         .collect();
     let colliding: Vec<_> = fixtures.intersection(&real).collect();
     assert!(
         colliding.is_empty(),
-        "a test-fixture id may never collide with a shipped/planned/code row \
-         (historical ids are the deliberate exception for back-compat tests): {colliding:?}"
+        "a test-fixture id may never collide with a real contract row: {colliding:?}"
+    );
+    let leaked: Vec<_> = fixtures
+        .intersection(&emitted_envelope_ids().production)
+        .cloned()
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "test-fixture ids emitted from production code — the fixture table \
+         registers test-scope literals only: {leaked:?}"
+    );
+}
+
+#[test]
+fn test_only_use_does_not_split_the_scope() {
+    let fixture = r#"
+        #[cfg(test)]
+        use std::fmt;
+
+        pub const REAL: &str = "adoc.diff.v0";
+    "#;
+    let (production, _) = split_test_scope(fixture);
+    assert!(
+        envelope_ids_in(&production).contains("adoc.diff.v0"),
+        "a test-only use at the file top must not push real emitters into test scope"
+    );
+}
+
+#[test]
+fn tail_test_module_is_test_scope() {
+    let fixture = r#"
+        pub const REAL: &str = "adoc.diff.v0";
+
+        #[cfg(test)]
+        mod tests {
+            const REJECTED_VERSION_FIXTURE: &str = "adoc.search.v99";
+        }
+    "#;
+    let (production, test) = split_test_scope(fixture);
+    assert!(envelope_ids_in(&production).contains("adoc.diff.v0"));
+    assert!(
+        !envelope_ids_in(&production).contains("adoc.search.v99"),
+        "rejected-version fixtures live in test scope"
+    );
+    assert!(envelope_ids_in(&test).contains("adoc.search.v99"));
+}
+
+#[test]
+fn out_of_line_test_module_fails_loudly() {
+    let fixture = "#[cfg(test)]\nmod tests;\npub const LATE: &str = \"adoc.diff.v0\";";
+    let result = std::panic::catch_unwind(|| split_test_scope(fixture));
+    assert!(
+        result.is_err(),
+        "an out-of-line test module would misclassify the code after it — must fail loudly"
     );
 }
 

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -97,6 +97,8 @@ const ANCHORS: &[&str] = &[
     "registry:diagnostic-codes",
     "registry:action-codes",
     "registry:gate-codes",
+    "registry:attestation-codes",
+    "registry:dispositions",
 ];
 
 /// True for `adoc.<dotted lowercase path>.v<digits>` — the envelope
@@ -460,4 +462,101 @@ fn planned_rows_name_exactly_one_owner_repo() {
         );
     }
     assert!(data_rows > 0, "the planned table lost its rows");
+}
+
+/// Backticked codes cited by the executable planning surface, one
+/// `(document, line, code)` per citation. Covers `gate.*`/`action.*` codes
+/// and envelope ids; `attestation.*` siblings are deliberately outside the
+/// net — E8.1.T1 registers them as a registry edit in that slice.
+fn cited_codes() -> Vec<(String, usize, String)> {
+    let dir = repo_root().join("docs/roadmap/v10");
+    let mut cited = Vec::new();
+    let mut entries: Vec<_> = fs::read_dir(&dir)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", dir.display()))
+        .map(|entry| entry.expect("directory entry").path())
+        .filter(|path| path.extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    entries.sort();
+    assert!(!entries.is_empty(), "no v10 planning documents found");
+    for path in entries {
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+        if let Some(opener) = support::doc_scan::unclosed_fence(&content) {
+            panic!("{name}:{opener}: fence never closes — citations past it are invisible");
+        }
+        for (number, line) in support::doc_scan::structural_lines(&content) {
+            for span in line.split('`').skip(1).step_by(2) {
+                let is_reason_code = ["gate.", "action."].iter().any(|prefix| {
+                    span.strip_prefix(prefix).is_some_and(|rest| {
+                        !rest.is_empty() && rest.chars().all(|c| c.is_ascii_lowercase() || c == '_')
+                    })
+                });
+                if is_reason_code || is_envelope_id(span) {
+                    cited.push((name.clone(), number, span.to_string()));
+                }
+            }
+        }
+    }
+    cited
+}
+
+#[test]
+fn cited_codes_resolve_to_registered_entries_only() {
+    let registered = all_registered_ids(&registry());
+    let unresolved: Vec<_> = cited_codes()
+        .into_iter()
+        .filter(|(_, _, code)| !registered.contains(code))
+        .map(|(name, number, code)| format!("{name}:{number}: `{code}`"))
+        .collect();
+    assert!(
+        unresolved.is_empty(),
+        "planning surfaces cite wire codes with no registry row (dispositions count as rows): \n{}",
+        unresolved.join("\n")
+    );
+}
+
+#[test]
+fn semantic_failed_has_exactly_one_disposition() {
+    let registry = registry();
+    let dispositions = anchored_ids(&registry, "registry:dispositions");
+    assert!(
+        dispositions.contains("action.semantic_failed"),
+        "action.semantic_failed lost its disposition row (RT-21: one canonical resolution)"
+    );
+    let row = registry
+        .lines()
+        .find(|line| line.starts_with("| `action.semantic_failed`"))
+        .expect("disposition row");
+    assert!(
+        row.contains("`action.semantic_review_failed`"),
+        "the disposition must name the surviving canonical code: {row:?}"
+    );
+    let action_codes = anchored_ids(&registry, "registry:action-codes");
+    assert!(
+        action_codes.contains("action.semantic_review_failed"),
+        "the surviving code must itself be a registered Action code"
+    );
+    assert!(
+        !action_codes.contains("action.semantic_failed"),
+        "a removed code may never also appear as a registered Action code"
+    );
+}
+
+#[test]
+fn bot_attestation_family_has_one_documented_wrapper_mapping() {
+    let registry = registry();
+    let attestation = anchored_ids(&registry, "registry:attestation-codes");
+    assert!(
+        attestation.contains("attestation.bot_approver_rejected"),
+        "the canonical bot-attestation family root must stay registered (RT-21)"
+    );
+    let wrapper_row = registry
+        .lines()
+        .find(|line| line.starts_with("| `action.attestation_bot_rejected`"))
+        .expect("the Action wrapper code row (E8.1.T3) is registered");
+    assert!(
+        wrapper_row.contains("`attestation.bot_approver_rejected`"),
+        "the Action wrapper row must document its mapping to the canonical code: {wrapper_row:?}"
+    );
 }

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -48,6 +48,12 @@ fn anchored_ids(doc: &str, anchor: &str) -> BTreeSet<String> {
         .find(&close)
         .unwrap_or_else(|| panic!("{REGISTRY} is missing the closing `{close}` anchor"))
         + start;
+    // A duplicated anchor block (the classic bad merge-conflict resolution)
+    // would make every row in the later block invisible to the scan.
+    assert!(
+        doc[start..].find(&open).is_none(),
+        "{REGISTRY}: `{open}` appears more than once — rows in later blocks are invisible to the scan"
+    );
 
     let mut ids = BTreeSet::new();
     let mut saw_header = false;
@@ -59,7 +65,9 @@ fn anchored_ids(doc: &str, anchor: &str) -> BTreeSet<String> {
             panic!("{REGISTRY}: `{anchor}` block contains a non-table line: {line:?}");
         };
         let first_cell = row.split('|').next().unwrap_or_default().trim();
-        if first_cell.chars().all(|c| c == '-' || c == ':') {
+        // An empty first cell must fall through and fail loudly below —
+        // `all()` is vacuously true on "", which would silently drop the row.
+        if !first_cell.is_empty() && first_cell.chars().all(|c| c == '-' || c == ':') {
             continue; // separator row
         }
         if let Some(id) = first_cell
@@ -123,17 +131,20 @@ fn is_envelope_id(candidate: &str) -> bool {
 }
 
 /// Envelope ids appearing as complete double-quoted string literals in one
-/// source text. Quote pairing restarts on every line, so a stray `'"'` char
-/// literal or an escaped quote earlier in the FILE can never desync the
-/// scan and hide a later id — desync is bounded to the one line carrying
-/// it. Whole files are scanned, `#[cfg(test)]` modules included: fixture
-/// ids there are registered rows (the test-fixture table), so a new
-/// unregistered literal fails loudly wherever it sits.
+/// source text. `//` comment lines are skipped (mirroring
+/// `diagnostic_codes_in`) so an id surviving only in a comment cannot keep
+/// a stale shipped row alive. Quote pairing restarts on every line, so a
+/// stray `'"'` char literal or an escaped quote earlier in the FILE can
+/// never desync the scan and hide a later id — desync is bounded to the one
+/// line carrying it. Whole files are scanned, `#[cfg(test)]` modules
+/// included: fixture ids there are registered rows (the test-fixture
+/// table), so a new unregistered literal fails loudly wherever it sits.
 // ponytail: ids built with format!/concat are outside any textual net —
 // the workspace convention is whole-literal schema-version consts.
 fn envelope_ids_in(source: &str) -> BTreeSet<String> {
     source
         .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
         .flat_map(|line| line.split('"').skip(1).step_by(2))
         .filter(|chunk| is_envelope_id(chunk))
         .map(str::to_string)
@@ -251,8 +262,8 @@ fn shipped_adoc_envelope_rows_match_the_source_scan() {
     let stale: Vec<_> = registered.difference(&emitted).collect();
     assert!(
         stale.is_empty(),
-        "shipped adoc envelope rows in {REGISTRY} no longer emitted by any \
-         non-test source: {stale:?}"
+        "shipped adoc envelope rows in {REGISTRY} no longer appear in any \
+         crates/*/src string literal (test modules included): {stale:?}"
     );
 }
 
@@ -404,6 +415,50 @@ fn guard_fires_on_a_malformed_registry_row() {
     assert!(
         result.is_err(),
         "a data row whose first cell is not backticked must fail loudly, never drop silently"
+    );
+}
+
+#[test]
+fn guard_fires_on_a_duplicated_anchor_block() {
+    let duplicated = "\
+<!-- registry:dup -->\n\
+| id | status |\n\
+| --- | --- |\n\
+| `adoc.graph.v5` | shipped |\n\
+<!-- /registry:dup -->\n\
+<!-- registry:dup -->\n\
+| `adoc.diff.v0` | shipped |\n\
+<!-- /registry:dup -->\n";
+    let result = std::panic::catch_unwind(|| anchored_ids(duplicated, "registry:dup"));
+    assert!(
+        result.is_err(),
+        "a duplicated anchor block must fail loudly — later rows are invisible to the scan"
+    );
+}
+
+#[test]
+fn guard_fires_on_an_empty_first_cell() {
+    let broken = "\
+<!-- registry:empty -->\n\
+| id | status |\n\
+| --- | --- |\n\
+|  | shipped |\n\
+<!-- /registry:empty -->\n";
+    let result = std::panic::catch_unwind(|| anchored_ids(broken, "registry:empty"));
+    assert!(
+        result.is_err(),
+        "a data row with an empty first cell must fail loudly, never scan as a separator"
+    );
+}
+
+#[test]
+fn comment_lines_do_not_scan_as_emissions() {
+    let commented = r#"
+        // wire id: "adoc.diff.v0"
+    "#;
+    assert!(
+        envelope_ids_in(commented).is_empty(),
+        "an id surviving only in a line comment must not keep a stale shipped row alive"
     );
 }
 
@@ -565,8 +620,8 @@ fn bot_attestation_family_has_one_documented_wrapper_mapping() {
     );
 }
 
-/// One closed vocabulary pinned exactly: registry rows = the annex list,
-/// in the S8/K9 order, no additions and no losses.
+/// One closed vocabulary pinned exactly: registry rows equal the annex
+/// list, no additions and no losses (sets — document order is not checked).
 fn assert_vocabulary(anchor: &str, annex: &str, expected: &[&str]) {
     let registered = anchored_ids(&registry(), anchor);
     let expected_set: BTreeSet<String> = expected.iter().map(|s| s.to_string()).collect();

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -582,9 +582,8 @@ fn obligations_table_pins_o01() {
     }
     let block =
         support::doc_scan::anchored_block(&content, DECISION_REGISTER, "decisions:obligations");
-    let row = block
-        .lines()
-        .map(str::trim)
+    let row = support::doc_scan::structural_lines(block)
+        .map(|(_, line)| line.trim())
         .find(|line| {
             line.strip_prefix('|')
                 .and_then(|rest| rest.split('|').next())
@@ -608,6 +607,33 @@ fn obligations_table_pins_o01() {
         is_slice_start,
         "{DECISION_REGISTER}: O-01's \"Owed at\" cell must name an executable \
          `E<major>.<minor> slice start`, got {owed_at:?}"
+    );
+    let slice_id = owed_at.strip_suffix(" slice start").unwrap_or_default();
+    let map = read_repo_doc("docs/roadmap/v10/EXECUTION-MAP.md");
+    let heading = format!("## {slice_id} ");
+    assert!(
+        support::doc_scan::structural_lines(&map).any(|(_, line)| line.starts_with(&heading)),
+        "{DECISION_REGISTER}: O-01 is owed at {slice_id}, but the execution map \
+         has no such slice — the obligation points at nothing"
+    );
+}
+
+#[test]
+fn guard_fires_on_a_duplicated_close_marker() {
+    let broken = "\
+<!-- registry:dup-close -->\n\
+| id |\n\
+| --- |\n\
+| `adoc.kept.v0` |\n\
+<!-- /registry:dup-close -->\n\
+| `adoc.lost.v0` | shipped |\n\
+<!-- /registry:dup-close -->\n";
+    let result = std::panic::catch_unwind(|| {
+        support::doc_scan::anchored_block(broken, "fixture", "registry:dup-close").len()
+    });
+    assert!(
+        result.is_err(),
+        "a duplicated close marker orphans the rows between the closes — it must fail loudly"
     );
 }
 

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -1,0 +1,400 @@
+//! Docs-truth guard (E0.3): `docs/roadmap/v10/CONTRACT-REGISTRY.md` is the
+//! single canonical inventory of externally observable wire surfaces — no
+//! envelope schema-version id or Diagnostic Code may be emitted by `adoc`
+//! source without a registry row, and no shipped registry row may outlive
+//! the code that emitted it. The parse targets pinned HTML comment anchors
+//! and backticked first table cells, never free prose.
+
+mod support;
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+const REGISTRY: &str = "docs/roadmap/v10/CONTRACT-REGISTRY.md";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
+}
+
+fn read_repo_doc(relative: &str) -> String {
+    let path = repo_root().join(relative);
+    fs::read_to_string(&path)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()))
+}
+
+/// The registry document, refusing a tree where a fence never closes —
+/// the span from the opener to EOF would be invisible to every check here.
+fn registry() -> String {
+    let content = read_repo_doc(REGISTRY);
+    if let Some(opener) = support::doc_scan::unclosed_fence(&content) {
+        panic!("{REGISTRY}:{opener}: fence never closes — every check below is blind past it");
+    }
+    content
+}
+
+/// Backticked ids from the first cell of the table rows between
+/// `<!-- {anchor} -->` and `<!-- /{anchor} -->`. Between the anchors only a
+/// header row, a separator row, a blank line, or a `| `id` |…` data row is
+/// legal — anything else fails loudly rather than silently dropping a row.
+fn anchored_ids(doc: &str, anchor: &str) -> BTreeSet<String> {
+    let open = format!("<!-- {anchor} -->");
+    let close = format!("<!-- /{anchor} -->");
+    let start = doc
+        .find(&open)
+        .unwrap_or_else(|| panic!("{REGISTRY} is missing the `{open}` anchor"))
+        + open.len();
+    let end = doc[start..]
+        .find(&close)
+        .unwrap_or_else(|| panic!("{REGISTRY} is missing the closing `{close}` anchor"))
+        + start;
+
+    let mut ids = BTreeSet::new();
+    let mut saw_header = false;
+    for line in doc[start..end].lines().map(str::trim) {
+        if line.is_empty() {
+            continue;
+        }
+        let Some(row) = line.strip_prefix('|') else {
+            panic!("{REGISTRY}: `{anchor}` block contains a non-table line: {line:?}");
+        };
+        let first_cell = row.split('|').next().unwrap_or_default().trim();
+        if first_cell.chars().all(|c| c == '-' || c == ':') {
+            continue; // separator row
+        }
+        if let Some(id) = first_cell
+            .strip_prefix('`')
+            .and_then(|rest| rest.strip_suffix('`'))
+        {
+            if !ids.insert(id.to_string()) {
+                panic!("{REGISTRY}: `{anchor}` registers {id:?} twice");
+            }
+        } else if saw_header {
+            panic!("{REGISTRY}: `{anchor}` data row's first cell is not a backticked id: {line:?}");
+        } else {
+            saw_header = true; // exactly one unbackticked header row is legal
+        }
+    }
+    ids
+}
+
+/// Every id registered anywhere in the registry, across all anchored tables.
+fn all_registered_ids(doc: &str) -> BTreeSet<String> {
+    ANCHORS
+        .iter()
+        .flat_map(|anchor| anchored_ids(doc, anchor))
+        .collect()
+}
+
+/// Every anchored id table in the registry. A new table means a new entry
+/// here — `all_anchors_present` fails until the two lists agree.
+const ANCHORS: &[&str] = &[
+    "registry:envelopes-shipped-adoc",
+    "registry:envelopes-shipped-action",
+    "registry:envelopes-historical",
+    "registry:test-fixture-ids",
+    "registry:diagnostic-codes",
+    "registry:action-codes",
+];
+
+/// True for `adoc.<dotted lowercase path>.v<digits>` — the envelope
+/// schema-version id shape and nothing else.
+fn is_envelope_id(candidate: &str) -> bool {
+    let Some(rest) = candidate.strip_prefix("adoc.") else {
+        return false;
+    };
+    let Some((path, version)) = rest.rsplit_once(".v") else {
+        return false;
+    };
+    !path.is_empty()
+        && path
+            .chars()
+            .all(|c| c.is_ascii_lowercase() || c == '_' || c == '.')
+        && !version.is_empty()
+        && version.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Envelope ids appearing as complete double-quoted string literals in one
+/// source text. Quote pairing restarts on every line, so a stray `'"'` char
+/// literal or an escaped quote earlier in the FILE can never desync the
+/// scan and hide a later id — desync is bounded to the one line carrying
+/// it. Whole files are scanned, `#[cfg(test)]` modules included: fixture
+/// ids there are registered rows (the test-fixture table), so a new
+/// unregistered literal fails loudly wherever it sits.
+// ponytail: ids built with format!/concat are outside any textual net —
+// the workspace convention is whole-literal schema-version consts.
+fn envelope_ids_in(source: &str) -> BTreeSet<String> {
+    source
+        .lines()
+        .flat_map(|line| line.split('"').skip(1).step_by(2))
+        .filter(|chunk| is_envelope_id(chunk))
+        .map(str::to_string)
+        .collect()
+}
+
+fn rust_sources_under(dir: &Path, sources: &mut Vec<PathBuf>) {
+    let entries = fs::read_dir(dir)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", dir.display()));
+    for entry in entries {
+        let path = entry
+            .unwrap_or_else(|error| panic!("failed to list {}: {error}", dir.display()))
+            .path();
+        if path.is_dir() {
+            rust_sources_under(&path, sources);
+        } else if path.extension().is_some_and(|ext| ext == "rs") {
+            sources.push(path);
+        }
+    }
+}
+
+/// Every envelope id appearing in `crates/*/src`, test modules included.
+// ponytail: the walk covers crates/<name>/src only — a build.rs or a nested
+// crate would sit outside it; neither exists in this workspace.
+fn emitted_envelope_ids() -> BTreeSet<String> {
+    let crates_dir = repo_root().join("crates");
+    let mut sources = Vec::new();
+    let entries = fs::read_dir(&crates_dir)
+        .unwrap_or_else(|error| panic!("failed to read {}: {error}", crates_dir.display()));
+    for entry in entries {
+        let src = entry
+            .unwrap_or_else(|error| panic!("failed to list {}: {error}", crates_dir.display()))
+            .path()
+            .join("src");
+        if src.is_dir() {
+            rust_sources_under(&src, &mut sources);
+        }
+    }
+    assert!(
+        !sources.is_empty(),
+        "no Rust sources found under crates/*/src — the scan would pass vacuously"
+    );
+    sources
+        .iter()
+        .flat_map(|path| {
+            let content = fs::read_to_string(path)
+                .unwrap_or_else(|error| panic!("failed to read {}: {error}", path.display()));
+            envelope_ids_in(&content)
+        })
+        .collect()
+}
+
+/// `Variant = "wire.string" =>` rows from one source text. Comment lines
+/// are stripped first (the macro's doc comment shows a placeholder row),
+/// then the text is flattened so a rustfmt-wrapped row still parses.
+fn diagnostic_codes_in(content: &str) -> BTreeSet<String> {
+    let flattened = content
+        .lines()
+        .filter(|line| !line.trim_start().starts_with("//"))
+        .flat_map(str::split_whitespace)
+        .collect::<Vec<_>>()
+        .join(" ");
+    let mut codes = BTreeSet::new();
+    let mut rest = flattened.as_str();
+    while let Some(start) = rest.find("= \"") {
+        rest = &rest[start + 3..];
+        let Some(end) = rest.find('"') else { break };
+        let code = &rest[..end];
+        rest = &rest[end + 1..];
+        if rest.trim_start().starts_with("=>") && code.contains('.') {
+            codes.insert(code.to_string());
+        }
+    }
+    codes
+}
+
+/// Every wire code declared in the `diagnostic_codes!` table — one
+/// `Variant = "wire.string" =>` row per code, the single source of truth
+/// the macro expands from.
+fn diagnostic_code_table() -> BTreeSet<String> {
+    let content = read_repo_doc("crates/adoc-core/src/domain/diagnostic.rs");
+    let codes = diagnostic_codes_in(&content);
+    assert!(
+        codes.len() > 100,
+        "diagnostic_codes! parse found only {} rows — the row pattern drifted",
+        codes.len()
+    );
+    codes
+}
+
+#[test]
+fn all_anchors_present() {
+    let registry = registry();
+    for anchor in ANCHORS {
+        anchored_ids(&registry, anchor); // panics on a missing anchor
+    }
+}
+
+#[test]
+fn shipped_adoc_envelope_rows_match_the_source_scan() {
+    let registry = registry();
+    let registered = anchored_ids(&registry, "registry:envelopes-shipped-adoc");
+    let fixtures = anchored_ids(&registry, "registry:test-fixture-ids");
+    let emitted: BTreeSet<String> = emitted_envelope_ids()
+        .difference(&fixtures)
+        .cloned()
+        .collect();
+
+    let unregistered: Vec<_> = emitted.difference(&registered).collect();
+    assert!(
+        unregistered.is_empty(),
+        "envelope ids emitted by crates/*/src without a shipped registry row \
+         in {REGISTRY}: {unregistered:?}"
+    );
+    let stale: Vec<_> = registered.difference(&emitted).collect();
+    assert!(
+        stale.is_empty(),
+        "shipped adoc envelope rows in {REGISTRY} no longer emitted by any \
+         non-test source: {stale:?}"
+    );
+}
+
+#[test]
+fn historical_envelope_rows_are_no_longer_emitted() {
+    let registry = registry();
+    let historical = anchored_ids(&registry, "registry:envelopes-historical");
+    assert!(
+        !historical.is_empty(),
+        "{REGISTRY}: the historical table lost its rows — adoc.retrieval.v0 \
+         is a retained documented version"
+    );
+    let fixtures = anchored_ids(&registry, "registry:test-fixture-ids");
+    let emitted: BTreeSet<String> = emitted_envelope_ids()
+        .difference(&fixtures)
+        .cloned()
+        .collect();
+    let resurrected: Vec<_> = historical.intersection(&emitted).collect();
+    assert!(
+        resurrected.is_empty(),
+        "historical envelope rows are emitted again — move them back to the \
+         shipped table: {resurrected:?}"
+    );
+}
+
+#[test]
+fn action_owned_envelope_rows_are_pinned() {
+    let registry = registry();
+    let registered = anchored_ids(&registry, "registry:envelopes-shipped-action");
+    let expected: BTreeSet<String> = ["adoc.pr_assessment_receipt.v0", "adoc.semantic_review.v0"]
+        .iter()
+        .map(|id| id.to_string())
+        .collect();
+    assert_eq!(
+        registered, expected,
+        "Action-owned shipped envelopes (ADR-0051/ADR-0052) drifted in {REGISTRY}"
+    );
+}
+
+#[test]
+fn diagnostic_code_rows_match_the_code_table() {
+    let registry = registry();
+    let registered = anchored_ids(&registry, "registry:diagnostic-codes");
+    let declared = diagnostic_code_table();
+
+    let unregistered: Vec<_> = declared.difference(&registered).collect();
+    assert!(
+        unregistered.is_empty(),
+        "Diagnostic Codes declared in diagnostic.rs without a registry row \
+         in {REGISTRY}: {unregistered:?}"
+    );
+    let stale: Vec<_> = registered.difference(&declared).collect();
+    assert!(
+        stale.is_empty(),
+        "Diagnostic Code rows in {REGISTRY} with no declaring code table row: {stale:?}"
+    );
+}
+
+#[test]
+fn scan_flags_an_unregistered_wire_code_fixture() {
+    let fixture = r#"
+        pub const ROGUE_SCHEMA_VERSION: &str = "adoc.unregistered.v0";
+    "#;
+    let emitted = envelope_ids_in(fixture);
+    let registered = all_registered_ids(&registry());
+    let unregistered: Vec<_> = emitted.difference(&registered).collect();
+    assert_eq!(
+        unregistered,
+        ["adoc.unregistered.v0"],
+        "the completeness scan must fail on a fixture emitting one unregistered wire code"
+    );
+}
+
+#[test]
+fn fixture_ids_are_registered_and_disjoint_from_real_rows() {
+    let registry = registry();
+    let fixtures = anchored_ids(&registry, "registry:test-fixture-ids");
+    assert!(
+        fixtures.contains("adoc.search.v99"),
+        "the rejected-version fixture id lost its registry row"
+    );
+    let real: BTreeSet<String> = ANCHORS
+        .iter()
+        .filter(|anchor| **anchor != "registry:test-fixture-ids")
+        .flat_map(|anchor| anchored_ids(&registry, anchor))
+        .collect();
+    let colliding: Vec<_> = fixtures.intersection(&real).collect();
+    assert!(
+        colliding.is_empty(),
+        "a test-fixture id may never collide with a real contract row: {colliding:?}"
+    );
+}
+
+#[test]
+fn quote_desync_stays_bounded_to_its_line() {
+    let fixture = r#"
+        const QUOTE: char = '"';
+        pub const REAL: &str = "adoc.diff.v0";
+    "#;
+    assert!(
+        envelope_ids_in(fixture).contains("adoc.diff.v0"),
+        "a char-literal quote on an earlier line must not hide later ids"
+    );
+}
+
+#[test]
+fn wrapped_diagnostic_row_still_parses() {
+    let wrapped = "SomeCode =\n    \"assessment.wrapped_row\" =>\n    \"help\";";
+    assert!(
+        diagnostic_codes_in(wrapped).contains("assessment.wrapped_row"),
+        "a rustfmt-wrapped diagnostic_codes! row must still scan"
+    );
+    let commented = r#"/// carrying `(Variant = "wire.string" => "default help";)`"#;
+    assert!(
+        diagnostic_codes_in(commented).is_empty(),
+        "the macro doc-comment placeholder must never scan as a code"
+    );
+}
+
+#[test]
+fn envelope_id_shape_rejects_prose_and_paths() {
+    for not_an_id in [
+        "adoc.graph",          // no version suffix
+        "adoc.graph.v5.json",  // file name, version not terminal
+        "adoc.Graph.v5",       // uppercase
+        "docs/adoc.graph.v5",  // path prefix
+        "prose adoc.graph.v5", // embedded in prose
+        "adoc..v5",            // empty path
+        "adoc.graph.v",        // empty version
+    ] {
+        assert!(
+            !is_envelope_id(not_an_id),
+            "{not_an_id:?} must not scan as an envelope id"
+        );
+    }
+    assert!(is_envelope_id("adoc.graph.v5"));
+    assert!(is_envelope_id("adoc.mcp.command.v0"));
+}
+
+#[test]
+fn guard_fires_on_a_malformed_registry_row() {
+    let broken = "\
+<!-- registry:broken -->\n\
+| id | status |\n\
+| --- | --- |\n\
+| adoc.graph.v5 | shipped |\n\
+<!-- /registry:broken -->\n";
+    let result = std::panic::catch_unwind(|| anchored_ids(broken, "registry:broken"));
+    assert!(
+        result.is_err(),
+        "a data row whose first cell is not backticked must fail loudly, never drop silently"
+    );
+}

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -568,6 +568,49 @@ fn cited_codes_resolve_to_registered_entries_only() {
     );
 }
 
+/// The decision register's executable obligations table claims O-01 "cannot
+/// silently lapse" — this is what makes that claim true: deleting the row or
+/// blanking its "Owed at" cell fails here (E0.3.T5).
+#[test]
+fn obligations_table_pins_o01() {
+    const DECISION_REGISTER: &str = "docs/roadmap/v10/DECISION-REGISTER.md";
+    let content = read_repo_doc(DECISION_REGISTER);
+    if let Some(opener) = support::doc_scan::unclosed_fence(&content) {
+        panic!(
+            "{DECISION_REGISTER}:{opener}: fence never closes — the table below may be invisible"
+        );
+    }
+    let block =
+        support::doc_scan::anchored_block(&content, DECISION_REGISTER, "decisions:obligations");
+    let row = block
+        .lines()
+        .map(str::trim)
+        .find(|line| {
+            line.strip_prefix('|')
+                .and_then(|rest| rest.split('|').next())
+                .is_some_and(|cell| cell.trim() == "O-01")
+        })
+        .unwrap_or_else(|| {
+            panic!("{DECISION_REGISTER}: the O-01 obligation row is gone — the E4.6 true-up lapsed")
+        });
+    let owed_at = row.split('|').nth(3).map(str::trim).unwrap_or_default();
+    let is_slice_start = owed_at
+        .strip_prefix('E')
+        .and_then(|rest| rest.strip_suffix(" slice start"))
+        .and_then(|slice| slice.split_once('.'))
+        .is_some_and(|(major, minor)| {
+            !major.is_empty()
+                && major.chars().all(|c| c.is_ascii_digit())
+                && !minor.is_empty()
+                && minor.chars().all(|c| c.is_ascii_digit())
+        });
+    assert!(
+        is_slice_start,
+        "{DECISION_REGISTER}: O-01's \"Owed at\" cell must name an executable \
+         `E<major>.<minor> slice start`, got {owed_at:?}"
+    );
+}
+
 #[test]
 fn semantic_failed_has_exactly_one_disposition() {
     let registry = registry();

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -99,6 +99,9 @@ const ANCHORS: &[&str] = &[
     "registry:gate-codes",
     "registry:attestation-codes",
     "registry:dispositions",
+    "registry:untrusted-change-states",
+    "registry:retention-classes",
+    "registry:replay-postures",
 ];
 
 /// True for `adoc.<dotted lowercase path>.v<digits>` — the envelope
@@ -558,5 +561,64 @@ fn bot_attestation_family_has_one_documented_wrapper_mapping() {
     assert!(
         wrapper_row.contains("`attestation.bot_approver_rejected`"),
         "the Action wrapper row must document its mapping to the canonical code: {wrapper_row:?}"
+    );
+}
+
+/// One closed vocabulary pinned exactly: registry rows = the annex list,
+/// in the S8/K9 order, no additions and no losses.
+fn assert_vocabulary(anchor: &str, annex: &str, expected: &[&str]) {
+    let registered = anchored_ids(&registry(), anchor);
+    let expected_set: BTreeSet<String> = expected.iter().map(|s| s.to_string()).collect();
+    assert_eq!(
+        registered, expected_set,
+        "`{anchor}` drifted from the closed vocabulary in {annex} — \
+         a change there is a registry edit plus an annex amendment"
+    );
+}
+
+#[test]
+fn untrusted_change_states_match_s8() {
+    assert_vocabulary(
+        "registry:untrusted-change-states",
+        "SEMANTICS.md §S8",
+        &[
+            "not_required",
+            "awaiting_authorization",
+            "authorized",
+            "running",
+            "completed",
+            "denied",
+            "failed",
+            "expired_after_head_change",
+        ],
+    );
+}
+
+#[test]
+fn retention_classes_match_k9() {
+    assert_vocabulary(
+        "registry:retention-classes",
+        "KNOWLEDGE-MODEL.md §K9",
+        &[
+            "digest_only",
+            "bounded_evidence",
+            "exact_candidate_input",
+            "temporary_processing",
+            "full_source_snapshot",
+        ],
+    );
+}
+
+#[test]
+fn replay_postures_match_k9() {
+    assert_vocabulary(
+        "registry:replay-postures",
+        "KNOWLEDGE-MODEL.md §K9",
+        &[
+            "fully_replayable",
+            "source_access_required",
+            "intentionally_non_replayable",
+            "no_longer_replayable_after_deletion",
+        ],
     );
 }

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -273,6 +273,25 @@ fn all_anchors_present() {
 }
 
 #[test]
+fn anchors_cover_every_registry_table() {
+    let registry = registry();
+    let found: BTreeSet<String> = support::doc_scan::structural_lines(&registry)
+        .filter_map(|(_, line)| {
+            line.trim()
+                .strip_prefix("<!-- registry:")
+                .and_then(|rest| rest.strip_suffix(" -->"))
+                .map(|name| format!("registry:{name}"))
+        })
+        .collect();
+    let declared: BTreeSet<String> = ANCHORS.iter().map(|anchor| anchor.to_string()).collect();
+    assert_eq!(
+        found, declared,
+        "{REGISTRY}: the anchors in the document and the ANCHORS list drifted — \
+         a table outside the list would be invisible to every id check"
+    );
+}
+
+#[test]
 fn shipped_adoc_envelope_rows_match_the_source_scan() {
     let registry = registry();
     let registered = anchored_ids(&registry, "registry:envelopes-shipped-adoc");
@@ -774,6 +793,61 @@ fn bot_attestation_family_has_one_documented_wrapper_mapping() {
     );
 }
 
+/// The annex section opened by `heading` (a `## …` line), up to the next
+/// `## ` heading or EOF. Loud when the heading is missing.
+fn annex_section<'doc>(doc: &'doc str, doc_name: &str, heading: &str) -> &'doc str {
+    let start = doc
+        .find(heading)
+        .unwrap_or_else(|| panic!("{doc_name} lost its `{heading}` section"));
+    let body = &doc[start + heading.len()..];
+    match body.find("\n## ") {
+        Some(end) => &body[..end],
+        None => body,
+    }
+}
+
+/// The fenced blocks inside one annex section, in document order, each as
+/// its non-empty trimmed lines. A simple open/close toggle is enough here:
+/// the K9 lists are bare ``` blocks with one term per line.
+fn fenced_lists_in(section: &str) -> Vec<Vec<String>> {
+    let mut blocks = Vec::new();
+    let mut current: Option<Vec<String>> = None;
+    for line in section.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            match current.take() {
+                Some(block) => blocks.push(block),
+                None => current = Some(Vec::new()),
+            }
+        } else if let Some(block) = current.as_mut() {
+            if !trimmed.is_empty() {
+                block.push(trimmed.to_string());
+            }
+        }
+    }
+    assert!(
+        current.is_none(),
+        "annex section ends inside a fence — the list is invisible past it"
+    );
+    blocks
+}
+
+/// K9's two fenced lists (retention classes, then replay postures), in
+/// document order.
+fn k9_fenced_lists() -> Vec<Vec<String>> {
+    let knowledge_model = read_repo_doc("docs/roadmap/v10/KNOWLEDGE-MODEL.md");
+    let section = annex_section(&knowledge_model, "KNOWLEDGE-MODEL.md", "## K9.");
+    let lists = fenced_lists_in(section);
+    assert_eq!(
+        lists.len(),
+        2,
+        "KNOWLEDGE-MODEL.md §K9 must carry exactly its two fenced lists \
+         (retention classes, replay postures), found {}",
+        lists.len()
+    );
+    lists
+}
+
 /// One closed vocabulary pinned exactly: registry rows equal the annex
 /// list, no additions and no losses (sets — document order is not checked).
 fn assert_vocabulary(anchor: &str, annex: &str, expected: &[&str]) {
@@ -791,44 +865,74 @@ fn untrusted_change_states_match_s8() {
     assert_vocabulary(
         "registry:untrusted-change-states",
         "SEMANTICS.md §S8",
-        &[
-            "not_required",
-            "awaiting_authorization",
-            "authorized",
-            "running",
-            "completed",
-            "denied",
-            "failed",
-            "expired_after_head_change",
-        ],
+        &STATES,
     );
+    // The annex itself must still carry every state — an S8 rename with an
+    // unchanged registry may not pass silently. (S8 lists the states in
+    // prose, so this is a citation check, not a list parse.)
+    let semantics = read_repo_doc("docs/roadmap/v10/SEMANTICS.md");
+    let section = annex_section(&semantics, "SEMANTICS.md", "## S8.");
+    for state in STATES {
+        assert!(
+            section.contains(&format!("`{state}`")),
+            "SEMANTICS.md §S8 no longer cites `{state}` — amend the registry \
+             and the annex together, never one alone"
+        );
+    }
 }
+
+const STATES: [&str; 8] = [
+    "not_required",
+    "awaiting_authorization",
+    "authorized",
+    "running",
+    "completed",
+    "denied",
+    "failed",
+    "expired_after_head_change",
+];
 
 #[test]
 fn retention_classes_match_k9() {
     assert_vocabulary(
         "registry:retention-classes",
         "KNOWLEDGE-MODEL.md §K9",
-        &[
-            "digest_only",
-            "bounded_evidence",
-            "exact_candidate_input",
-            "temporary_processing",
-            "full_source_snapshot",
-        ],
+        &RETENTION_CLASSES,
+    );
+    assert_eq!(
+        k9_fenced_lists()[0],
+        RETENTION_CLASSES,
+        "KNOWLEDGE-MODEL.md §K9's retention-class list drifted from the \
+         registry — amend both together, never one alone"
     );
 }
+
+const RETENTION_CLASSES: [&str; 5] = [
+    "digest_only",
+    "bounded_evidence",
+    "exact_candidate_input",
+    "temporary_processing",
+    "full_source_snapshot",
+];
 
 #[test]
 fn replay_postures_match_k9() {
     assert_vocabulary(
         "registry:replay-postures",
         "KNOWLEDGE-MODEL.md §K9",
-        &[
-            "fully_replayable",
-            "source_access_required",
-            "intentionally_non_replayable",
-            "no_longer_replayable_after_deletion",
-        ],
+        &REPLAY_POSTURES,
+    );
+    assert_eq!(
+        k9_fenced_lists()[1],
+        REPLAY_POSTURES,
+        "KNOWLEDGE-MODEL.md §K9's replay-posture list drifted from the \
+         registry — amend both together, never one alone"
     );
 }
+
+const REPLAY_POSTURES: [&str; 4] = [
+    "fully_replayable",
+    "source_access_required",
+    "intentionally_non_replayable",
+    "no_longer_replayable_after_deletion",
+];

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -776,6 +776,28 @@ fn semantic_failed_has_exactly_one_disposition() {
 }
 
 #[test]
+fn bot_attestation_codes_are_exactly_the_canonical_pair() {
+    let registry = registry();
+    let bot_attestation: BTreeSet<String> = all_registered_ids(&registry)
+        .into_iter()
+        .filter(|id| id.contains("bot") && (id.contains("attestation") || id.contains("approver")))
+        .collect();
+    let canonical: BTreeSet<String> = [
+        "attestation.bot_approver_rejected",
+        "action.attestation_bot_rejected",
+    ]
+    .iter()
+    .map(|id| id.to_string())
+    .collect();
+    assert_eq!(
+        bot_attestation, canonical,
+        "competing bot-attestation suffixes across the registry — the E0.3 \
+         acceptance allows exactly one canonical Cloud code and its one \
+         documented Action wrapper"
+    );
+}
+
+#[test]
 fn bot_attestation_family_has_one_documented_wrapper_mapping() {
     let registry = registry();
     let attestation = anchored_ids(&registry, "registry:attestation-codes");

--- a/crates/adoc-mcp/tests/support/doc_scan.rs
+++ b/crates/adoc-mcp/tests/support/doc_scan.rs
@@ -56,6 +56,31 @@ pub fn unclosed_fence(content: &str) -> Option<usize> {
     open.map(|(line, _, _)| line)
 }
 
+/// The span between `<!-- {anchor} -->` and `<!-- /{anchor} -->` in one
+/// document. Panics loudly (naming `doc_name`) on a missing open or close
+/// marker, and on a second open marker anywhere in the remainder — a
+/// duplicated anchor block (the classic bad merge-conflict resolution)
+/// would make every row in the later block invisible to any scan over the
+/// returned span. One implementation, so the guards' notion of "anchored
+/// block" can never drift apart. Used by `contract_registry_guard`.
+pub fn anchored_block<'a>(doc: &'a str, doc_name: &str, anchor: &str) -> &'a str {
+    let open = format!("<!-- {anchor} -->");
+    let close = format!("<!-- /{anchor} -->");
+    let start = doc
+        .find(&open)
+        .unwrap_or_else(|| panic!("{doc_name} is missing the `{open}` anchor"))
+        + open.len();
+    let end = doc[start..]
+        .find(&close)
+        .unwrap_or_else(|| panic!("{doc_name} is missing the closing `{close}` anchor"))
+        + start;
+    assert!(
+        doc[start..].find(&open).is_none(),
+        "{doc_name}: `{open}` appears more than once — rows in later blocks are invisible to the scan"
+    );
+    &doc[start..end]
+}
+
 /// `Some((fence char, run length))` when the line starts a ``` or ~~~ run of
 /// at least three; trailing text (an info string) is permitted here — whether
 /// it may close a fence is the caller's pairing decision.

--- a/crates/adoc-mcp/tests/support/doc_scan.rs
+++ b/crates/adoc-mcp/tests/support/doc_scan.rs
@@ -78,6 +78,10 @@ pub fn anchored_block<'a>(doc: &'a str, doc_name: &str, anchor: &str) -> &'a str
         doc[start..].find(&open).is_none(),
         "{doc_name}: `{open}` appears more than once — rows in later blocks are invisible to the scan"
     );
+    assert!(
+        doc[end + close.len()..].find(&close).is_none(),
+        "{doc_name}: `{close}` appears more than once — rows between the closes are outside every scan"
+    );
     &doc[start..end]
 }
 

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -63,7 +63,7 @@ Producer for every row is the `adoc` 0.3.4 release train (CLI, MCP server, and l
 
 ## Test-fixture ids — never emitted
 
-Deliberately invalid version fixtures inside `#[cfg(test)]` modules in `crates/*/src`, proving rejected-version handling. The completeness scan subtracts exactly these rows and nothing else. A fixture row may also carry a historical id exercised by back-compat tests; a fixture id must never collide with a shipped or planned id (guard-enforced).
+Deliberately invalid version fixtures cited from test modules in `crates/*/src`, proving rejected-version handling. The completeness scan splits every file at its `#[cfg(test)] mod` boundary: production literals must match the shipped table exactly, and a fixture id emitted from production scope fails the scan. Back-compat tests citing a historical id need no fixture row — the historical table already registers the id — so a fixture id must never collide with any real contract row (guard-enforced).
 
 <!-- registry:test-fixture-ids -->
 | id | status | notes |

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -63,7 +63,7 @@ Producer for every row is the `adoc` 0.3.4 release train (CLI, MCP server, and l
 
 ## Test-fixture ids — never emitted
 
-Deliberately invalid version fixtures inside `#[cfg(test)]` modules in `crates/*/src`, proving rejected-version handling. The completeness scan subtracts exactly these rows and nothing else; a fixture id must never collide with a real contract id (guard-enforced).
+Deliberately invalid version fixtures inside `#[cfg(test)]` modules in `crates/*/src`, proving rejected-version handling. The completeness scan subtracts exactly these rows and nothing else. A fixture row may also carry a historical id exercised by back-compat tests; a fixture id must never collide with a shipped or planned id (guard-enforced).
 
 <!-- registry:test-fixture-ids -->
 | id | status | notes |

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -12,13 +12,13 @@ No externally observable V1 wire code or contract exists outside this registry (
 
 The executable planning surface this registry governs is `docs/roadmap/v10`; preserved historical documents (non-executable per [`EXECUTION-MAP.md`](EXECUTION-MAP.md) §1) may cite retired codes as provenance without a row here.
 
-Field vocabularies enclosed by an envelope (statuses, enum-valued fields) are governed by that envelope's schema and registered through its row; vocabularies observable independently of a single envelope are registered explicitly in §9.
+Field vocabularies enclosed by an envelope (statuses, enum-valued fields) are governed by that envelope's schema and registered through its row; vocabularies observable independently of a single envelope are registered explicitly in the vocabulary sections at the end of this file.
 
-**Statuses:** `shipped` — emitted by a released surface; `planned` — reserved id with an owning E-slice (name adjustments before first implementation are registry edits at slice start); `historical` — no longer emitted, documentation retained; `removed` — never to be emitted again, carried as a disposition (§8).
+**Statuses:** `shipped` — emitted by a released surface; `planned` — reserved id with an owning E-slice (name adjustments before first implementation are registry edits at slice start); `historical` — no longer emitted, documentation retained; `removed` — never to be emitted again, carried as a disposition (see “Dispositions”).
 
 **Version cells** name the minimum–maximum tested producer/consumer releases; a single value means minimum = maximum. **v0-additive** as a migration posture means fields may be added JSON-optionally within the version and any breaking change requires a new registered version id.
 
-## 1. Envelopes — shipped, owner `adoc`
+## Envelopes — shipped, owner `adoc`
 
 Producer for every row is the `adoc` 0.3.4 release train (CLI, MCP server, and local gateway surfaces).
 
@@ -38,13 +38,13 @@ Producer for every row is the `adoc` 0.3.4 release train (CLI, MCP server, and l
 | `adoc.patch.v0` | shipped | adoc 0.3.4 (validator; input authored by agents) | adoc 0.3.4; Action v2.0.0-alpha.19 | v0-additive |
 | `adoc.project.status.v0` | shipped | adoc 0.3.4 | MCP agent clients (contract-tested at adoc 0.3.4) | v0-additive |
 | `adoc.repository_baseline.v0` | shipped | adoc 0.3.4 | Action v2.0.0-alpha.19 | v0-additive; known registration-gap history — the original V10 inventory flagged it unregistered; true-up obligation tracked in [`DECISION-REGISTER.md`](DECISION-REGISTER.md) |
-| `adoc.retrieval.v1` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v1 additive; v0 is historical (§3) |
+| `adoc.retrieval.v1` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v1 additive; v0 is historical (see “Envelopes — historical”) |
 | `adoc.review.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
 | `adoc.search.v1` | shipped | adoc 0.3.4 | adoc 0.3.4 | v1 additive |
 | `adoc.stale.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
 <!-- /registry:envelopes-shipped-adoc -->
 
-## 2. Envelopes — shipped, owner `action`
+## Envelopes — shipped, owner `action`
 
 <!-- registry:envelopes-shipped-action -->
 | id | status | producer (min–max tested) | consumers (min–max tested) | migration posture |
@@ -53,7 +53,7 @@ Producer for every row is the `adoc` 0.3.4 release train (CLI, MCP server, and l
 | `adoc.semantic_review.v0` | shipped | Action v2.0.0-alpha.19 (ADR-0052) | Action report surfaces v2.0.0-alpha.19 | v0-additive; deprecation only via the E8.6 machinery |
 <!-- /registry:envelopes-shipped-action -->
 
-## 3. Envelopes — historical
+## Envelopes — historical
 
 <!-- registry:envelopes-historical -->
 | id | status | notes |
@@ -71,9 +71,39 @@ Deliberately invalid version fixtures inside `#[cfg(test)]` modules in `crates/*
 | `adoc.search.v99` | fixture | rejected-version fixture for Search Artifact version gating |
 <!-- /registry:test-fixture-ids -->
 
-## 4. Diagnostic Codes — shipped, owner `adoc`
+## Envelopes and contracts — planned
 
-Shared row values: producer `adoc` 0.3.4 (`adoc-core` `diagnostic_codes!` table, the single declaring source); consumers are every envelope embedding `Diagnostic` records (CLI/MCP surfaces at adoc 0.3.4, Action v2.0.0-alpha.19 report rendering). Migration posture for every row: wire-stable string — a meaning change or removal requires a disposition row in §8, never reuse.
+Reserved ids for the accepted V1 contract set (E0.3.T2). Each row names its owning repository and the E-slice that implements it; producer/consumer versions are recorded when the owning slice ships its first tested implementation. A name adjustment before first implementation is a registry edit at slice start, never an unregistered rename afterwards.
+
+<!-- registry:envelopes-planned -->
+| id | owner | planned by | notes |
+| --- | --- | --- | --- |
+| `adoc.semantic_context.v0` | adoc | E3.1 | exact revisions, deterministic digests, closed citation handles, coverage diagnostics |
+| `adoc.semantic_assessment.v0` | adoc | E3.2 | provider-neutral typed findings/citations/materiality |
+| `adoc.validation_receipt.v0` | adoc | E1.7 | digest-bound AgentDoc Validation Runtime receipt |
+| `adoc.lifecycle_mapping.v0` | adoc | E1.5 | versioned flat-status ↔ managed mapping/projection with explicit loss |
+| `adoc.source_record.v0` | adoc | E4.1 | immutable source observation |
+| `adoc.source_assertion.v0` | adoc | E4.1 | source assertion bound to its Source Record |
+| `adoc.source_acl_snapshot.v0` | adoc | E2.6 | historical ACL provenance, separate from freshness-bounded authorization |
+| `adoc.source_binding.v0` | adoc | E1.1 | exact source placement binding, independent of the semantic hash |
+| `adoc.sensitive_access.v0` | adoc | E6.3 | name held until a final registered successor (RT-08) |
+| `adoc.egress_policy.v0` | adoc | E6.6 | provenance RT-21: absent from the original V10 inventory |
+| `adoc.authorization_decision.v0` | adoc | E2.2 | `allow`/`deny`/`insufficient_context` decision record |
+| `adoc.work_request.v0` | adoc | E3.7 | versioned external work request with nonce/digest/expiry/workload identity |
+| `adoc.work_result.v0` | adoc | E3.7 | result binding with replay/idempotency state |
+| `adoc.migration_request.v0` | adoc | E7.1 | exact-revision standalone-to-Cloud migration request |
+| `adoc.migration_receipt.v0` | adoc | E7.1 | migration receipt with qualification policy outcome |
+| `adoc.connector_manifest.v0` | adoc | E4.5 | capability manifest bound to exact adapter version and publisher |
+| `adoc.governance_event.v0` | cloud | E4.2 | append-only governance transition record |
+| `adoc.proposal.v0` | cloud | E5.1 | canonical proposal record; includes the typed per-finding no-change disposition record (E5.3.T3) |
+| `adoc.approval.v0` | cloud | E5.2 | native approval bound to exact proposal digest, principal, policy version |
+| `adoc.gate_result.v0` | adoc | E5.3 | four-mode gate decision record carrying registered `gate.*` codes |
+| `adoc.graph.v6` | adoc | E1.1 | successor Graph Artifact separating governed semantic hash from source placement |
+<!-- /registry:envelopes-planned -->
+
+## Diagnostic Codes — shipped, owner `adoc`
+
+Shared row values: producer `adoc` 0.3.4 (`adoc-core` `diagnostic_codes!` table, the single declaring source); consumers are every envelope embedding `Diagnostic` records (CLI/MCP surfaces at adoc 0.3.4, Action v2.0.0-alpha.19 report rendering). Migration posture for every row: wire-stable string — a meaning change or removal requires a row in “Dispositions”, never reuse.
 
 <!-- registry:diagnostic-codes -->
 | code |
@@ -226,9 +256,9 @@ Shared row values: producer `adoc` 0.3.4 (`adoc-core` `diagnostic_codes!` table,
 | `task.overdue` |
 <!-- /registry:diagnostic-codes -->
 
-## 5. Action codes — owner `action`
+## Action codes — owner `action`
 
-Shared row values for shipped rows: producer Action v2.0.0-alpha.19 (workflow annotations, check conclusions, receipt `reason_codes`); consumers are GitHub check/annotation readers and receipt consumers. Migration posture: wire-stable string — meaning change or removal requires a disposition row in §8.
+Shared row values for shipped rows: producer Action v2.0.0-alpha.19 (workflow annotations, check conclusions, receipt `reason_codes`); consumers are GitHub check/annotation readers and receipt consumers. Migration posture: wire-stable string — meaning change or removal requires a row in “Dispositions”.
 
 <!-- registry:action-codes -->
 | code | status | meaning |
@@ -252,8 +282,26 @@ Shared row values for shipped rows: producer Action v2.0.0-alpha.19 (workflow an
 | `action.proposal_rejected` | shipped | proposal rejected by validation |
 | `action.provider_integrity_failed` | shipped | provider binary integrity verification failed |
 | `action.receipt_failed` | shipped | receipt finalization failed |
-| `action.semantic_review_failed` | shipped | semantic review failed; the single canonical Action semantic-failure reason code (§8) |
+| `action.semantic_review_failed` | shipped | semantic review failed; the single canonical Action semantic-failure reason code (see “Dispositions”) |
 | `action.structural_errors_changed` | shipped | structural errors in changed objects |
 | `action.structural_errors_full` | shipped | structural errors in the full graph |
 | `action.unsupported_event` | shipped | unsupported triggering event |
 <!-- /registry:action-codes -->
+
+## Gate codes — planned, owner `adoc`
+
+Contract codes for the four-mode gate evaluator (E5.3; check publication E5.4). The failure matrix is a closed 12-code set fixed red-first at E5.3 slice start; the rows here are the subset already named by the execution map and milestones — the remaining rows register as a registry edit in that slice, never ad hoc.
+
+<!-- registry:gate-codes -->
+| code | status | planned by | meaning |
+| --- | --- | --- | --- |
+| `gate.assessment_missing` | planned | E5.3 | `assessment_required` without a valid complete deterministic + semantic assessment |
+| `gate.semantic_invalid` | planned | E5.3 | semantic assessment present but invalid/incomplete |
+| `gate.proposal_missing` | planned | E5.3 | materially affected finding without a proposal or accepted no-change disposition |
+| `gate.proposal_hash_mismatch` | planned | E5.3 | approval bound to a proposal digest that no longer matches |
+| `gate.approval_invalidated` | planned | E5.3 | semantic content change invalidated a prior approval |
+| `gate.cloud_unavailable` | planned | E5.3 | required Cloud decision input unavailable — blocks, never defaults |
+| `gate.audit_persistence_failed` | planned | E5.3 | decision audit record could not be persisted — blocks |
+| `gate.mode_unknown` | planned | E5.3 | unknown gate mode string is a configuration error, never a fallback |
+| `gate.check_publish_failed` | planned | E5.4 | required check could not publish; blocks by absence, recorded for diagnosability |
+<!-- /registry:gate-codes -->

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -308,6 +308,16 @@ Contract codes for the four-mode gate evaluator (E5.3; check publication E5.4). 
 | `gate.check_publish_failed` | planned | E5.4 | required check could not publish; blocks by absence, recorded for diagnosability |
 <!-- /registry:gate-codes -->
 
+## Cloud codes — owner `cloud`
+
+Operation labels of the private Cloud scaffold. The scaffold's `main` emits no wire code today (the E0.4 baseline: login/register tracers, workspaces table, creator/owner-only RLS); new Cloud wire codes register here before they ship — the row below pre-registers the label the in-flight identity-bootstrap work introduces.
+
+<!-- registry:cloud-codes -->
+| code | status | meaning |
+| --- | --- | --- |
+| `workspace.bootstrap` | planned (in-flight scaffold work) | identity-bootstrap ledger operation label recorded when a workspace is created |
+<!-- /registry:cloud-codes -->
+
 ## Attestation codes — planned, owner `cloud`
 
 The canonical bot-attestation code family root (RT-21, E0.3.T3). The Action never mints its own bot-attestation family: its check surface wraps this code via the registered `action.attestation_bot_rejected` row above. The E8.1 attestation record contract and the sibling codes (`attestation.binding_mismatch`, `attestation.requirements_unmet`) register at E8.1.T1 as a registry edit, flipping this row from planned to implemented rather than re-registering it.

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -327,3 +327,47 @@ Codes resolved out of existence (RT-21). A disposition is permanent: the id is n
 | --- | --- |
 | `action.semantic_failed` | removed — appeared only in pre-V10 planning text and never shipped (no occurrence in Action v2.0.0-alpha.19 sources); the shipped registered code `action.semantic_review_failed` is the single canonical Action semantic-failure reason code, and any gate-matrix or planning reference resolves there |
 <!-- /registry:dispositions -->
+
+## Untrusted-change states — owner `adoc` contracts, produced by `action`/`cloud`
+
+The closed S8 state vocabulary for the base-controlled trusted workflow ([`SEMANTICS.md §S8`](SEMANTICS.md#s8-base-controlled-trusted-workflow-for-untrusted-changes), E3.8). A new state is a registry edit plus an S8 amendment, never an ad hoc string.
+
+<!-- registry:untrusted-change-states -->
+| state |
+| --- |
+| `not_required` |
+| `awaiting_authorization` |
+| `authorized` |
+| `running` |
+| `completed` |
+| `denied` |
+| `failed` |
+| `expired_after_head_change` |
+<!-- /registry:untrusted-change-states -->
+
+## Source retention classes — owner `adoc` contracts, enforced by `cloud`
+
+The closed K9 retention-class vocabulary ([`KNOWLEDGE-MODEL.md §K9`](KNOWLEDGE-MODEL.md#k9-policy-driven-layered-source-retention), E6.6). Full source mirroring stays exceptional and disabled by default.
+
+<!-- registry:retention-classes -->
+| class |
+| --- |
+| `digest_only` |
+| `bounded_evidence` |
+| `exact_candidate_input` |
+| `temporary_processing` |
+| `full_source_snapshot` |
+<!-- /registry:retention-classes -->
+
+## Replay postures — owner `adoc` contracts, recorded by `cloud`
+
+The closed K9 replay-posture vocabulary. A digest-only record is never `fully_replayable`; deleting retained evidence appends a deletion/tombstone event and updates the posture without rewriting governance history.
+
+<!-- registry:replay-postures -->
+| posture |
+| --- |
+| `fully_replayable` |
+| `source_access_required` |
+| `intentionally_non_replayable` |
+| `no_longer_replayable_after_deletion` |
+<!-- /registry:replay-postures -->

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -286,6 +286,8 @@ Shared row values for shipped rows: producer Action v2.0.0-alpha.19 (workflow an
 | `action.structural_errors_changed` | shipped | structural errors in changed objects |
 | `action.structural_errors_full` | shipped | structural errors in the full graph |
 | `action.unsupported_event` | shipped | unsupported triggering event |
+| `action.cloud_sync_failed` | planned (E3.7) | Cloud hand-off upload failed; local assessment preserved and annotated, never failed retroactively |
+| `action.attestation_bot_rejected` | planned (E8.1) | Action check wrapper for the canonical Cloud code `attestation.bot_approver_rejected` — one documented mapping, no competing suffix |
 <!-- /registry:action-codes -->
 
 ## Gate codes — planned, owner `adoc`
@@ -305,3 +307,23 @@ Contract codes for the four-mode gate evaluator (E5.3; check publication E5.4). 
 | `gate.mode_unknown` | planned | E5.3 | unknown gate mode string is a configuration error, never a fallback |
 | `gate.check_publish_failed` | planned | E5.4 | required check could not publish; blocks by absence, recorded for diagnosability |
 <!-- /registry:gate-codes -->
+
+## Attestation codes — planned, owner `cloud`
+
+The canonical bot-attestation code family root (RT-21, E0.3.T3). The Action never mints its own bot-attestation family: its check surface wraps this code via the registered `action.attestation_bot_rejected` row above. The E8.1 attestation record contract and the sibling codes (`attestation.binding_mismatch`, `attestation.requirements_unmet`) register at E8.1.T1 as a registry edit, flipping this row from planned to implemented rather than re-registering it.
+
+<!-- registry:attestation-codes -->
+| code | status | planned by | meaning |
+| --- | --- | --- | --- |
+| `attestation.bot_approver_rejected` | planned | E8.1 | bot/service approver rejected by default for approval attestation |
+<!-- /registry:attestation-codes -->
+
+## Dispositions
+
+Codes resolved out of existence (RT-21). A disposition is permanent: the id is never reused with another meaning.
+
+<!-- registry:dispositions -->
+| code | disposition |
+| --- | --- |
+| `action.semantic_failed` | removed — appeared only in pre-V10 planning text and never shipped (no occurrence in Action v2.0.0-alpha.19 sources); the shipped registered code `action.semantic_review_failed` is the single canonical Action semantic-failure reason code, and any gate-matrix or planning reference resolves there |
+<!-- /registry:dispositions -->

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -1,0 +1,259 @@
+# Product V1 Contract and Wire-Code Registry
+
+**Status:** Accepted — canonical wire inventory (E0.3)  
+**Date:** 2026-08-22  
+**Registry version:** 1  
+**Authority:** [`EXECUTION-MAP.md`](EXECUTION-MAP.md) §E0.3 · corrections provenance [`RED-TEAM-CLOSURE.md §RT-21`](RED-TEAM-CLOSURE.md#rt-21--contract-inventory-corrections-from-original-pr-review)  
+**Guards:** `crates/adoc-mcp/tests/contract_registry_guard.rs` (`adoc`) and the completeness-scan CI referencing this file from `agentdoc-dev/action` and `agentdoc-dev/cloud` (E0.3.T5)
+
+## Registry rule
+
+No externally observable V1 wire code or contract exists outside this registry (E0.3 exit gate). A new envelope, Diagnostic Code, event code, state vocabulary entry, retention class, or replay posture ships only together with its row here; the guards fail any repository emitting a code this file does not carry.
+
+The executable planning surface this registry governs is `docs/roadmap/v10`; preserved historical documents (non-executable per [`EXECUTION-MAP.md`](EXECUTION-MAP.md) §1) may cite retired codes as provenance without a row here.
+
+Field vocabularies enclosed by an envelope (statuses, enum-valued fields) are governed by that envelope's schema and registered through its row; vocabularies observable independently of a single envelope are registered explicitly in §9.
+
+**Statuses:** `shipped` — emitted by a released surface; `planned` — reserved id with an owning E-slice (name adjustments before first implementation are registry edits at slice start); `historical` — no longer emitted, documentation retained; `removed` — never to be emitted again, carried as a disposition (§8).
+
+**Version cells** name the minimum–maximum tested producer/consumer releases; a single value means minimum = maximum. **v0-additive** as a migration posture means fields may be added JSON-optionally within the version and any breaking change requires a new registered version id.
+
+## 1. Envelopes — shipped, owner `adoc`
+
+Producer for every row is the `adoc` 0.3.4 release train (CLI, MCP server, and local gateway surfaces).
+
+<!-- registry:envelopes-shipped-adoc -->
+| id | status | producer (min–max tested) | consumers (min–max tested) | migration posture |
+| --- | --- | --- | --- | --- |
+| `adoc.change_assessment.v0` | shipped | adoc 0.3.4 | Action v2.0.0-alpha.19; Cloud ingestion planned (E4.6) | v0-additive |
+| `adoc.contradictions.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+| `adoc.diff.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+| `adoc.graph.traversal.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+| `adoc.graph.v5` | shipped | adoc 0.3.4 | adoc 0.3.4; Action v2.0.0-alpha.19 | frozen at v5; `adoc.graph.v6` (E1.1) ships with deterministic v5→v6 migration fixtures |
+| `adoc.impacted.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+| `adoc.mcp.command.v0` | shipped | adoc 0.3.4 | MCP agent clients (contract-tested at adoc 0.3.4) | v0-additive |
+| `adoc.migrate.report.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+| `adoc.patch.apply.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4; Action v2.0.0-alpha.19 | v0-additive |
+| `adoc.patch.check.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4; Action v2.0.0-alpha.19 | v0-additive |
+| `adoc.patch.v0` | shipped | adoc 0.3.4 (validator; input authored by agents) | adoc 0.3.4; Action v2.0.0-alpha.19 | v0-additive |
+| `adoc.project.status.v0` | shipped | adoc 0.3.4 | MCP agent clients (contract-tested at adoc 0.3.4) | v0-additive |
+| `adoc.repository_baseline.v0` | shipped | adoc 0.3.4 | Action v2.0.0-alpha.19 | v0-additive; known registration-gap history — the original V10 inventory flagged it unregistered; true-up obligation tracked in [`DECISION-REGISTER.md`](DECISION-REGISTER.md) |
+| `adoc.retrieval.v1` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v1 additive; v0 is historical (§3) |
+| `adoc.review.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+| `adoc.search.v1` | shipped | adoc 0.3.4 | adoc 0.3.4 | v1 additive |
+| `adoc.stale.v0` | shipped | adoc 0.3.4 | CLI/MCP agent clients at adoc 0.3.4 | v0-additive |
+<!-- /registry:envelopes-shipped-adoc -->
+
+## 2. Envelopes — shipped, owner `action`
+
+<!-- registry:envelopes-shipped-action -->
+| id | status | producer (min–max tested) | consumers (min–max tested) | migration posture |
+| --- | --- | --- | --- | --- |
+| `adoc.pr_assessment_receipt.v0` | shipped | Action v2.0.0-alpha.19 (ADR-0051) | Action report/enforce surfaces v2.0.0-alpha.19; Cloud ingestion planned (E4.6) | v0-additive |
+| `adoc.semantic_review.v0` | shipped | Action v2.0.0-alpha.19 (ADR-0052) | Action report surfaces v2.0.0-alpha.19 | v0-additive; deprecation only via the E8.6 machinery |
+<!-- /registry:envelopes-shipped-action -->
+
+## 3. Envelopes — historical
+
+<!-- registry:envelopes-historical -->
+| id | status | notes |
+| --- | --- | --- |
+| `adoc.retrieval.v0` | historical | superseded by `adoc.retrieval.v1`; the v0 schema stays published at `docs/agent/v0/schema/retrieval-envelope.v0.json` for readers of retained output |
+<!-- /registry:envelopes-historical -->
+
+## Test-fixture ids — never emitted
+
+Deliberately invalid version fixtures inside `#[cfg(test)]` modules in `crates/*/src`, proving rejected-version handling. The completeness scan subtracts exactly these rows and nothing else; a fixture id must never collide with a real contract id (guard-enforced).
+
+<!-- registry:test-fixture-ids -->
+| id | status | notes |
+| --- | --- | --- |
+| `adoc.search.v99` | fixture | rejected-version fixture for Search Artifact version gating |
+<!-- /registry:test-fixture-ids -->
+
+## 4. Diagnostic Codes — shipped, owner `adoc`
+
+Shared row values: producer `adoc` 0.3.4 (`adoc-core` `diagnostic_codes!` table, the single declaring source); consumers are every envelope embedding `Diagnostic` records (CLI/MCP surfaces at adoc 0.3.4, Action v2.0.0-alpha.19 report rendering). Migration posture for every row: wire-stable string — a meaning change or removal requires a disposition row in §8, never reuse.
+
+<!-- registry:diagnostic-codes -->
+| code |
+| --- |
+| `api.verified_missing_schema_evidence` |
+| `assessment.base_partial` |
+| `assessment.changed_set_failed` |
+| `assessment.comparison_base_unavailable` |
+| `assessment.graph_failed` |
+| `assessment.head_invalid` |
+| `assessment.invalid_changed_path` |
+| `assessment.invalid_config_path` |
+| `assessment.ref_unresolved` |
+| `assessment.snapshot_failed` |
+| `build.embeddings_cache_ignored` |
+| `build.embeddings_cached` |
+| `build.embeddings_skipped` |
+| `claim.evidence_quality_low` |
+| `claim.status_casing` |
+| `claim.verified_missing_evidence` |
+| `compat.raw_html_quarantined` |
+| `compat.unknown_extension` |
+| `compat.unsafe_image_src_dropped` |
+| `compat.unsafe_link_dropped` |
+| `embed.compute_failed` |
+| `embed.model_load_failed` |
+| `embed.unexpected_dim` |
+| `evidence.hash_drift` |
+| `evidence.hash_invalid` |
+| `evidence.hash_target_missing` |
+| `evidence.hash_unverifiable` |
+| `graph.object_not_found` |
+| `id.duplicate` |
+| `id.duplicate_in_artifact` |
+| `id.invalid` |
+| `impacted.git_unavailable` |
+| `impacted.invalid_path` |
+| `impacted.ref_unresolvable` |
+| `io.artifact_malformed` |
+| `io.artifact_missing` |
+| `io.artifact_unreadable` |
+| `io.source_path_unsafe` |
+| `io.unreadable_directory` |
+| `io.unreadable_file` |
+| `io.unsupported_source_extension` |
+| `lifecycle.expired` |
+| `lifecycle.invalid_expires_at` |
+| `mcp.patch_apply_disabled` |
+| `migrate.broken_link` |
+| `migrate.export_typed_blocks_present` |
+| `migrate.raw_html_quarantined` |
+| `migrate.source_not_committed` |
+| `migrate.target_exists` |
+| `migrate.unrecognized_extension` |
+| `parse.malformed_field` |
+| `parse.malformed_markdown` |
+| `parse.malformed_open_fence` |
+| `parse.malformed_page_annotation` |
+| `parse.nested_typed_block` |
+| `parse.raw_html` |
+| `parse.unclosed_fence` |
+| `parse.unsafe_link` |
+| `patch.base_hash_mismatch` |
+| `patch.create_missing_placement` |
+| `patch.invalid_document` |
+| `patch.placement_invalid` |
+| `patch.placement_not_adoc` |
+| `patch.source_drift` |
+| `patch.target_already_exists` |
+| `patch.validation_failed` |
+| `procedure.verified_missing_evidence` |
+| `ref.broken` |
+| `retrieval.no_knowledge_objects_consider_migration` |
+| `retrieval.object_not_found` |
+| `schema.agent_instruction_actions_not_disjoint` |
+| `schema.agent_instruction_invalid_trust` |
+| `schema.agent_instruction_missing_allowed_actions` |
+| `schema.agent_instruction_missing_forbidden_actions` |
+| `schema.agent_instruction_missing_scope` |
+| `schema.agent_instruction_missing_trust` |
+| `schema.api_conflicting_method_and_interface_type` |
+| `schema.api_conflicting_path_and_symbol` |
+| `schema.api_invalid_method` |
+| `schema.api_invalid_path` |
+| `schema.api_missing_method_or_interface_type` |
+| `schema.api_missing_path_or_symbol` |
+| `schema.claim_contradicted_by_unresolved` |
+| `schema.constraint_invalid_severity` |
+| `schema.constraint_missing_severity` |
+| `schema.contradiction_claim_not_a_claim` |
+| `schema.contradiction_claim_not_found` |
+| `schema.contradiction_claims_too_few` |
+| `schema.contradiction_invalid_severity` |
+| `schema.contradiction_invalid_status` |
+| `schema.contradiction_missing_claims` |
+| `schema.contradiction_missing_severity` |
+| `schema.contradiction_missing_status` |
+| `schema.duplicate_field` |
+| `schema.evidence_target_not_a_source` |
+| `schema.evidence_target_not_found` |
+| `schema.example_invalid_lang` |
+| `schema.example_invalid_sandbox` |
+| `schema.example_missing_lang` |
+| `schema.example_verified_requires_checks` |
+| `schema.example_verified_requires_sandbox` |
+| `schema.impacts_empty` |
+| `schema.impacts_invalid_path` |
+| `schema.invalid_status` |
+| `schema.missing_field` |
+| `schema.observation_invalid_observed_at` |
+| `schema.observation_invalid_sample_size` |
+| `schema.observation_invalid_status` |
+| `schema.observation_missing_status` |
+| `schema.policy_future_effective_at` |
+| `schema.policy_invalid_effective_at` |
+| `schema.policy_invalid_review_interval` |
+| `schema.policy_missing_approved_by` |
+| `schema.policy_missing_body` |
+| `schema.policy_missing_effective_at` |
+| `schema.policy_missing_owner` |
+| `schema.policy_missing_status` |
+| `schema.policy_review_overdue` |
+| `schema.procedure_body_must_start_with_ordered_list` |
+| `schema.procedure_missing_body` |
+| `schema.procedure_missing_status` |
+| `schema.question_answered_missing_resolved_by` |
+| `schema.question_missing_status` |
+| `schema.question_resolved_by_not_found` |
+| `schema.question_resolved_by_wrong_kind` |
+| `schema.question_unexpected_resolved_by` |
+| `schema.source_conflicting_path_and_url` |
+| `schema.source_invalid_kind` |
+| `schema.source_invalid_path` |
+| `schema.source_invalid_url` |
+| `schema.source_kind_target_mismatch` |
+| `schema.source_missing_kind` |
+| `schema.source_missing_path_or_url` |
+| `schema.task_invalid_due` |
+| `schema.task_invalid_status` |
+| `schema.task_missing_owner` |
+| `schema.task_missing_status` |
+| `schema.unknown_kind` |
+| `schema.unsupported_version` |
+| `search.artifact_missing` |
+| `search.deterministic_quality` |
+| `search.hash_drift` |
+| `search.invalid_filter` |
+| `search.invalid_scope` |
+| `search.model_mismatch` |
+| `task.overdue` |
+<!-- /registry:diagnostic-codes -->
+
+## 5. Action codes — owner `action`
+
+Shared row values for shipped rows: producer Action v2.0.0-alpha.19 (workflow annotations, check conclusions, receipt `reason_codes`); consumers are GitHub check/annotation readers and receipt consumers. Migration posture: wire-stable string — meaning change or removal requires a disposition row in §8.
+
+<!-- registry:action-codes -->
+| code | status | meaning |
+| --- | --- | --- |
+| `action.assessment_contract_failed` | shipped | assessment envelope violated its contract |
+| `action.assessment_not_evaluated` | shipped | assessment did not run for the change set |
+| `action.assessment_partial` | shipped | assessment completed with partial coverage |
+| `action.assessment_ref_failed` | shipped | assessment base/head ref resolution failed |
+| `action.baseline_contract_failed` | shipped | repository baseline envelope violated its contract |
+| `action.baseline_not_ready` | shipped | repository baseline not yet available for this head |
+| `action.baseline_unavailable` | shipped | repository baseline could not be produced |
+| `action.bootstrap_dirty` | shipped | bootstrap found a dirty working tree |
+| `action.install_failed` | shipped | toolchain/provider installation failed |
+| `action.invalid_input` | shipped | Action inputs invalid |
+| `action.knowledge_delivery_failed` | shipped | knowledge proposal delivery failed |
+| `action.knowledge_proposal_incomplete` | shipped | knowledge proposal set incomplete |
+| `action.knowledge_review_incomplete` | shipped | knowledge review incomplete |
+| `action.knowledge_sync_pending` | shipped | knowledge synchronization still pending |
+| `action.path_limit_exceeded` | shipped | changed-path limit exceeded |
+| `action.proposal_failed` | shipped | proposal creation failed |
+| `action.proposal_rejected` | shipped | proposal rejected by validation |
+| `action.provider_integrity_failed` | shipped | provider binary integrity verification failed |
+| `action.receipt_failed` | shipped | receipt finalization failed |
+| `action.semantic_review_failed` | shipped | semantic review failed; the single canonical Action semantic-failure reason code (§8) |
+| `action.structural_errors_changed` | shipped | structural errors in changed objects |
+| `action.structural_errors_full` | shipped | structural errors in the full graph |
+| `action.unsupported_event` | shipped | unsupported triggering event |
+<!-- /registry:action-codes -->

--- a/docs/roadmap/v10/DECISION-REGISTER.md
+++ b/docs/roadmap/v10/DECISION-REGISTER.md
@@ -76,9 +76,11 @@ The 2026-08-12 planning session produced D01–D35. The 2026-08-13 red-team prod
 
 Decision work owed at a named slice start, tracked here so it cannot silently lapse (E0.3.T5).
 
+<!-- decisions:obligations -->
 | ID | Obligation | Owed at | Provenance |
 | --- | --- | --- | --- |
 | O-01 | Repository-readiness true-up for `adoc.repository_baseline.v0`, which shipped in PR #140 without a decision record or contract registration: a retroactive ADR, a published schema, and a parity test must exist before Cloud ingestion consumes the envelope. Registry row: [`CONTRACT-REGISTRY.md`](CONTRACT-REGISTRY.md). | E4.6 slice start | V10.1.6 (historical), RT-21 |
+<!-- /decisions:obligations -->
 
 ## Required post-V1 commitments
 

--- a/docs/roadmap/v10/DECISION-REGISTER.md
+++ b/docs/roadmap/v10/DECISION-REGISTER.md
@@ -16,6 +16,7 @@ The 2026-08-12 planning session produced D01–D35. The 2026-08-13 red-team prod
 - [`ADDENDUM.md`](ADDENDUM.md)
 - [`BOUNDARY-AMENDMENTS.md`](BOUNDARY-AMENDMENTS.md)
 - [`RED-TEAM-CLOSURE.md`](RED-TEAM-CLOSURE.md)
+- [`CONTRACT-REGISTRY.md`](CONTRACT-REGISTRY.md)
 
 ## D01–D09 — authorization, canonicality, gates
 
@@ -70,6 +71,14 @@ The 2026-08-12 planning session produced D01–D35. The 2026-08-13 red-team prod
 - **D37:** content versions are immutable; governance/verification/effectivity/freshness/integrity/sync transitions are append-only events over content versions.
 - **D38:** authorization uses one deterministic precedence with source ACL as ceiling, scope specificity, expiry, explicit restrictions, and fail-closed consequential uncertainty.
 - **D39:** human semantic assessment may self-assess only where policy allows; an independent-review obligation requires a distinct eligible principal.
+
+## Executable decision obligations
+
+Decision work owed at a named slice start, tracked here so it cannot silently lapse (E0.3.T5).
+
+| ID | Obligation | Owed at | Provenance |
+| --- | --- | --- | --- |
+| O-01 | Repository-readiness true-up for `adoc.repository_baseline.v0`, which shipped in PR #140 without a decision record or contract registration: a retroactive ADR, a published schema, and a parity test must exist before Cloud ingestion consumes the envelope. Registry row: [`CONTRACT-REGISTRY.md`](CONTRACT-REGISTRY.md). | E4.6 slice start | V10.1.6 (historical), RT-21 |
 
 ## Required post-V1 commitments
 


### PR DESCRIPTION
Implements execution-map slice **E0.3 — Canonical contract/code inventory** (adoc side; the `action`/`cloud` completeness-scan CI lands as sibling PRs referencing this registry).

## What this adds

- **`docs/roadmap/v10/CONTRACT-REGISTRY.md`** — the single versioned inventory of externally observable wire surfaces: 17 shipped adoc envelopes, the 2 Action-owned envelopes (ADR-0051/ADR-0052), the retained historical `adoc.retrieval.v0`, all 146 Diagnostic Codes, 23 shipped + 2 planned Action codes, the planned V1 contract set (21 reserved ids with owners and owning E-slices), planned `gate.*` codes, the canonical bot-attestation family, the pre-registered Cloud identity-bootstrap label, and the S8/K9 closed vocabularies.
- **`crates/adoc-mcp/tests/contract_registry_guard.rs`** — the completeness scan: envelope ids emitted by `crates/*/src` and the `diagnostic_codes!` table must match the registry exactly (both directions); every `gate.*`/`action.*`/envelope citation in the v10 planning surface must resolve to a registry row; the S8 states, K9 retention classes, and K9 replay postures are pinned exactly; fixtures prove the scan fails on one unregistered wire code.
- **`action.semantic_failed` disposition (T3)** — removed in favor of the shipped, registered `action.semantic_review_failed` (the code never shipped; Action v2.0.0-alpha.19 sources contain no occurrence). The registry carries the disposition permanently; the guard enforces exactly one resolution.
- **Decision obligation O-01 (T5)** — the V10.1.6 repository-readiness true-up for `adoc.repository_baseline.v0` (retroactive ADR + published schema + parity test before Cloud ingestion consumes it), recorded in DECISION-REGISTER, owed at E4.6 slice start.

## Tracer bullets → commits

One conventional commit per bullet, each individually green (fmt + clippy `-D warnings` + full workspace tests):

- `E0.3.T1` — registry seeded with every shipped contract + failing-first completeness scan
- `E0.3.T2` — planned V1 contract set registered with owners
- `E0.3.T3` — `action.semantic_failed` disposition + bot-attestation family and its one documented Action wrapper mapping
- `E0.3.T4` — S8 untrusted-change states, K9 retention classes, K9 replay postures
- `E0.3.T5` — repository-readiness decision obligation (O-01) + the Cloud scaffold operation label the cloud scan verifies against

## Exit gate

No externally observable V1 wire code or contract exists outside the registry: the adoc guard proves it for this repo; agentdoc-dev/action and agentdoc-dev/cloud enforce it in CI against this same file (sibling PRs, merge after this one).

## Out of scope (per the milestone card)

No registered contract is implemented here, and the legacy semantic-review contract is not deprecated (that requires the E8.6 machinery).


## Hardening (pre-PR adversarial self-audit)

Three audit agents reviewed the branch before this PR; their confirmed findings are folded in: per-line quote pairing (a stray quote character earlier in a file can no longer desync the scan), whole-file scanning with registered test-fixture ids instead of a truncation heuristic, a flatten-parse for the diagnostic table that survives rustfmt wrapping, unclosed-fence alarms on every consumed document, and two registry corrections (the macro doc-comment placeholder no longer scans as a code; the Cloud identity-bootstrap label is registered as planned, not shipped, because cloud main emits no wire code today).

https://claude.ai/code/session_014KAAWeoJLseTv1Jrtc32pm
