### PR TITLE
E1.2 — Workspace-qualified managed Object identity contract

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -183,7 +183,7 @@ The identity of one immutable Source Assertion extracted from a Source Artifact 
 _Avoid_: Source Binding synonym, assertion as Knowledge Object, mutable assertion
 
 **Managed Repository Record**:
-One imported repository inside a Cloud workspace (`ManagedRepositoryRecord` in `adoc-core`), keyed on the Graph Artifact's `repository_identity` — `{kind, config_path}` or explicit `null`, required since v5 (ADR-0049). The record is the binding slot: it can be reserved before the first artifact arrives (V10.3.2), and its Object IDs stay repository-local — the same ID in another repository is a different **Managed Object**, never silently merged.
+One imported repository inside a Cloud workspace (`ManagedRepositoryRecord` in `adoc-core`), keyed on the Graph Artifact's `repository_identity` — `{kind, config_path}` or explicit `null`, required since v5 (ADR-0049). The record is the binding slot: it can be reserved before the first artifact arrives (V10.3.2), and its Object IDs stay repository-local — the same ID in a distinctly keyed repository is a different **Managed Object**, never silently merged. The graph identity names the producing invocation family, not a workspace-unique repository — every project-bound build emits the constant `{local_project, "agentdoc.config.yaml"}`, so identity-equality keying distinguishes repositories only as far as the caller's identities do; explicit routing of an import to a reserved binding slot keyed from the authenticated channel is E1.3.
 _Avoid_: global repository namespace, path-string repository key, cross-repository ID merge
 
 **Reconciliation Candidate**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -170,6 +170,22 @@ _Avoid_: UUID-only ID, heading slug, arbitrary string
 A Knowledge Object under managed Cloud governance, carrying workspace-qualified canonical identity distinct from its human-readable **Object ID**, its immutable managed version ID, and its Source Binding (ADR-0057 invariant 1; EXECUTION-MAP E1.2). Matching IDs, titles, hashes, or semantic similarity across sources never auto-merge Managed Objects — collisions produce reconciliation candidates only.
 _Avoid_: global object namespace, auto-merged identity, cross-workspace object
 
+**Workspace Canonical Identity**:
+The workspace-qualified canonical identity of a **Managed Object** (K6 layer 1; `WorkspaceCanonicalIdentity` in `adoc-core`): a Cloud workspace id plus an opaque canonical id, stored separately from the human-readable **Object ID**. Equality includes the workspace, so identity is never linkable across workspaces by an unqualified Object ID.
+_Avoid_: Object ID as canonical key, cross-workspace identity linkage, content-derived canonical id
+
+**Managed Version ID**:
+The unique immutable identifier every managed candidate/active version receives (K6 layer 3; `ManagedVersionId` in `adoc-core`). A semantic content change mints a new one; a state-only transition or an unchanged re-observation never does (RT-04). Opaque and never reused.
+_Avoid_: content hash as version id, mutable version record, version id reuse
+
+**Source Assertion Identity**:
+The identity of one immutable Source Assertion extracted from a Source Artifact (K6 layer 4, K7; `SourceAssertionIdentity` in `adoc-core`). Only the identity layer exists today — the Source Record/Assertion store lands in E4.1. Carried per managed version so reconciliation preserves original provenance.
+_Avoid_: Source Binding synonym, assertion as Knowledge Object, mutable assertion
+
+**Reconciliation Candidate**:
+The typed record (`adoc.reconciliation_candidate.v0`, registered planned) emitted when an imported **Object ID** collides with a **Managed Object** in another repository of the same workspace. Both objects stay distinct; the candidate names both parties by **Workspace Canonical Identity**, repository identity, latest **Managed Version ID**, and content hash. Deciding a candidate (keep distinct, link, supersede, merge) is a governed E1.3 action; matching hashes, titles, or similarity never produce one.
+_Avoid_: auto-merge, duplicate detector, similarity-based unification
+
 **Diagnostic Code**:
 A grouped semantic identifier for a compiler diagnostic, such as `parse.raw_html` or `schema.missing_field`. Lives in code as the `DiagnosticCode` enum in `adoc-core`; emission sites accept the typed value rather than a free-form string.
 _Avoid_: numeric-only code, unstable message matching

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -182,6 +182,10 @@ _Avoid_: content hash as version id, mutable version record, version id reuse
 The identity of one immutable Source Assertion extracted from a Source Artifact (K6 layer 4, K7; `SourceAssertionIdentity` in `adoc-core`). Only the identity layer exists today — the Source Record/Assertion store lands in E4.1. Carried per managed version so reconciliation preserves original provenance.
 _Avoid_: Source Binding synonym, assertion as Knowledge Object, mutable assertion
 
+**Managed Repository Record**:
+One imported repository inside a Cloud workspace (`ManagedRepositoryRecord` in `adoc-core`), keyed on the Graph Artifact's `repository_identity` — `{kind, config_path}` or explicit `null`, required since v5 (ADR-0049). The record is the binding slot: it can be reserved before the first artifact arrives (V10.3.2), and its Object IDs stay repository-local — the same ID in another repository is a different **Managed Object**, never silently merged.
+_Avoid_: global repository namespace, path-string repository key, cross-repository ID merge
+
 **Reconciliation Candidate**:
 The typed record (`adoc.reconciliation_candidate.v0`, registered planned) emitted when an imported **Object ID** collides with a **Managed Object** in another repository of the same workspace. Both objects stay distinct; the candidate names both parties by **Workspace Canonical Identity**, repository identity, latest **Managed Version ID**, and content hash. Deciding a candidate (keep distinct, link, supersede, merge) is a governed E1.3 action; matching hashes, titles, or similarity never produce one.
 _Avoid_: auto-merge, duplicate detector, similarity-based unification

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -77,7 +77,7 @@ pub(crate) struct GraphArtifactDocument {
     pub(crate) diagnostics: Vec<Diagnostic>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(transparent)]
 pub(crate) struct GraphRepositoryIdentity(pub(crate) Option<RepositoryIdentity>);
 
@@ -97,7 +97,7 @@ impl Default for GraphRepositoryIdentity {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "kind", rename_all = "snake_case")]
 pub(crate) enum RepositoryIdentity {
     LocalProject { config_path: String },

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -984,7 +984,7 @@ fn content_hash_diagnostic(node: &GraphKnowledgeObjectNode) -> Option<Diagnostic
 /// trust boundary it enforces the full published v6 grammar
 /// `^sha256:[0-9a-f]+$` instead (`domain::managed`), so padded or non-hex
 /// spellings never reach an immutable managed version.
-pub(crate) fn content_hash_matches_grammar(value: &str) -> bool {
+fn content_hash_matches_grammar(value: &str) -> bool {
     value
         .strip_prefix("sha256:")
         .is_some_and(|suffix| !suffix.trim().is_empty())

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -977,8 +977,13 @@ fn content_hash_diagnostic(node: &GraphKnowledgeObjectNode) -> Option<Diagnostic
     None
 }
 
-/// The single content-hash grammar shared by the graph loader (above) and
-/// managed import (`domain::managed`): `sha256:` with a non-empty suffix.
+/// Loader-side content-hash acceptance: `sha256:` with a non-empty suffix.
+/// Deliberately lenient — non-hex and whitespace-padded suffixes pass —
+/// because this acceptance is pinned wire behavior (the help text below
+/// promises exactly this shape). Managed import does not share it: at its
+/// trust boundary it enforces the full published v6 grammar
+/// `^sha256:[0-9a-f]+$` instead (`domain::managed`), so padded or non-hex
+/// spellings never reach an immutable managed version.
 pub(crate) fn content_hash_matches_grammar(value: &str) -> bool {
     value
         .strip_prefix("sha256:")

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -970,14 +970,19 @@ fn content_hash_diagnostic(node: &GraphKnowledgeObjectNode) -> Option<Diagnostic
         );
     }
 
-    let Some(suffix) = node.content_hash.strip_prefix("sha256:") else {
-        return Some(invalid_content_hash_diagnostic(node));
-    };
-    if suffix.trim().is_empty() {
+    if !content_hash_matches_grammar(&node.content_hash) {
         return Some(invalid_content_hash_diagnostic(node));
     }
 
     None
+}
+
+/// The single content-hash grammar shared by the graph loader (above) and
+/// managed import (`domain::managed`): `sha256:` with a non-empty suffix.
+pub(crate) fn content_hash_matches_grammar(value: &str) -> bool {
+    value
+        .strip_prefix("sha256:")
+        .is_some_and(|suffix| !suffix.trim().is_empty())
 }
 
 fn invalid_content_hash_diagnostic(node: &GraphKnowledgeObjectNode) -> Diagnostic {

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -21,7 +21,10 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
-use super::graph::{GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding};
+use super::graph::{
+    GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding,
+    content_hash_matches_grammar,
+};
 use super::identity::ObjectId;
 
 /// Cloud workspace identifier — opaque to `adoc-core`. Blank or padded
@@ -94,6 +97,8 @@ pub(crate) enum ManagedIdentityError {
     InvalidObjectId,
     #[error("object id appears more than once in one artifact")]
     DuplicateObjectId,
+    #[error("content hash must be `sha256:` with a non-empty suffix")]
+    InvalidContentHash,
 }
 
 /// One managed repository inside a workspace, keyed on the graph
@@ -255,14 +260,17 @@ impl ManagedWorkspace {
     ///
     /// Fail closed on crafted input (`GraphArtifactDocument` derives
     /// `Deserialize`, so callers cannot assume compiler-built documents): a
-    /// blank, grammar-violating, or repeated Object ID anywhere in the
+    /// blank, grammar-violating, or repeated Object ID — or a
+    /// `content_hash` outside the shared grammar — anywhere in the
     /// artifact rejects the whole import before any state changes. The
     /// graph loader enforces the same invariants (`id.invalid`,
-    /// `DiagnosticCode::IdDuplicateInArtifact`); a document handed to
-    /// import directly must not bypass them — a grammar-evading ID would
-    /// also evade the exact-ID collision detector, and a repeated ID would
-    /// silently unify into one record (the intra-artifact shape of the
-    /// merge RT-03/D36 forbids).
+    /// `DiagnosticCode::IdDuplicateInArtifact`, `io.artifact_malformed`);
+    /// a document handed to import directly must not bypass them — a
+    /// grammar-evading ID would also evade the exact-ID collision
+    /// detector, a repeated ID would silently unify into one record (the
+    /// intra-artifact shape of the merge RT-03/D36 forbids), and a
+    /// malformed hash would be enshrined in an immutable version and
+    /// compared for RT-04 unchanged-ness ever after.
     pub(crate) fn import_artifact(
         &mut self,
         artifact: &GraphArtifactDocument,
@@ -281,6 +289,9 @@ impl ManagedWorkspace {
             }
             if !seen_ids.insert(node.id.as_str()) {
                 return Err(ManagedIdentityError::DuplicateObjectId);
+            }
+            if !content_hash_matches_grammar(&node.content_hash) {
+                return Err(ManagedIdentityError::InvalidContentHash);
             }
         }
         // Arrival binds the slot even when the artifact carries no
@@ -791,6 +802,34 @@ mod tests {
             assert_eq!(
                 outcome,
                 Err(ManagedIdentityError::InvalidObjectId),
+                "{invalid:?} must be rejected"
+            );
+        }
+        assert!(
+            workspace.repository(&repo).is_none(),
+            "a rejected import must not bind the repository slot or mint anything"
+        );
+    }
+
+    /// A crafted artifact carrying a blank or malformed `content_hash`
+    /// would otherwise mint an immutable version around it, surface it in
+    /// reconciliation candidates, and treat every later observation of the
+    /// same malformed value as unchanged. The graph loader rejects these
+    /// documents (`content_hash_diagnostic`, `io.artifact_malformed`);
+    /// import fails closed the same way, before any state changes.
+    #[test]
+    fn malformed_content_hashes_on_import_are_rejected_without_partial_state() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        for invalid in ["", "  ", "sha256:", "sha256:  ", "md5:abc"] {
+            let outcome = workspace.import_artifact(&artifact(
+                repo.clone(),
+                vec![knowledge_object("billing.credits", invalid)],
+            ));
+            assert_eq!(
+                outcome,
+                Err(ManagedIdentityError::InvalidContentHash),
                 "{invalid:?} must be rejected"
             );
         }

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -119,8 +119,8 @@ fn content_hash_matches_published_grammar(value: &str) -> bool {
 /// `repository_identity` (`{kind, config_path}` or explicit `null` —
 /// required since v5, ADR-0049). The record is the binding slot (V10.3.2):
 /// it can exist before the first artifact arrives, and its Object IDs stay
-/// repository-local — the same ID in another repository is a different
-/// Managed Object.
+/// repository-local — the same ID in a distinctly keyed repository is a
+/// different Managed Object.
 ///
 /// The graph identity names the producing invocation family, not a
 /// workspace-unique repository: every project-bound build emits the
@@ -288,11 +288,13 @@ impl ManagedWorkspace {
     /// Fail closed on crafted input (`GraphArtifactDocument` derives
     /// `Deserialize`, so callers cannot assume compiler-built documents): a
     /// blank, grammar-violating, or repeated Object ID — or a
-    /// `content_hash` outside the shared grammar — anywhere in the
-    /// artifact rejects the whole import before any state changes. The
-    /// graph loader enforces the same invariants (`id.invalid`,
-    /// `DiagnosticCode::IdDuplicateInArtifact`, `io.artifact_malformed`);
-    /// a document handed to import directly must not bypass them — a
+    /// `content_hash` outside the published v6 wire grammar — anywhere in
+    /// the artifact rejects the whole import before any state changes.
+    /// The graph loader enforces the same ID invariants (`id.invalid`,
+    /// `DiagnosticCode::IdDuplicateInArtifact`); for `content_hash` it is
+    /// deliberately more lenient (see
+    /// `content_hash_matches_published_grammar`). A document handed to
+    /// import directly must not bypass this boundary — a
     /// grammar-evading ID would also evade the exact-ID collision
     /// detector, a repeated ID would silently unify into one record (the
     /// intra-artifact shape of the merge RT-03/D36 forbids), and a

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -624,4 +624,134 @@ mod tests {
         assert_eq!(object.versions[0].source_binding, expected);
         assert!(object.versions[0].source_assertions.is_empty());
     }
+
+    // E1.2.T2 negative fixtures (RT-03/D36): no auto-merge on ID, title,
+    // hash, or similarity. No similarity machinery exists in this crate —
+    // these fixtures prove the absence of any unification path: candidates
+    // arise from exact Object-ID collision alone, and even those never
+    // merge.
+
+    /// Exit test: the same semantic `content_hash` under two different
+    /// Object IDs stays two objects — no candidate, no merge. Two objects
+    /// can hash identically at all because ADR-0058 §2 keeps identity out
+    /// of the v6 hash payload (identity and semantic hash are separate K6
+    /// layers).
+    #[test]
+    fn same_content_hash_under_two_object_ids_stays_two_objects() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        let outcome = workspace.import_artifact(&artifact(
+            repo.clone(),
+            vec![
+                knowledge_object("billing.credits", "sha256:same"),
+                knowledge_object("billing.refunds", "sha256:same"),
+            ],
+        ));
+
+        assert!(outcome.reconciliation_candidates.is_empty());
+        let objects = &workspace.repository(&repo).expect("repo recorded").objects;
+        assert_eq!(objects.len(), 2);
+        assert_ne!(
+            objects["billing.credits"].canonical, objects["billing.refunds"].canonical,
+            "equal hashes must never collapse two Object IDs into one identity"
+        );
+        assert_ne!(
+            objects["billing.credits"].versions[0].version_id,
+            objects["billing.refunds"].versions[0].version_id
+        );
+    }
+
+    /// Equal hashes across repositories without an ID collision produce
+    /// nothing: no candidate, no link, both objects retained.
+    #[test]
+    fn equal_hashes_across_repositories_without_id_collision_produce_nothing() {
+        let mut workspace = workspace();
+        let repo_a = local_repo("a/agentdoc.config.yaml");
+        let repo_b = local_repo("b/agentdoc.config.yaml");
+
+        workspace.import_artifact(&artifact(
+            repo_a.clone(),
+            vec![knowledge_object("billing.credits", "sha256:same")],
+        ));
+        let outcome = workspace.import_artifact(&artifact(
+            repo_b.clone(),
+            vec![knowledge_object("billing.refunds", "sha256:same")],
+        ));
+
+        assert!(outcome.reconciliation_candidates.is_empty());
+        assert_eq!(
+            workspace.repository(&repo_a).expect("repo a").objects.len(),
+            1
+        );
+        assert_eq!(
+            workspace.repository(&repo_b).expect("repo b").objects.len(),
+            1
+        );
+    }
+
+    /// Same title, same body, same hash — maximum surface similarity under
+    /// two different Object IDs — never unifies and emits no candidate.
+    #[test]
+    fn identical_titles_and_bodies_never_unify() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+        let mut first = knowledge_object("billing.credits", "sha256:same");
+        first
+            .fields
+            .insert("title".to_string(), "Credit policy".to_string());
+        let mut second = knowledge_object("billing.credit-rules", "sha256:same");
+        second
+            .fields
+            .insert("title".to_string(), "Credit policy".to_string());
+        assert_eq!(first.body, second.body);
+
+        let outcome = workspace.import_artifact(&artifact(repo.clone(), vec![first, second]));
+
+        assert!(outcome.reconciliation_candidates.is_empty());
+        let objects = &workspace.repository(&repo).expect("repo recorded").objects;
+        assert_eq!(objects.len(), 2);
+        assert_ne!(
+            objects["billing.credits"].canonical,
+            objects["billing.credit-rules"].canonical
+        );
+    }
+
+    /// Adversarial (MILESTONES §E1.2 acceptance): a crafted import
+    /// replaying an existing object's exact Object ID AND `content_hash`
+    /// from another repository — the most merge-tempting collision — is
+    /// retained distinct with a candidate only; hash equality confers no
+    /// unification.
+    #[test]
+    fn crafted_replay_of_id_and_hash_is_retained_distinct_candidate_only() {
+        let mut workspace = workspace();
+        let repo_a = local_repo("a/agentdoc.config.yaml");
+        let repo_b = local_repo("b/agentdoc.config.yaml");
+
+        workspace.import_artifact(&artifact(
+            repo_a.clone(),
+            vec![knowledge_object("billing.credits", "sha256:same")],
+        ));
+        let outcome = workspace.import_artifact(&artifact(
+            repo_b.clone(),
+            vec![knowledge_object("billing.credits", "sha256:same")],
+        ));
+
+        assert_eq!(outcome.reconciliation_candidates.len(), 1);
+        let candidate = &outcome.reconciliation_candidates[0];
+        assert_eq!(candidate.reason, ReconciliationReason::ObjectIdCollision);
+        assert_eq!(
+            candidate.existing.content_hash,
+            candidate.incoming.content_hash
+        );
+        assert_ne!(
+            candidate.existing.canonical, candidate.incoming.canonical,
+            "an identical hash must not let the replay adopt the existing identity"
+        );
+        let object_a = &workspace.repository(&repo_a).expect("repo a").objects["billing.credits"];
+        let object_b = &workspace.repository(&repo_b).expect("repo b").objects["billing.credits"];
+        assert_ne!(object_a.canonical, object_b.canonical);
+        assert_eq!(object_a.versions.len(), 1);
+        assert_eq!(object_b.versions.len(), 1);
+    }
 }

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -77,12 +77,17 @@ impl SourceAssertionIdentity {
     }
 }
 
+// Every identity layer rejects blank input the same way; the shared
+// `Blank` prefix is the vocabulary, not noise.
+#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum ManagedIdentityError {
     #[error("workspace id must not be blank")]
     BlankWorkspaceId,
     #[error("source assertion identity must not be blank")]
     BlankSourceAssertionIdentity,
+    #[error("object id must not be blank")]
+    BlankObjectId,
 }
 
 /// One managed repository inside a workspace, keyed on the graph
@@ -105,8 +110,8 @@ pub(crate) struct ManagedRepositoryRecord {
 pub(crate) struct ManagedObjectRecord {
     pub(crate) canonical: WorkspaceCanonicalIdentity,
     /// The human-readable Object ID — persists across revisions
-    /// (invariant: non-empty by construction, only created from graph node
-    /// ids observed on import).
+    /// (invariant: non-empty — [`ManagedWorkspace::import_artifact`]
+    /// rejects blank graph node ids before recording anything).
     pub(crate) object_id: String,
     /// Append-only: every import that changes governed meaning appends an
     /// immutable version; nothing is ever rewritten (RT-04).
@@ -230,11 +235,21 @@ impl ManagedWorkspace {
     /// Import every Knowledge Object of a Graph Artifact into the
     /// artifact's repository record. Retains every object; a same-ID
     /// collision with another repository emits a [`ReconciliationCandidate`]
-    /// and never merges, links, or re-homes anything.
+    /// and never merges, links, or re-homes anything. A blank Object ID
+    /// anywhere in the artifact rejects the whole import before any state
+    /// changes (fail closed — a keyed `""` object would be unaddressable).
     pub(crate) fn import_artifact(
         &mut self,
         artifact: &GraphArtifactDocument,
-    ) -> ManagedImportOutcome {
+    ) -> Result<ManagedImportOutcome, ManagedIdentityError> {
+        if artifact
+            .nodes
+            .iter()
+            .filter_map(GraphNode::as_knowledge_object)
+            .any(|node| node.id.trim().is_empty())
+        {
+            return Err(ManagedIdentityError::BlankObjectId);
+        }
         // Arrival binds the slot even when the artifact carries no
         // Knowledge Objects (E1.2.T4).
         self.reserve_repository(artifact.repository_identity.clone());
@@ -312,10 +327,10 @@ impl ManagedWorkspace {
                 version_id,
             });
         }
-        ManagedImportOutcome {
+        Ok(ManagedImportOutcome {
             imported,
             reconciliation_candidates,
-        }
+        })
     }
 
     /// Same-ID parties in every other repository of this workspace. The
@@ -439,16 +454,20 @@ mod tests {
         let repo_a = local_repo("a/agentdoc.config.yaml");
         let repo_b = local_repo("b/agentdoc.config.yaml");
 
-        let first = workspace.import_artifact(&artifact(
-            repo_a.clone(),
-            vec![knowledge_object("billing.credits", "sha256:aaa")],
-        ));
+        let first = workspace
+            .import_artifact(&artifact(
+                repo_a.clone(),
+                vec![knowledge_object("billing.credits", "sha256:aaa")],
+            ))
+            .expect("import accepted");
         assert!(first.reconciliation_candidates.is_empty());
 
-        let second = workspace.import_artifact(&artifact(
-            repo_b.clone(),
-            vec![knowledge_object("billing.credits", "sha256:bbb")],
-        ));
+        let second = workspace
+            .import_artifact(&artifact(
+                repo_b.clone(),
+                vec![knowledge_object("billing.credits", "sha256:bbb")],
+            ))
+            .expect("import accepted");
 
         let object_a = &workspace
             .repository(&repo_a)
@@ -482,14 +501,18 @@ mod tests {
     #[test]
     fn reconciliation_candidate_serialized_record_shape_is_pinned() {
         let mut workspace = workspace();
-        workspace.import_artifact(&artifact(
-            local_repo("a/agentdoc.config.yaml"),
-            vec![knowledge_object("billing.credits", "sha256:aaa")],
-        ));
-        let outcome = workspace.import_artifact(&artifact(
-            GraphRepositoryIdentity::standalone(),
-            vec![knowledge_object("billing.credits", "sha256:bbb")],
-        ));
+        workspace
+            .import_artifact(&artifact(
+                local_repo("a/agentdoc.config.yaml"),
+                vec![knowledge_object("billing.credits", "sha256:aaa")],
+            ))
+            .expect("import accepted");
+        let outcome = workspace
+            .import_artifact(&artifact(
+                GraphRepositoryIdentity::standalone(),
+                vec![knowledge_object("billing.credits", "sha256:bbb")],
+            ))
+            .expect("import accepted");
 
         let candidate = &outcome.reconciliation_candidates[0];
         let value = serde_json::to_value(candidate).expect("candidate serializes");
@@ -532,14 +555,18 @@ mod tests {
         let mut workspace = workspace();
         let repo = local_repo("a/agentdoc.config.yaml");
 
-        let first = workspace.import_artifact(&artifact(
-            repo.clone(),
-            vec![knowledge_object("billing.credits", "sha256:aaa")],
-        ));
-        let second = workspace.import_artifact(&artifact(
-            repo.clone(),
-            vec![knowledge_object("billing.credits", "sha256:ccc")],
-        ));
+        let first = workspace
+            .import_artifact(&artifact(
+                repo.clone(),
+                vec![knowledge_object("billing.credits", "sha256:aaa")],
+            ))
+            .expect("import accepted");
+        let second = workspace
+            .import_artifact(&artifact(
+                repo.clone(),
+                vec![knowledge_object("billing.credits", "sha256:ccc")],
+            ))
+            .expect("import accepted");
 
         let object =
             &workspace.repository(&repo).expect("repo recorded").objects["billing.credits"];
@@ -561,8 +588,12 @@ mod tests {
             vec![knowledge_object("billing.credits", "sha256:aaa")],
         );
 
-        workspace.import_artifact(&document);
-        let again = workspace.import_artifact(&document);
+        workspace
+            .import_artifact(&document)
+            .expect("import accepted");
+        let again = workspace
+            .import_artifact(&document)
+            .expect("import accepted");
 
         assert!(again.imported.is_empty());
         assert!(again.reconciliation_candidates.is_empty());
@@ -585,8 +616,12 @@ mod tests {
             vec![knowledge_object("billing.credits", "sha256:aaa")],
         );
 
-        let in_a = workspace_a.import_artifact(&document);
-        let in_b = workspace_b.import_artifact(&document);
+        let in_a = workspace_a
+            .import_artifact(&document)
+            .expect("import accepted");
+        let in_b = workspace_b
+            .import_artifact(&document)
+            .expect("import accepted");
 
         assert_eq!(in_a.imported[0].canonical.canonical_id, "mo-1");
         assert_eq!(in_b.imported[0].canonical.canonical_id, "mo-1");
@@ -602,6 +637,32 @@ mod tests {
     fn blank_workspace_id_is_rejected() {
         assert!(WorkspaceId::new("").is_err());
         assert!(WorkspaceId::new(" \t").is_err());
+    }
+
+    /// A crafted artifact carrying a blank Object ID (empty or
+    /// whitespace-only — `GraphArtifactDocument` derives `Deserialize`, so
+    /// import callers cannot assume compiler-built input) is rejected
+    /// before any state changes: no slot bound, nothing minted (fail
+    /// closed, matching the Cloud store's non-empty check).
+    #[test]
+    fn blank_object_id_on_import_is_rejected_without_partial_state() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        for blank in ["", "  "] {
+            let outcome = workspace.import_artifact(&artifact(
+                repo.clone(),
+                vec![
+                    knowledge_object("billing.credits", "sha256:aaa"),
+                    knowledge_object(blank, "sha256:bbb"),
+                ],
+            ));
+            assert_eq!(outcome, Err(ManagedIdentityError::BlankObjectId));
+        }
+        assert!(
+            workspace.repository(&repo).is_none(),
+            "a rejected import must not bind the repository slot or mint anything"
+        );
     }
 
     /// The Source Assertion identity layer (K7) exists as its own type;
@@ -635,7 +696,9 @@ mod tests {
         });
         let expected = node.source_binding.clone();
 
-        workspace.import_artifact(&artifact(repo.clone(), vec![node]));
+        workspace
+            .import_artifact(&artifact(repo.clone(), vec![node]))
+            .expect("import accepted");
 
         let object =
             &workspace.repository(&repo).expect("repo recorded").objects["billing.credits"];
@@ -659,13 +722,15 @@ mod tests {
         let mut workspace = workspace();
         let repo = local_repo("a/agentdoc.config.yaml");
 
-        let outcome = workspace.import_artifact(&artifact(
-            repo.clone(),
-            vec![
-                knowledge_object("billing.credits", "sha256:same"),
-                knowledge_object("billing.refunds", "sha256:same"),
-            ],
-        ));
+        let outcome = workspace
+            .import_artifact(&artifact(
+                repo.clone(),
+                vec![
+                    knowledge_object("billing.credits", "sha256:same"),
+                    knowledge_object("billing.refunds", "sha256:same"),
+                ],
+            ))
+            .expect("import accepted");
 
         assert!(outcome.reconciliation_candidates.is_empty());
         let objects = &workspace.repository(&repo).expect("repo recorded").objects;
@@ -688,14 +753,18 @@ mod tests {
         let repo_a = local_repo("a/agentdoc.config.yaml");
         let repo_b = local_repo("b/agentdoc.config.yaml");
 
-        workspace.import_artifact(&artifact(
-            repo_a.clone(),
-            vec![knowledge_object("billing.credits", "sha256:same")],
-        ));
-        let outcome = workspace.import_artifact(&artifact(
-            repo_b.clone(),
-            vec![knowledge_object("billing.refunds", "sha256:same")],
-        ));
+        workspace
+            .import_artifact(&artifact(
+                repo_a.clone(),
+                vec![knowledge_object("billing.credits", "sha256:same")],
+            ))
+            .expect("import accepted");
+        let outcome = workspace
+            .import_artifact(&artifact(
+                repo_b.clone(),
+                vec![knowledge_object("billing.refunds", "sha256:same")],
+            ))
+            .expect("import accepted");
 
         assert!(outcome.reconciliation_candidates.is_empty());
         assert_eq!(
@@ -724,7 +793,9 @@ mod tests {
             .insert("title".to_string(), "Credit policy".to_string());
         assert_eq!(first.body, second.body);
 
-        let outcome = workspace.import_artifact(&artifact(repo.clone(), vec![first, second]));
+        let outcome = workspace
+            .import_artifact(&artifact(repo.clone(), vec![first, second]))
+            .expect("import accepted");
 
         assert!(outcome.reconciliation_candidates.is_empty());
         let objects = &workspace.repository(&repo).expect("repo recorded").objects;
@@ -746,14 +817,18 @@ mod tests {
         let repo_a = local_repo("a/agentdoc.config.yaml");
         let repo_b = local_repo("b/agentdoc.config.yaml");
 
-        workspace.import_artifact(&artifact(
-            repo_a.clone(),
-            vec![knowledge_object("billing.credits", "sha256:same")],
-        ));
-        let outcome = workspace.import_artifact(&artifact(
-            repo_b.clone(),
-            vec![knowledge_object("billing.credits", "sha256:same")],
-        ));
+        workspace
+            .import_artifact(&artifact(
+                repo_a.clone(),
+                vec![knowledge_object("billing.credits", "sha256:same")],
+            ))
+            .expect("import accepted");
+        let outcome = workspace
+            .import_artifact(&artifact(
+                repo_b.clone(),
+                vec![knowledge_object("billing.credits", "sha256:same")],
+            ))
+            .expect("import accepted");
 
         assert_eq!(outcome.reconciliation_candidates.len(), 1);
         let candidate = &outcome.reconciliation_candidates[0];
@@ -803,10 +878,12 @@ mod tests {
         workspace.reserve_repository(repo.clone());
         workspace.reserve_repository(repo.clone());
 
-        workspace.import_artifact(&artifact(
-            repo.clone(),
-            vec![knowledge_object("billing.credits", "sha256:aaa")],
-        ));
+        workspace
+            .import_artifact(&artifact(
+                repo.clone(),
+                vec![knowledge_object("billing.credits", "sha256:aaa")],
+            ))
+            .expect("import accepted");
         workspace.reserve_repository(repo.clone());
 
         let record = workspace.repository(&repo).expect("repo recorded");
@@ -820,7 +897,9 @@ mod tests {
         let mut workspace = workspace();
         let repo = local_repo("a/agentdoc.config.yaml");
 
-        let outcome = workspace.import_artifact(&artifact(repo.clone(), Vec::new()));
+        let outcome = workspace
+            .import_artifact(&artifact(repo.clone(), Vec::new()))
+            .expect("import accepted");
 
         assert!(outcome.imported.is_empty());
         let record = workspace
@@ -839,14 +918,18 @@ mod tests {
         let project = local_repo("a/agentdoc.config.yaml");
         let standalone = GraphRepositoryIdentity::standalone();
 
-        workspace.import_artifact(&artifact(
-            project.clone(),
-            vec![knowledge_object("billing.credits", "sha256:aaa")],
-        ));
-        let outcome = workspace.import_artifact(&artifact(
-            standalone.clone(),
-            vec![knowledge_object("billing.credits", "sha256:bbb")],
-        ));
+        workspace
+            .import_artifact(&artifact(
+                project.clone(),
+                vec![knowledge_object("billing.credits", "sha256:aaa")],
+            ))
+            .expect("import accepted");
+        let outcome = workspace
+            .import_artifact(&artifact(
+                standalone.clone(),
+                vec![knowledge_object("billing.credits", "sha256:bbb")],
+            ))
+            .expect("import accepted");
 
         assert_eq!(outcome.reconciliation_candidates.len(), 1);
         let in_project = &workspace

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -107,6 +107,18 @@ pub(crate) enum ManagedIdentityError {
 /// it can exist before the first artifact arrives, and its Object IDs stay
 /// repository-local — the same ID in another repository is a different
 /// Managed Object.
+///
+/// The graph identity names the producing invocation family, not a
+/// workspace-unique repository: every project-bound build emits the
+/// constant `{local_project, "agentdoc.config.yaml"}`
+/// (`FsSourceProvider::repository_identity`, ADR-0049 §7), so two
+/// physical repositories importing under the producer identity are one
+/// record to this aggregate. Identity-equality keying is therefore the
+/// single-repository convenience only. A multi-repository workspace
+/// routes each import to a reserved slot explicitly — the key supplied
+/// by the caller from its authenticated channel, never read from the
+/// artifact — with the reserved binding slot as the disambiguator; that
+/// routing path is E1.3 scope (PR #150 adjudication).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ManagedRepositoryRecord {
     pub(crate) repository_identity: GraphRepositoryIdentity,
@@ -271,6 +283,15 @@ impl ManagedWorkspace {
     /// intra-artifact shape of the merge RT-03/D36 forbids), and a
     /// malformed hash would be enshrined in an immutable version and
     /// compared for RT-04 unchanged-ness ever after.
+    ///
+    /// Two deliberate boundaries: (1) unlike `GraphIndex::from_document`,
+    /// which degrades per node into diagnostics, one bad node rejects the
+    /// whole document — at this trust boundary a partial import would be
+    /// a silent drop; (2) the artifact's self-declared
+    /// `repository_identity` is taken as the record key, which
+    /// distinguishes repositories only as far as the caller's identities
+    /// do ([`ManagedRepositoryRecord`]) — a caller on a trust boundary
+    /// routes to a reserved slot instead of trusting the payload (E1.3).
     pub(crate) fn import_artifact(
         &mut self,
         artifact: &GraphArtifactDocument,
@@ -281,6 +302,8 @@ impl ManagedWorkspace {
             .iter()
             .filter_map(GraphNode::as_knowledge_object)
         {
+            // Blank is a strict subset of the grammar failure below —
+            // checked first only for the more precise error.
             if node.id.trim().is_empty() {
                 return Err(ManagedIdentityError::BlankObjectId);
             }
@@ -1141,5 +1164,49 @@ mod tests {
         assert_ne!(in_project.canonical, in_standalone.canonical);
         assert_eq!(in_project.versions[0].content_hash, "sha256:aaa");
         assert_eq!(in_standalone.versions[0].content_hash, "sha256:bbb");
+    }
+
+    /// Pins what the wire actually exhibits today: every project-bound
+    /// artifact the compiler emits carries the constant
+    /// `{local_project, "agentdoc.config.yaml"}` identity
+    /// (`FsSourceProvider::repository_identity`, ADR-0049 §7), so two
+    /// physical repositories importing under the producer identity are
+    /// one record here — the shared Object ID appends as a revision and
+    /// no candidate is emitted. Identity-equality keying distinguishes
+    /// repositories only as far as the caller's identities do
+    /// ([`ManagedRepositoryRecord`]); explicit routing to a reserved
+    /// binding slot (V10.3.2) is E1.3 scope, and the Cloud cut keys
+    /// uploads from its authenticated channel, never from the artifact.
+    #[test]
+    fn identical_producer_identities_collapse_into_one_repository_record() {
+        let mut workspace = workspace();
+        let producer = local_repo("agentdoc.config.yaml");
+
+        workspace
+            .import_artifact(&artifact(
+                producer.clone(),
+                vec![knowledge_object("billing.credits", "sha256:aaa")],
+            ))
+            .expect("import accepted");
+        let second = workspace
+            .import_artifact(&artifact(
+                producer.clone(),
+                vec![knowledge_object("billing.credits", "sha256:bbb")],
+            ))
+            .expect("import accepted");
+
+        assert!(
+            second.reconciliation_candidates.is_empty(),
+            "equal keys are one repository: no cross-repository collision exists to announce"
+        );
+        let object = &workspace
+            .repository(&producer)
+            .expect("one record under the producer identity")
+            .objects["billing.credits"];
+        assert_eq!(
+            object.versions.len(),
+            2,
+            "the second import appends a revision of the first repository's object"
+        );
     }
 }

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -532,6 +532,27 @@ mod tests {
         assert_eq!(candidate.existing.repository_identity, repo_a);
         assert_eq!(candidate.incoming.canonical, object_b.canonical);
         assert_eq!(candidate.incoming.repository_identity, repo_b);
+
+        // Single-shot: the collision was announced on the ID's first
+        // appearance in repo b — a later revision of the still-colliding
+        // object mints a version but never re-announces the candidate
+        // (the caller persists it until decided, E1.2.T3/E1.3).
+        let third = workspace
+            .import_artifact(&artifact(
+                repo_b.clone(),
+                vec![knowledge_object("billing.credits", "sha256:ccc")],
+            ))
+            .expect("import accepted");
+        assert_eq!(third.imported.len(), 1);
+        assert!(
+            third.reconciliation_candidates.is_empty(),
+            "a candidate is emitted exactly once, not per revision"
+        );
+        let object_b = &workspace
+            .repository(&repo_b)
+            .expect("repo b recorded")
+            .objects["billing.credits"];
+        assert_eq!(object_b.versions.len(), 2);
     }
 
     /// The serialized record the Cloud cut consumes under the planned

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -162,6 +162,9 @@ pub(crate) struct ManagedObjectRecord {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ManagedVersionRecord {
     pub(crate) version_id: ManagedVersionId,
+    /// The producer-declared v6 governed-meaning hash, trusted as
+    /// declared: grammar-checked at import, never re-derived from node
+    /// content (see [`ManagedWorkspace::import_artifact`]).
     pub(crate) content_hash: String,
     /// The exact Source Binding observed when this version was minted,
     /// when the artifact carried one. A same-hash re-observation with a
@@ -311,6 +314,20 @@ impl ManagedWorkspace {
     /// repository key so the record is bound from the authenticated
     /// channel rather than the payload; until then the artifact's
     /// declared identity *is* the key.
+    ///
+    /// Two trust assumptions stay with the producer, deliberately —
+    /// the fail-closed list above is NOT exhaustive verification:
+    /// (1) schema admission — the exact-match v6 loader
+    /// (`infrastructure/artifact/graph_json.rs`) is the only
+    /// deserialization path for external artifact JSON, and import never
+    /// re-checks `schema_version`, so a document deserialized around
+    /// that boundary could enshrine placement-bearing v5 hashes as
+    /// governed-meaning version keys; (2) the declared `content_hash`
+    /// is trusted as the authority on governed meaning —
+    /// grammar-checked, never re-derived from node content (the
+    /// crate-wide posture; `domain/review/object_diff.rs` makes the
+    /// same assumption for change detection) — so unchanged-ness under
+    /// RT-04 is exactly as trustworthy as the producer's hash.
     pub(crate) fn import_artifact(
         &mut self,
         artifact: &GraphArtifactDocument,

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -1,0 +1,627 @@
+//! Managed Object identity contract (E1.2; ADR-0057 invariant 1).
+//!
+//! KNOWLEDGE-MODEL §K6 separates five identity layers, each its own type:
+//!
+//! 1. workspace canonical identity — [`WorkspaceCanonicalIdentity`];
+//! 2. human-readable Object ID — the graph node `id` (authored as the
+//!    `ObjectId` grammar, `domain::identity`);
+//! 3. immutable managed version ID — [`ManagedVersionId`];
+//! 4. Source Assertion identity — [`SourceAssertionIdentity`] (the Source
+//!    Record/Assertion store itself is E4.1);
+//! 5. Source Binding — `GraphSourceBinding` (E1.1, ADR-0058 §4).
+//!
+//! Managed import (RT-03, D36): matching Object IDs, titles, hashes, or
+//! semantic similarity never auto-merge. A same-ID collision across
+//! repositories retains every object distinct and emits a typed
+//! [`ReconciliationCandidate`] (`adoc.reconciliation_candidate.v0`,
+//! registered planned in CONTRACT-REGISTRY.md); deciding a candidate is a
+//! governed E1.3 action, never an import side effect.
+
+use std::collections::BTreeMap;
+
+use serde::Serialize;
+
+use super::graph::{GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding};
+
+/// Cloud workspace identifier — opaque to `adoc-core`. Blank input is
+/// rejected: an empty workspace id would produce unqualified canonical
+/// identities, defeating the qualification that keeps identity unlinkable
+/// across workspaces (MILESTONES §E1.2 stop-ship).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub(crate) struct WorkspaceId(String);
+
+impl WorkspaceId {
+    pub(crate) fn new(value: impl Into<String>) -> Result<Self, ManagedIdentityError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Err(ManagedIdentityError::BlankWorkspaceId)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+/// K6 layer 1: the workspace-qualified canonical identity of a Managed
+/// Object, stored separately from the human-readable Object ID (RT-03).
+/// Equality includes the workspace, so identities from different
+/// workspaces never compare equal even when their opaque suffix matches.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+pub(crate) struct WorkspaceCanonicalIdentity {
+    pub(crate) workspace_id: WorkspaceId,
+    pub(crate) canonical_id: String,
+}
+
+/// K6 layer 3: the unique immutable version ID every managed candidate or
+/// active version receives. Opaque, never reused, never derived from
+/// content — a semantic content change mints a new one (RT-04).
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub(crate) struct ManagedVersionId(String);
+
+/// K6 layer 4: the identity of one immutable Source Assertion (K7). Only
+/// the identity layer lands in E1.2 — the Source Record/Assertion store is
+/// E4.1. Blank identities fail closed.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
+#[serde(transparent)]
+pub(crate) struct SourceAssertionIdentity(String);
+
+impl SourceAssertionIdentity {
+    pub(crate) fn new(value: impl Into<String>) -> Result<Self, ManagedIdentityError> {
+        let value = value.into();
+        if value.trim().is_empty() {
+            Err(ManagedIdentityError::BlankSourceAssertionIdentity)
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub(crate) enum ManagedIdentityError {
+    #[error("workspace id must not be blank")]
+    BlankWorkspaceId,
+    #[error("source assertion identity must not be blank")]
+    BlankSourceAssertionIdentity,
+}
+
+/// One managed repository inside a workspace, keyed on the graph
+/// `repository_identity` (`{kind, config_path}` or explicit `null` —
+/// required since v5, ADR-0049). The record is the binding slot (V10.3.2):
+/// it can exist before the first artifact arrives, and its Object IDs stay
+/// repository-local — the same ID in another repository is a different
+/// Managed Object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManagedRepositoryRecord {
+    pub(crate) repository_identity: GraphRepositoryIdentity,
+    /// Managed Objects keyed by their repository-local Object ID.
+    pub(crate) objects: BTreeMap<String, ManagedObjectRecord>,
+}
+
+/// One Managed Object under one repository: a stable Object ID and
+/// workspace canonical identity over an append-only list of immutable
+/// versions. Never merged, rewritten, or re-homed by import.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManagedObjectRecord {
+    pub(crate) canonical: WorkspaceCanonicalIdentity,
+    /// The human-readable Object ID — persists across revisions
+    /// (invariant: non-empty by construction, only created from graph node
+    /// ids observed on import).
+    pub(crate) object_id: String,
+    /// Append-only: every import that changes governed meaning appends an
+    /// immutable version; nothing is ever rewritten (RT-04).
+    pub(crate) versions: Vec<ManagedVersionRecord>,
+}
+
+/// One immutable managed version with its preserved provenance (RT-03:
+/// reconciliation preserves all original Source Records, Assertions, and
+/// Bindings).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManagedVersionRecord {
+    pub(crate) version_id: ManagedVersionId,
+    pub(crate) content_hash: String,
+    /// The exact Source Binding observed at import time, when the artifact
+    /// carried one.
+    pub(crate) source_binding: Option<GraphSourceBinding>,
+    /// Contributing Source Assertions. Empty until the Source
+    /// Record/Assertion store lands (E4.1).
+    pub(crate) source_assertions: Vec<SourceAssertionIdentity>,
+}
+
+/// The typed reconciliation candidate (`adoc.reconciliation_candidate.v0`):
+/// emitted when an imported Object ID collides with a Managed Object in
+/// another repository of the same workspace. Both objects stay distinct —
+/// keep-distinct / link / supersede / merge decisions are governed E1.3
+/// actions with exact authority, policy, and version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ReconciliationCandidate {
+    /// The colliding human-readable Object ID (identical on both parties
+    /// by construction).
+    pub(crate) object_id: String,
+    pub(crate) reason: ReconciliationReason,
+    pub(crate) existing: ReconciliationParty,
+    pub(crate) incoming: ReconciliationParty,
+}
+
+/// Closed reason vocabulary. Only an exact Object-ID collision produces a
+/// candidate — hash equality, title equality, or semantic similarity never
+/// do (RT-03/D36), and no such detector exists anywhere in this crate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub(crate) enum ReconciliationReason {
+    ObjectIdCollision,
+}
+
+/// One side of a reconciliation candidate, identified by its workspace
+/// canonical identity, repository, and latest immutable version.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub(crate) struct ReconciliationParty {
+    pub(crate) canonical: WorkspaceCanonicalIdentity,
+    pub(crate) repository_identity: GraphRepositoryIdentity,
+    pub(crate) version_id: ManagedVersionId,
+    pub(crate) content_hash: String,
+}
+
+/// What one [`ManagedWorkspace::import_artifact`] call did.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManagedImportOutcome {
+    /// One entry per version minted by this import. Unchanged governed
+    /// meaning mints nothing — a re-observation is not a new content
+    /// version (RT-04).
+    pub(crate) imported: Vec<ImportedVersion>,
+    pub(crate) reconciliation_candidates: Vec<ReconciliationCandidate>,
+}
+
+/// One minted version: the identity layers assigned to an imported object.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ImportedVersion {
+    pub(crate) object_id: String,
+    pub(crate) canonical: WorkspaceCanonicalIdentity,
+    pub(crate) version_id: ManagedVersionId,
+}
+
+/// The managed-import domain service: one Cloud workspace's managed
+/// repositories, objects, and versions, in memory. Durable storage is the
+/// Cloud cut (E1.2.T3); this aggregate is the executable identity
+/// contract the stacked E1 slices build on.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ManagedWorkspace {
+    workspace_id: WorkspaceId,
+    repositories: BTreeMap<GraphRepositoryIdentity, ManagedRepositoryRecord>,
+    // ponytail: workspace-local monotonic minting; both ids are opaque to
+    // every consumer — Cloud storage mints its own scheme (the contract is
+    // opacity and uniqueness, not the format).
+    minted_canonical_ids: u64,
+    minted_version_ids: u64,
+}
+
+impl ManagedWorkspace {
+    pub(crate) fn new(workspace_id: WorkspaceId) -> Self {
+        Self {
+            workspace_id,
+            repositories: BTreeMap::new(),
+            minted_canonical_ids: 0,
+            minted_version_ids: 0,
+        }
+    }
+
+    pub(crate) fn repository(
+        &self,
+        repository_identity: &GraphRepositoryIdentity,
+    ) -> Option<&ManagedRepositoryRecord> {
+        self.repositories.get(repository_identity)
+    }
+
+    /// Import every Knowledge Object of a Graph Artifact into the
+    /// artifact's repository record. Retains every object; a same-ID
+    /// collision with another repository emits a [`ReconciliationCandidate`]
+    /// and never merges, links, or re-homes anything.
+    pub(crate) fn import_artifact(
+        &mut self,
+        artifact: &GraphArtifactDocument,
+    ) -> ManagedImportOutcome {
+        let mut imported = Vec::new();
+        let mut reconciliation_candidates = Vec::new();
+        for node in artifact
+            .nodes
+            .iter()
+            .filter_map(GraphNode::as_knowledge_object)
+        {
+            let known = self
+                .repositories
+                .get(&artifact.repository_identity)
+                .and_then(|record| record.objects.get(&node.id))
+                .map(|object| {
+                    let unchanged = object
+                        .versions
+                        .last()
+                        .is_some_and(|latest| latest.content_hash == node.content_hash);
+                    (object.canonical.clone(), unchanged)
+                });
+            let (canonical, colliding_parties) = match known {
+                // RT-04: unchanged governed meaning re-observed — no new
+                // content version, nothing minted.
+                Some((_, true)) => continue,
+                Some((canonical, false)) => (canonical, Vec::new()),
+                // First appearance of this Object ID in this repository:
+                // record same-ID parties from every other repository, then
+                // mint a fresh canonical identity — a colliding object's
+                // identity is never adopted.
+                None => {
+                    let parties = self.colliding_parties(&artifact.repository_identity, &node.id);
+                    (self.mint_canonical_identity(), parties)
+                }
+            };
+            let version_id = self.mint_version_id();
+            let record = self
+                .repositories
+                .entry(artifact.repository_identity.clone())
+                .or_insert_with(|| ManagedRepositoryRecord {
+                    repository_identity: artifact.repository_identity.clone(),
+                    objects: BTreeMap::new(),
+                });
+            let object =
+                record
+                    .objects
+                    .entry(node.id.clone())
+                    .or_insert_with(|| ManagedObjectRecord {
+                        canonical: canonical.clone(),
+                        object_id: node.id.clone(),
+                        versions: Vec::new(),
+                    });
+            object.versions.push(ManagedVersionRecord {
+                version_id: version_id.clone(),
+                content_hash: node.content_hash.clone(),
+                source_binding: node.source_binding.clone(),
+                source_assertions: Vec::new(),
+            });
+            for existing in colliding_parties {
+                reconciliation_candidates.push(ReconciliationCandidate {
+                    object_id: node.id.clone(),
+                    reason: ReconciliationReason::ObjectIdCollision,
+                    existing,
+                    incoming: ReconciliationParty {
+                        canonical: canonical.clone(),
+                        repository_identity: artifact.repository_identity.clone(),
+                        version_id: version_id.clone(),
+                        content_hash: node.content_hash.clone(),
+                    },
+                });
+            }
+            imported.push(ImportedVersion {
+                object_id: node.id.clone(),
+                canonical,
+                version_id,
+            });
+        }
+        ManagedImportOutcome {
+            imported,
+            reconciliation_candidates,
+        }
+    }
+
+    /// Same-ID parties in every other repository of this workspace. The
+    /// scan is exact-ID only: no hash, title, or similarity matching
+    /// exists (RT-03/D36).
+    fn colliding_parties(
+        &self,
+        repository_identity: &GraphRepositoryIdentity,
+        object_id: &str,
+    ) -> Vec<ReconciliationParty> {
+        self.repositories
+            .iter()
+            .filter(|(key, _)| *key != repository_identity)
+            .filter_map(|(key, record)| {
+                let object = record.objects.get(object_id)?;
+                // Non-empty by construction: records only ever gain
+                // versions, starting with one at creation.
+                let latest = object.versions.last()?;
+                Some(ReconciliationParty {
+                    canonical: object.canonical.clone(),
+                    repository_identity: key.clone(),
+                    version_id: latest.version_id.clone(),
+                    content_hash: latest.content_hash.clone(),
+                })
+            })
+            .collect()
+    }
+
+    fn mint_canonical_identity(&mut self) -> WorkspaceCanonicalIdentity {
+        self.minted_canonical_ids += 1;
+        WorkspaceCanonicalIdentity {
+            workspace_id: self.workspace_id.clone(),
+            canonical_id: format!("mo-{}", self.minted_canonical_ids),
+        }
+    }
+
+    fn mint_version_id(&mut self) -> ManagedVersionId {
+        self.minted_version_ids += 1;
+        ManagedVersionId(format!("mv-{}", self.minted_version_ids))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! E1.2.T1 exit tests (MILESTONES §E1.2; RED-TEAM-CLOSURE §RT-03;
+    //! DECISION-REGISTER §D36; ADR-0057 invariant 1): importing two Graph
+    //! Artifacts that carry the same Object ID retains both objects
+    //! distinct and emits a typed reconciliation candidate — never a merge.
+    use std::collections::BTreeMap;
+
+    use serde_json::json;
+
+    use super::*;
+    use crate::domain::graph::{
+        GraphKnowledgeObjectNode, GraphNode, GraphRelations, GraphSourceBinding, GraphSourceSpan,
+    };
+
+    /// Registered (planned) contract id governing the serialized candidate
+    /// record shape pinned below.
+    const RECONCILIATION_CANDIDATE_CONTRACT: &str = "adoc.reconciliation_candidate.v0";
+
+    fn workspace() -> ManagedWorkspace {
+        ManagedWorkspace::new(WorkspaceId::new("ws-acme").expect("workspace id is non-blank"))
+    }
+
+    fn local_repo(config_path: &str) -> GraphRepositoryIdentity {
+        GraphRepositoryIdentity::local_project(config_path.to_string())
+    }
+
+    fn knowledge_object(id: &str, content_hash: &str) -> GraphKnowledgeObjectNode {
+        GraphKnowledgeObjectNode {
+            id: id.to_string(),
+            kind: "claim".to_string(),
+            content_hash: content_hash.to_string(),
+            status: None,
+            severity: None,
+            trust: None,
+            body: "Credits apply after payment.".to_string(),
+            page_id: "team.page".to_string(),
+            source_span: GraphSourceSpan {
+                path: "docs/team.adoc".to_string(),
+                line: 1,
+                column: 1,
+            },
+            source_binding: None,
+            visibility: None,
+            field_visibility: None,
+            fields: BTreeMap::new(),
+            relations: GraphRelations::default(),
+            impacts: Vec::new(),
+            approved_by: Vec::new(),
+            allowed_actions: Vec::new(),
+            forbidden_actions: Vec::new(),
+            contradiction_claims: Vec::new(),
+            evidence: Vec::new(),
+            effective_status: None,
+            effective_reason: None,
+            evidence_quality: None,
+        }
+    }
+
+    fn artifact(
+        repository_identity: GraphRepositoryIdentity,
+        nodes: Vec<GraphKnowledgeObjectNode>,
+    ) -> GraphArtifactDocument {
+        GraphArtifactDocument {
+            schema_version: "adoc.graph.v6".to_string(),
+            repository_identity,
+            nodes: nodes.into_iter().map(GraphNode::KnowledgeObject).collect(),
+            edges: Vec::new(),
+            diagnostics: Vec::new(),
+        }
+    }
+
+    /// Exit test: same Object ID in two repositories — both retained
+    /// distinct under fresh workspace canonical identities, one typed
+    /// reconciliation candidate emitted, never a merge (RT-03, D36).
+    #[test]
+    fn same_object_id_in_two_repositories_retains_both_and_emits_candidate() {
+        let mut workspace = workspace();
+        let repo_a = local_repo("a/agentdoc.config.yaml");
+        let repo_b = local_repo("b/agentdoc.config.yaml");
+
+        let first = workspace.import_artifact(&artifact(
+            repo_a.clone(),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        ));
+        assert!(first.reconciliation_candidates.is_empty());
+
+        let second = workspace.import_artifact(&artifact(
+            repo_b.clone(),
+            vec![knowledge_object("billing.credits", "sha256:bbb")],
+        ));
+
+        let object_a = &workspace
+            .repository(&repo_a)
+            .expect("repo a recorded")
+            .objects["billing.credits"];
+        let object_b = &workspace
+            .repository(&repo_b)
+            .expect("repo b recorded")
+            .objects["billing.credits"];
+        assert_eq!(object_a.object_id, "billing.credits");
+        assert_eq!(object_b.object_id, "billing.credits");
+        assert_ne!(
+            object_a.canonical, object_b.canonical,
+            "colliding Object IDs must never share a canonical identity"
+        );
+
+        assert_eq!(second.reconciliation_candidates.len(), 1);
+        let candidate = &second.reconciliation_candidates[0];
+        assert_eq!(candidate.object_id, "billing.credits");
+        assert_eq!(candidate.reason, ReconciliationReason::ObjectIdCollision);
+        assert_eq!(candidate.existing.canonical, object_a.canonical);
+        assert_eq!(candidate.existing.repository_identity, repo_a);
+        assert_eq!(candidate.incoming.canonical, object_b.canonical);
+        assert_eq!(candidate.incoming.repository_identity, repo_b);
+    }
+
+    /// The serialized record the Cloud cut consumes under the planned
+    /// `adoc.reconciliation_candidate.v0` registry row. Covers both
+    /// repository identity spellings: `{kind, config_path}` and explicit
+    /// `null` (standalone).
+    #[test]
+    fn reconciliation_candidate_serialized_record_shape_is_pinned() {
+        let mut workspace = workspace();
+        workspace.import_artifact(&artifact(
+            local_repo("a/agentdoc.config.yaml"),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        ));
+        let outcome = workspace.import_artifact(&artifact(
+            GraphRepositoryIdentity::standalone(),
+            vec![knowledge_object("billing.credits", "sha256:bbb")],
+        ));
+
+        let candidate = &outcome.reconciliation_candidates[0];
+        let value = serde_json::to_value(candidate).expect("candidate serializes");
+        assert_eq!(
+            value,
+            json!({
+                "object_id": "billing.credits",
+                "reason": "object_id_collision",
+                "existing": {
+                    "canonical": {
+                        "workspace_id": "ws-acme",
+                        "canonical_id": "mo-1"
+                    },
+                    "repository_identity": {
+                        "kind": "local_project",
+                        "config_path": "a/agentdoc.config.yaml"
+                    },
+                    "version_id": "mv-1",
+                    "content_hash": "sha256:aaa"
+                },
+                "incoming": {
+                    "canonical": {
+                        "workspace_id": "ws-acme",
+                        "canonical_id": "mo-2"
+                    },
+                    "repository_identity": null,
+                    "version_id": "mv-2",
+                    "content_hash": "sha256:bbb"
+                }
+            }),
+            "the {RECONCILIATION_CANDIDATE_CONTRACT} record shape drifted"
+        );
+    }
+
+    /// Acceptance: every managed candidate version receives a unique
+    /// immutable version ID while the Object ID and workspace canonical
+    /// identity stay stable across revisions.
+    #[test]
+    fn revisions_mint_unique_version_ids_under_a_stable_object_identity() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        let first = workspace.import_artifact(&artifact(
+            repo.clone(),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        ));
+        let second = workspace.import_artifact(&artifact(
+            repo.clone(),
+            vec![knowledge_object("billing.credits", "sha256:ccc")],
+        ));
+
+        let object =
+            &workspace.repository(&repo).expect("repo recorded").objects["billing.credits"];
+        assert_eq!(object.versions.len(), 2);
+        assert_ne!(object.versions[0].version_id, object.versions[1].version_id);
+        assert_eq!(first.imported[0].canonical, second.imported[0].canonical);
+        assert_eq!(second.imported[0].object_id, "billing.credits");
+        assert!(second.reconciliation_candidates.is_empty());
+    }
+
+    /// RT-04: re-observing unchanged governed meaning is not a new content
+    /// version — nothing is minted.
+    #[test]
+    fn reimporting_unchanged_content_mints_no_new_version() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+        let document = artifact(
+            repo.clone(),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        );
+
+        workspace.import_artifact(&document);
+        let again = workspace.import_artifact(&document);
+
+        assert!(again.imported.is_empty());
+        assert!(again.reconciliation_candidates.is_empty());
+        let object =
+            &workspace.repository(&repo).expect("repo recorded").objects["billing.credits"];
+        assert_eq!(object.versions.len(), 1);
+    }
+
+    /// Stop-ship guard (MILESTONES §E1.2 acceptance): identity is
+    /// workspace-qualified — equal opaque suffixes in two workspaces never
+    /// compare equal, so an unqualified Object ID cannot link identities
+    /// across workspaces.
+    #[test]
+    fn canonical_identity_is_workspace_qualified() {
+        let mut workspace_a = ManagedWorkspace::new(WorkspaceId::new("ws-a").expect("non-blank"));
+        let mut workspace_b = ManagedWorkspace::new(WorkspaceId::new("ws-b").expect("non-blank"));
+        let repo = local_repo("a/agentdoc.config.yaml");
+        let document = artifact(
+            repo.clone(),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        );
+
+        let in_a = workspace_a.import_artifact(&document);
+        let in_b = workspace_b.import_artifact(&document);
+
+        assert_eq!(in_a.imported[0].canonical.canonical_id, "mo-1");
+        assert_eq!(in_b.imported[0].canonical.canonical_id, "mo-1");
+        assert_ne!(
+            in_a.imported[0].canonical, in_b.imported[0].canonical,
+            "workspace qualification must separate identical opaque suffixes"
+        );
+    }
+
+    /// A blank workspace id would produce unqualified canonical identities;
+    /// construction fails closed instead.
+    #[test]
+    fn blank_workspace_id_is_rejected() {
+        assert!(WorkspaceId::new("").is_err());
+        assert!(WorkspaceId::new(" \t").is_err());
+    }
+
+    /// The Source Assertion identity layer (K7) exists as its own type;
+    /// blank identities fail closed and the value serializes transparently.
+    #[test]
+    fn source_assertion_identity_is_typed_and_rejects_blank_values() {
+        assert!(SourceAssertionIdentity::new("  ").is_err());
+        let identity =
+            SourceAssertionIdentity::new("confluence:page-9:rev-4:assertion-2").expect("non-blank");
+        assert_eq!(
+            serde_json::to_value(&identity).expect("serializes"),
+            json!("confluence:page-9:rev-4:assertion-2")
+        );
+    }
+
+    /// RT-03: imported versions preserve their exact Source Binding; the
+    /// Source Assertion slot exists per version and stays empty until the
+    /// Source Record/Assertion store lands (E4.1).
+    #[test]
+    fn imported_versions_preserve_the_source_binding() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+        let mut node = knowledge_object("billing.credits", "sha256:aaa");
+        node.source_binding = Some(GraphSourceBinding {
+            connector: "local_fs".to_string(),
+            source: "team.page".to_string(),
+            revision: None,
+            path: "docs/team.adoc".to_string(),
+            anchor: "billing.credits".to_string(),
+            source_revision_digest: "sha256:feed".to_string(),
+        });
+        let expected = node.source_binding.clone();
+
+        workspace.import_artifact(&artifact(repo.clone(), vec![node]));
+
+        let object =
+            &workspace.repository(&repo).expect("repo recorded").objects["billing.credits"];
+        assert_eq!(object.versions[0].source_binding, expected);
+        assert!(object.versions[0].source_assertions.is_empty());
+    }
+}

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -131,8 +131,13 @@ pub(crate) struct ManagedObjectRecord {
 pub(crate) struct ManagedVersionRecord {
     pub(crate) version_id: ManagedVersionId,
     pub(crate) content_hash: String,
-    /// The exact Source Binding observed at import time, when the artifact
-    /// carried one.
+    /// The exact Source Binding observed when this version was minted,
+    /// when the artifact carried one. A same-hash re-observation with a
+    /// changed binding (document moved, rename-only source revision) mints
+    /// nothing and does **not** refresh this record: versions are
+    /// immutable, and a placement change is not a content change (RT-04,
+    /// ADR-0058 — placement is excluded from the v6 hash). Re-observation
+    /// freshness is the connector/store's concern (E4.1).
     pub(crate) source_binding: Option<GraphSourceBinding>,
     /// Contributing Source Assertions. Empty until the Source
     /// Record/Assertion store lands (E4.1).
@@ -180,6 +185,11 @@ pub(crate) struct ManagedImportOutcome {
     /// meaning mints nothing — a re-observation is not a new content
     /// version (RT-04).
     pub(crate) imported: Vec<ImportedVersion>,
+    /// A collision is announced exactly once — on the colliding Object
+    /// ID's first appearance in a repository — and is not re-derivable
+    /// from the aggregate afterwards. The caller owns persisting every
+    /// candidate until it is decided (durability is the Cloud cut,
+    /// E1.2.T3; decisions are E1.3).
     pub(crate) reconciliation_candidates: Vec<ReconciliationCandidate>,
 }
 
@@ -598,6 +608,46 @@ mod tests {
         assert_eq!(first.imported[0].canonical, second.imported[0].canonical);
         assert_eq!(second.imported[0].object_id, "billing.credits");
         assert!(second.reconciliation_candidates.is_empty());
+    }
+
+    /// Pins the binding-retention contract: a same-hash re-observation
+    /// carrying a *changed* Source Binding mints nothing and keeps the
+    /// original binding — versions are immutable and placement is not
+    /// content (RT-04, ADR-0058). Re-observation freshness is E4.1's
+    /// concern, and the Cloud cut copies this behavior.
+    #[test]
+    fn reimporting_unchanged_content_with_a_new_binding_keeps_the_original() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+        let binding = |path: &str, digest: &str| GraphSourceBinding {
+            connector: "local_fs".to_string(),
+            source: "team.page".to_string(),
+            revision: None,
+            path: path.to_string(),
+            anchor: "billing.credits".to_string(),
+            source_revision_digest: digest.to_string(),
+        };
+        let mut node = knowledge_object("billing.credits", "sha256:aaa");
+        node.source_binding = Some(binding("docs/team.adoc", "sha256:feed"));
+        let original = node.source_binding.clone();
+        workspace
+            .import_artifact(&artifact(repo.clone(), vec![node]))
+            .expect("import accepted");
+
+        let mut moved = knowledge_object("billing.credits", "sha256:aaa");
+        moved.source_binding = Some(binding("docs/moved.adoc", "sha256:beef"));
+        let again = workspace
+            .import_artifact(&artifact(repo.clone(), vec![moved]))
+            .expect("import accepted");
+
+        assert!(again.imported.is_empty());
+        let object =
+            &workspace.repository(&repo).expect("repo recorded").objects["billing.credits"];
+        assert_eq!(object.versions.len(), 1);
+        assert_eq!(
+            object.versions[0].source_binding, original,
+            "an immutable version keeps the binding observed when it was minted"
+        );
     }
 
     /// RT-04: re-observing unchanged governed meaning is not a new content

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -12,10 +12,12 @@
 //!
 //! Managed import (RT-03, D36): matching Object IDs, titles, hashes, or
 //! semantic similarity never auto-merge. A same-ID collision across
-//! repositories retains every object distinct and emits a typed
-//! [`ReconciliationCandidate`] (`adoc.reconciliation_candidate.v0`,
-//! registered planned in CONTRACT-REGISTRY.md); deciding a candidate is a
-//! governed E1.3 action, never an import side effect.
+//! distinctly keyed repositories (see [`ManagedRepositoryRecord`] for what
+//! the graph identity does and does not distinguish) retains every object
+//! distinct and emits a typed [`ReconciliationCandidate`]
+//! (`adoc.reconciliation_candidate.v0`, registered planned in
+//! CONTRACT-REGISTRY.md); deciding a candidate is a governed E1.3 action,
+//! never an import side effect.
 
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -126,11 +128,12 @@ fn content_hash_matches_published_grammar(value: &str) -> bool {
 /// (`FsSourceProvider::repository_identity`, ADR-0049 §7), so two
 /// physical repositories importing under the producer identity are one
 /// record to this aggregate. Identity-equality keying is therefore the
-/// single-repository convenience only. A multi-repository workspace
-/// routes each import to a reserved slot explicitly — the key supplied
-/// by the caller from its authenticated channel, never read from the
-/// artifact — with the reserved binding slot as the disambiguator; that
-/// routing path is E1.3 scope (PR #150 adjudication).
+/// single-repository convenience only. E1.3 adds explicit routing for
+/// the multi-repository workspace — a caller-supplied repository key
+/// bound from the authenticated channel, never read from the artifact,
+/// with the reserved binding slot (V10.3.2) as the disambiguator (PR
+/// #150 adjudication); until then the artifact's declared identity *is*
+/// the key.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) struct ManagedRepositoryRecord {
     pub(crate) repository_identity: GraphRepositoryIdentity,
@@ -302,8 +305,10 @@ impl ManagedWorkspace {
     /// a silent drop; (2) the artifact's self-declared
     /// `repository_identity` is taken as the record key, which
     /// distinguishes repositories only as far as the caller's identities
-    /// do ([`ManagedRepositoryRecord`]) — a caller on a trust boundary
-    /// routes to a reserved slot instead of trusting the payload (E1.3).
+    /// do ([`ManagedRepositoryRecord`]) — E1.3 adds a caller-supplied
+    /// repository key so the record is bound from the authenticated
+    /// channel rather than the payload; until then the artifact's
+    /// declared identity *is* the key.
     pub(crate) fn import_artifact(
         &mut self,
         artifact: &GraphArtifactDocument,

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -212,6 +212,21 @@ impl ManagedWorkspace {
         self.repositories.get(repository_identity)
     }
 
+    /// V10.3.2: reserve the repository record — the binding slot — before
+    /// the first artifact arrives. Idempotent: a later reservation or
+    /// import binds to the existing record and never clears it.
+    pub(crate) fn reserve_repository(
+        &mut self,
+        repository_identity: GraphRepositoryIdentity,
+    ) -> &ManagedRepositoryRecord {
+        self.repositories
+            .entry(repository_identity.clone())
+            .or_insert_with(|| ManagedRepositoryRecord {
+                repository_identity,
+                objects: BTreeMap::new(),
+            })
+    }
+
     /// Import every Knowledge Object of a Graph Artifact into the
     /// artifact's repository record. Retains every object; a same-ID
     /// collision with another repository emits a [`ReconciliationCandidate`]
@@ -220,6 +235,9 @@ impl ManagedWorkspace {
         &mut self,
         artifact: &GraphArtifactDocument,
     ) -> ManagedImportOutcome {
+        // Arrival binds the slot even when the artifact carries no
+        // Knowledge Objects (E1.2.T4).
+        self.reserve_repository(artifact.repository_identity.clone());
         let mut imported = Vec::new();
         let mut reconciliation_candidates = Vec::new();
         for node in artifact
@@ -753,5 +771,94 @@ mod tests {
         assert_ne!(object_a.canonical, object_b.canonical);
         assert_eq!(object_a.versions.len(), 1);
         assert_eq!(object_b.versions.len(), 1);
+    }
+
+    // E1.2.T4: the managed repository record keys on the graph
+    // `repository_identity` ({kind, config_path} or explicit null,
+    // ADR-0049); the binding slot is reserved before the first artifact
+    // arrives (provenance V10.3.2); imported Object IDs stay
+    // repository-local.
+
+    /// V10.3.2: the binding slot — the keyed repository record — exists
+    /// before the first artifact arrives.
+    #[test]
+    fn reserved_repository_slot_exists_before_the_first_artifact() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        workspace.reserve_repository(repo.clone());
+
+        let record = workspace.repository(&repo).expect("slot reserved");
+        assert_eq!(record.repository_identity, repo);
+        assert!(record.objects.is_empty());
+    }
+
+    /// The first import binds into the reserved record — reservation and
+    /// import key on the same repository identity, and re-reserving never
+    /// clears what an import recorded.
+    #[test]
+    fn import_binds_to_the_reserved_record_and_reserve_is_idempotent() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+        workspace.reserve_repository(repo.clone());
+        workspace.reserve_repository(repo.clone());
+
+        workspace.import_artifact(&artifact(
+            repo.clone(),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        ));
+        workspace.reserve_repository(repo.clone());
+
+        let record = workspace.repository(&repo).expect("repo recorded");
+        assert!(record.objects.contains_key("billing.credits"));
+    }
+
+    /// Importing an artifact with no Knowledge Objects still records the
+    /// repository: arrival binds the slot even when nothing is imported.
+    #[test]
+    fn import_without_knowledge_objects_still_records_the_repository() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        let outcome = workspace.import_artifact(&artifact(repo.clone(), Vec::new()));
+
+        assert!(outcome.imported.is_empty());
+        let record = workspace
+            .repository(&repo)
+            .expect("repo recorded on arrival");
+        assert!(record.objects.is_empty());
+    }
+
+    /// Exit test: two imported repositories collide — `{kind, config_path}`
+    /// and explicit `null` are distinct keys, each retains its own object
+    /// under the shared Object ID, and the collision is a candidate, never
+    /// a silent same-ID merge across repositories.
+    #[test]
+    fn object_ids_stay_repository_local_across_null_and_project_keys() {
+        let mut workspace = workspace();
+        let project = local_repo("a/agentdoc.config.yaml");
+        let standalone = GraphRepositoryIdentity::standalone();
+
+        workspace.import_artifact(&artifact(
+            project.clone(),
+            vec![knowledge_object("billing.credits", "sha256:aaa")],
+        ));
+        let outcome = workspace.import_artifact(&artifact(
+            standalone.clone(),
+            vec![knowledge_object("billing.credits", "sha256:bbb")],
+        ));
+
+        assert_eq!(outcome.reconciliation_candidates.len(), 1);
+        let in_project = &workspace
+            .repository(&project)
+            .expect("project repo")
+            .objects["billing.credits"];
+        let in_standalone = &workspace
+            .repository(&standalone)
+            .expect("standalone repo")
+            .objects["billing.credits"];
+        assert_ne!(in_project.canonical, in_standalone.canonical);
+        assert_eq!(in_project.versions[0].content_hash, "sha256:aaa");
+        assert_eq!(in_standalone.versions[0].content_hash, "sha256:bbb");
     }
 }

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -239,7 +239,7 @@ impl ManagedWorkspace {
     pub(crate) fn reserve_repository(
         &mut self,
         repository_identity: GraphRepositoryIdentity,
-    ) -> &ManagedRepositoryRecord {
+    ) -> &mut ManagedRepositoryRecord {
         self.repositories
             .entry(repository_identity.clone())
             .or_insert_with(|| ManagedRepositoryRecord {
@@ -319,13 +319,9 @@ impl ManagedWorkspace {
                 }
             };
             let version_id = self.mint_version_id();
-            let record = self
-                .repositories
-                .entry(artifact.repository_identity.clone())
-                .or_insert_with(|| ManagedRepositoryRecord {
-                    repository_identity: artifact.repository_identity.clone(),
-                    objects: BTreeMap::new(),
-                });
+            // Reserved before the loop; re-reserving binds to the existing
+            // record — this is the single construction path.
+            let record = self.reserve_repository(artifact.repository_identity.clone());
             let object =
                 record
                     .objects

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -24,10 +24,13 @@ use serde::Serialize;
 use super::graph::{GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding};
 use super::identity::ObjectId;
 
-/// Cloud workspace identifier — opaque to `adoc-core`. Blank input is
-/// rejected: an empty workspace id would produce unqualified canonical
-/// identities, defeating the qualification that keeps identity unlinkable
-/// across workspaces (MILESTONES §E1.2 stop-ship).
+/// Cloud workspace identifier — opaque to `adoc-core`. Blank or padded
+/// input is rejected: an empty workspace id would produce unqualified
+/// canonical identities, defeating the qualification that keeps identity
+/// unlinkable across workspaces (MILESTONES §E1.2 stop-ship), and a
+/// whitespace-padded one would be a second spelling of the same workspace
+/// that never compares equal. Never normalized — silently unifying two
+/// spellings is a merge nobody decided.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]
 pub(crate) struct WorkspaceId(String);
@@ -35,8 +38,8 @@ pub(crate) struct WorkspaceId(String);
 impl WorkspaceId {
     pub(crate) fn new(value: impl Into<String>) -> Result<Self, ManagedIdentityError> {
         let value = value.into();
-        if value.trim().is_empty() {
-            Err(ManagedIdentityError::BlankWorkspaceId)
+        if value.is_empty() || value.trim() != value {
+            Err(ManagedIdentityError::InvalidWorkspaceId)
         } else {
             Ok(Self(value))
         }
@@ -62,7 +65,8 @@ pub(crate) struct ManagedVersionId(String);
 
 /// K6 layer 4: the identity of one immutable Source Assertion (K7). Only
 /// the identity layer lands in E1.2 — the Source Record/Assertion store is
-/// E4.1. Blank identities fail closed.
+/// E4.1. Blank or whitespace-padded identities fail closed (same posture
+/// as [`WorkspaceId`]: identity values are never normalized).
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize)]
 #[serde(transparent)]
 pub(crate) struct SourceAssertionIdentity(String);
@@ -70,8 +74,8 @@ pub(crate) struct SourceAssertionIdentity(String);
 impl SourceAssertionIdentity {
     pub(crate) fn new(value: impl Into<String>) -> Result<Self, ManagedIdentityError> {
         let value = value.into();
-        if value.trim().is_empty() {
-            Err(ManagedIdentityError::BlankSourceAssertionIdentity)
+        if value.is_empty() || value.trim() != value {
+            Err(ManagedIdentityError::InvalidSourceAssertionIdentity)
         } else {
             Ok(Self(value))
         }
@@ -80,10 +84,10 @@ impl SourceAssertionIdentity {
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum ManagedIdentityError {
-    #[error("workspace id must not be blank")]
-    BlankWorkspaceId,
-    #[error("source assertion identity must not be blank")]
-    BlankSourceAssertionIdentity,
+    #[error("workspace id must be non-blank without surrounding whitespace")]
+    InvalidWorkspaceId,
+    #[error("source assertion identity must be non-blank without surrounding whitespace")]
+    InvalidSourceAssertionIdentity,
     #[error("object id must not be blank")]
     BlankObjectId,
     #[error("object id violates the Object ID grammar")]
@@ -650,12 +654,18 @@ mod tests {
         );
     }
 
-    /// A blank workspace id would produce unqualified canonical identities;
-    /// construction fails closed instead.
+    /// A blank workspace id would produce unqualified canonical identities,
+    /// and a padded one would make `"ws-acme"` and `" ws-acme"` two
+    /// workspaces whose identities never compare equal — with the
+    /// whitespace shipping on the wire through the transparent payload.
+    /// Construction fails closed on both; it never normalizes (silently
+    /// unifying two spellings is a merge nobody decided).
     #[test]
-    fn blank_workspace_id_is_rejected() {
+    fn blank_or_padded_workspace_id_is_rejected() {
         assert!(WorkspaceId::new("").is_err());
         assert!(WorkspaceId::new(" \t").is_err());
+        assert!(WorkspaceId::new(" ws-acme").is_err());
+        assert!(WorkspaceId::new("ws-acme ").is_err());
     }
 
     /// A crafted artifact carrying a blank Object ID (empty or
@@ -745,10 +755,13 @@ mod tests {
     }
 
     /// The Source Assertion identity layer (K7) exists as its own type;
-    /// blank identities fail closed and the value serializes transparently.
+    /// blank and padded identities fail closed and the value serializes
+    /// transparently.
     #[test]
     fn source_assertion_identity_is_typed_and_rejects_blank_values() {
         assert!(SourceAssertionIdentity::new("  ").is_err());
+        assert!(SourceAssertionIdentity::new(" a:b").is_err());
+        assert!(SourceAssertionIdentity::new("a:b ").is_err());
         let identity =
             SourceAssertionIdentity::new("confluence:page-9:rev-4:assertion-2").expect("non-blank");
         assert_eq!(

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -21,10 +21,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
-use super::graph::{
-    GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding,
-    content_hash_matches_grammar,
-};
+use super::graph::{GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding};
 use super::identity::ObjectId;
 
 /// Cloud workspace identifier — opaque to `adoc-core`. Blank or padded
@@ -97,8 +94,23 @@ pub(crate) enum ManagedIdentityError {
     InvalidObjectId,
     #[error("object id appears more than once in one artifact")]
     DuplicateObjectId,
-    #[error("content hash must be `sha256:` with a non-empty suffix")]
+    #[error("content hash must be `sha256:` followed by lowercase hex")]
     InvalidContentHash,
+}
+
+/// The published v6 wire grammar for `content_hash`
+/// (`docs/agent/v0/schema/graph-artifact.v6.json`: `^sha256:[0-9a-f]+$`).
+/// Stricter than the graph loader's pinned non-blank-suffix acceptance
+/// (`graph::content_hash_matches_grammar`): at this trust boundary a
+/// malformed or padded value would be enshrined in an immutable version
+/// and compared verbatim for RT-04 unchanged-ness ever after.
+fn content_hash_matches_published_grammar(value: &str) -> bool {
+    value.strip_prefix("sha256:").is_some_and(|suffix| {
+        !suffix.is_empty()
+            && suffix
+                .bytes()
+                .all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+    })
 }
 
 /// One managed repository inside a workspace, keyed on the graph
@@ -313,7 +325,7 @@ impl ManagedWorkspace {
             if !seen_ids.insert(node.id.as_str()) {
                 return Err(ManagedIdentityError::DuplicateObjectId);
             }
-            if !content_hash_matches_grammar(&node.content_hash) {
+            if !content_hash_matches_published_grammar(&node.content_hash) {
                 return Err(ManagedIdentityError::InvalidContentHash);
             }
         }
@@ -806,7 +818,7 @@ mod tests {
         let mut workspace = workspace();
         let repo = local_repo("a/agentdoc.config.yaml");
 
-        for hashes in [["sha256:aaa", "sha256:bbb"], ["sha256:same", "sha256:same"]] {
+        for hashes in [["sha256:aaa", "sha256:bbb"], ["sha256:5a3e", "sha256:5a3e"]] {
             let outcome = workspace.import_artifact(&artifact(
                 repo.clone(),
                 vec![
@@ -858,15 +870,28 @@ mod tests {
     /// A crafted artifact carrying a blank or malformed `content_hash`
     /// would otherwise mint an immutable version around it, surface it in
     /// reconciliation candidates, and treat every later observation of the
-    /// same malformed value as unchanged. The graph loader rejects these
-    /// documents (`content_hash_diagnostic`, `io.artifact_malformed`);
-    /// import fails closed the same way, before any state changes.
+    /// same malformed value as unchanged. Import enforces the published v6
+    /// wire grammar `^sha256:[0-9a-f]+$` (graph-artifact.v6.json): non-hex,
+    /// uppercase, and whitespace-padded suffixes all fail closed before any
+    /// state changes — a padded spelling of an existing hash would
+    /// otherwise mint a fresh version of unchanged content and ship the
+    /// padded value in the candidate payload.
     #[test]
     fn malformed_content_hashes_on_import_are_rejected_without_partial_state() {
         let mut workspace = workspace();
         let repo = local_repo("a/agentdoc.config.yaml");
 
-        for invalid in ["", "  ", "sha256:", "sha256:  ", "md5:abc"] {
+        for invalid in [
+            "",
+            "  ",
+            "sha256:",
+            "sha256:  ",
+            "md5:abc",
+            "sha256:not-a-digest",
+            "sha256:abc ",
+            " sha256:abc",
+            "sha256:ABC",
+        ] {
             let outcome = workspace.import_artifact(&artifact(
                 repo.clone(),
                 vec![knowledge_object("billing.credits", invalid)],
@@ -947,8 +972,8 @@ mod tests {
             .import_artifact(&artifact(
                 repo.clone(),
                 vec![
-                    knowledge_object("billing.credits", "sha256:same"),
-                    knowledge_object("billing.refunds", "sha256:same"),
+                    knowledge_object("billing.credits", "sha256:5a3e"),
+                    knowledge_object("billing.refunds", "sha256:5a3e"),
                 ],
             ))
             .expect("import accepted");
@@ -977,13 +1002,13 @@ mod tests {
         workspace
             .import_artifact(&artifact(
                 repo_a.clone(),
-                vec![knowledge_object("billing.credits", "sha256:same")],
+                vec![knowledge_object("billing.credits", "sha256:5a3e")],
             ))
             .expect("import accepted");
         let outcome = workspace
             .import_artifact(&artifact(
                 repo_b.clone(),
-                vec![knowledge_object("billing.refunds", "sha256:same")],
+                vec![knowledge_object("billing.refunds", "sha256:5a3e")],
             ))
             .expect("import accepted");
 
@@ -1004,11 +1029,11 @@ mod tests {
     fn identical_titles_and_bodies_never_unify() {
         let mut workspace = workspace();
         let repo = local_repo("a/agentdoc.config.yaml");
-        let mut first = knowledge_object("billing.credits", "sha256:same");
+        let mut first = knowledge_object("billing.credits", "sha256:5a3e");
         first
             .fields
             .insert("title".to_string(), "Credit policy".to_string());
-        let mut second = knowledge_object("billing.credit-rules", "sha256:same");
+        let mut second = knowledge_object("billing.credit-rules", "sha256:5a3e");
         second
             .fields
             .insert("title".to_string(), "Credit policy".to_string());
@@ -1041,13 +1066,13 @@ mod tests {
         workspace
             .import_artifact(&artifact(
                 repo_a.clone(),
-                vec![knowledge_object("billing.credits", "sha256:same")],
+                vec![knowledge_object("billing.credits", "sha256:5a3e")],
             ))
             .expect("import accepted");
         let outcome = workspace
             .import_artifact(&artifact(
                 repo_b.clone(),
-                vec![knowledge_object("billing.credits", "sha256:same")],
+                vec![knowledge_object("billing.credits", "sha256:5a3e")],
             ))
             .expect("import accepted");
 

--- a/crates/adoc-core/src/domain/managed.rs
+++ b/crates/adoc-core/src/domain/managed.rs
@@ -17,11 +17,12 @@
 //! registered planned in CONTRACT-REGISTRY.md); deciding a candidate is a
 //! governed E1.3 action, never an import side effect.
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use serde::Serialize;
 
 use super::graph::{GraphArtifactDocument, GraphNode, GraphRepositoryIdentity, GraphSourceBinding};
+use super::identity::ObjectId;
 
 /// Cloud workspace identifier — opaque to `adoc-core`. Blank input is
 /// rejected: an empty workspace id would produce unqualified canonical
@@ -77,9 +78,6 @@ impl SourceAssertionIdentity {
     }
 }
 
-// Every identity layer rejects blank input the same way; the shared
-// `Blank` prefix is the vocabulary, not noise.
-#[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
 pub(crate) enum ManagedIdentityError {
     #[error("workspace id must not be blank")]
@@ -88,6 +86,10 @@ pub(crate) enum ManagedIdentityError {
     BlankSourceAssertionIdentity,
     #[error("object id must not be blank")]
     BlankObjectId,
+    #[error("object id violates the Object ID grammar")]
+    InvalidObjectId,
+    #[error("object id appears more than once in one artifact")]
+    DuplicateObjectId,
 }
 
 /// One managed repository inside a workspace, keyed on the graph
@@ -235,20 +237,37 @@ impl ManagedWorkspace {
     /// Import every Knowledge Object of a Graph Artifact into the
     /// artifact's repository record. Retains every object; a same-ID
     /// collision with another repository emits a [`ReconciliationCandidate`]
-    /// and never merges, links, or re-homes anything. A blank Object ID
-    /// anywhere in the artifact rejects the whole import before any state
-    /// changes (fail closed — a keyed `""` object would be unaddressable).
+    /// and never merges, links, or re-homes anything.
+    ///
+    /// Fail closed on crafted input (`GraphArtifactDocument` derives
+    /// `Deserialize`, so callers cannot assume compiler-built documents): a
+    /// blank, grammar-violating, or repeated Object ID anywhere in the
+    /// artifact rejects the whole import before any state changes. The
+    /// graph loader enforces the same invariants (`id.invalid`,
+    /// `DiagnosticCode::IdDuplicateInArtifact`); a document handed to
+    /// import directly must not bypass them — a grammar-evading ID would
+    /// also evade the exact-ID collision detector, and a repeated ID would
+    /// silently unify into one record (the intra-artifact shape of the
+    /// merge RT-03/D36 forbids).
     pub(crate) fn import_artifact(
         &mut self,
         artifact: &GraphArtifactDocument,
     ) -> Result<ManagedImportOutcome, ManagedIdentityError> {
-        if artifact
+        let mut seen_ids = BTreeSet::new();
+        for node in artifact
             .nodes
             .iter()
             .filter_map(GraphNode::as_knowledge_object)
-            .any(|node| node.id.trim().is_empty())
         {
-            return Err(ManagedIdentityError::BlankObjectId);
+            if node.id.trim().is_empty() {
+                return Err(ManagedIdentityError::BlankObjectId);
+            }
+            if ObjectId::new(node.id.as_str()).is_err() {
+                return Err(ManagedIdentityError::InvalidObjectId);
+            }
+            if !seen_ids.insert(node.id.as_str()) {
+                return Err(ManagedIdentityError::DuplicateObjectId);
+            }
         }
         // Arrival binds the slot even when the artifact carries no
         // Knowledge Objects (E1.2.T4).
@@ -658,6 +677,66 @@ mod tests {
                 ],
             ));
             assert_eq!(outcome, Err(ManagedIdentityError::BlankObjectId));
+        }
+        assert!(
+            workspace.repository(&repo).is_none(),
+            "a rejected import must not bind the repository slot or mint anything"
+        );
+    }
+
+    /// A crafted artifact repeating an Object ID would otherwise mint two
+    /// versions in one import (differing hashes) or silently drop the
+    /// second occurrence (equal hashes) — the intra-artifact shape of the
+    /// auto-merge RT-03/D36 forbids. The graph loader already rejects the
+    /// document (`DiagnosticCode::IdDuplicateInArtifact`); import fails
+    /// closed the same way, before any state changes.
+    #[test]
+    fn duplicate_object_ids_in_one_artifact_are_rejected_without_partial_state() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        for hashes in [["sha256:aaa", "sha256:bbb"], ["sha256:same", "sha256:same"]] {
+            let outcome = workspace.import_artifact(&artifact(
+                repo.clone(),
+                vec![
+                    knowledge_object("billing.credits", hashes[0]),
+                    knowledge_object("billing.credits", hashes[1]),
+                ],
+            ));
+            assert_eq!(outcome, Err(ManagedIdentityError::DuplicateObjectId));
+        }
+        assert!(
+            workspace.repository(&repo).is_none(),
+            "a rejected import must not bind the repository slot or mint anything"
+        );
+    }
+
+    /// Exact Object-ID equality is the only collision detector this module
+    /// has, so an ID evading the grammar evades reconciliation too:
+    /// `"billing.credits "` never collides with `"billing.credits"` yet
+    /// reads identically. Import enforces the same `ObjectId` grammar as
+    /// the graph loader (`id.invalid`) and fails closed.
+    #[test]
+    fn object_ids_violating_the_grammar_are_rejected_without_partial_state() {
+        let mut workspace = workspace();
+        let repo = local_repo("a/agentdoc.config.yaml");
+
+        for invalid in [
+            "billing.credits ",
+            " billing.credits",
+            "Billing.Credits",
+            "billing",
+            "billing.-credits",
+        ] {
+            let outcome = workspace.import_artifact(&artifact(
+                repo.clone(),
+                vec![knowledge_object(invalid, "sha256:aaa")],
+            ));
+            assert_eq!(
+                outcome,
+                Err(ManagedIdentityError::InvalidObjectId),
+                "{invalid:?} must be rejected"
+            );
         }
         assert!(
             workspace.repository(&repo).is_none(),

--- a/crates/adoc-core/src/domain/mod.rs
+++ b/crates/adoc-core/src/domain/mod.rs
@@ -6,6 +6,11 @@ pub(crate) mod graph;
 pub(crate) mod identity;
 pub(crate) mod inline;
 pub(crate) mod knowledge_object;
+// E1.2: the managed identity contract is consumed by its domain tests and
+// the stacked E1 slices; no local adapter surface exists yet (Cloud is the
+// adapter, in its own repository), so the lib build allows dead_code here.
+#[cfg_attr(not(test), allow(dead_code))]
+pub(crate) mod managed;
 pub(crate) mod obligation;
 pub(crate) mod patch;
 pub(crate) mod ports;

--- a/docs/roadmap/v10/COMPATIBILITY.md
+++ b/docs/roadmap/v10/COMPATIBILITY.md
@@ -25,7 +25,7 @@ E8.5's GitLab CI component has no named home repository yet; its row covers the 
 | --- | --- | --- | --- | --- |
 | `E0.3` | adoc, action, cloud | adoc | adoc 0.3.4 (graph v5) · Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |
 | `E0.4` | adoc, action, cloud | adoc | adoc 0.3.4 (graph v5) · Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |
-| `E1.2` | adoc, cloud | adoc | adoc 0.3.4 (graph v5) · Cloud scaffold (pre-release) | cloud |
+| `E1.2` | adoc, cloud | adoc | adoc 0.4.0 (graph v6) · Cloud v0.1.0 (pre-release) | cloud |
 | `E1.3` | adoc, cloud | adoc | adoc 0.3.4 (graph v5) · Cloud scaffold (pre-release) | cloud |
 | `E1.4` | adoc, cloud | adoc | adoc 0.3.4 (graph v5) · Cloud scaffold (pre-release) | cloud |
 | `E1.5` | adoc, cloud | adoc | adoc 0.3.4 (graph v5) · Cloud scaffold (pre-release) | cloud |

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -101,6 +101,7 @@ Reserved ids for the accepted V1 contract set (E0.3.T2). Each row names its owni
 | `adoc.approval.v0` | cloud | E5.2 | native approval bound to exact proposal digest, principal, policy version |
 | `adoc.gate_result.v0` | adoc | E5.3 | four-mode gate decision record carrying registered `gate.*` codes |
 | `adoc.reconciliation_candidate.v0` | adoc | E1.2 | typed same-Object-ID collision record (ADR-0057 invariant 1, RT-03/D36): names both parties by workspace canonical identity, repository identity, latest immutable version id, and content hash; reason vocabulary closed to `object_id_collision` — hash/title/similarity never produce a candidate and never merge; the record ships in `adoc-core` since E1.2.T1 with its serialized shape pinned in domain tests; moves to shipped when a surface emits it on the wire |
+| `adoc.managed_object_identity.v0` | cloud | E1.2 | workspace-qualified managed Object identity record, served by the Cloud object-identities route since E1.2.T3 (payload: `schema_version`, `canonical_id`, `workspace_id`, `object_id`); the canonical identity is server-minted and never derived from the human-readable Object ID, so the same unqualified Object ID in two Workspaces stays unlinkable (RT-03; MILESTONES §E1.2 stop-ship); v0-additive; moves to shipped at Cloud's first versioned release |
 <!-- /registry:envelopes-planned -->
 
 ## Diagnostic Codes — shipped, owner `adoc`

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -100,6 +100,7 @@ Reserved ids for the accepted V1 contract set (E0.3.T2). Each row names its owni
 | `adoc.proposal.v0` | cloud | E5.1 | canonical proposal record; includes the typed per-finding no-change disposition record (E5.3.T3) |
 | `adoc.approval.v0` | cloud | E5.2 | native approval bound to exact proposal digest, principal, policy version |
 | `adoc.gate_result.v0` | adoc | E5.3 | four-mode gate decision record carrying registered `gate.*` codes |
+| `adoc.reconciliation_candidate.v0` | adoc | E1.2 | typed same-Object-ID collision record (ADR-0057 invariant 1, RT-03/D36): names both parties by workspace canonical identity, repository identity, latest immutable version id, and content hash; reason vocabulary closed to `object_id_collision` — hash/title/similarity never produce a candidate and never merge; the record ships in `adoc-core` since E1.2.T1 with its serialized shape pinned in domain tests; moves to shipped when a surface emits it on the wire |
 <!-- /registry:envelopes-planned -->
 
 ## Diagnostic Codes — shipped, owner `adoc`


### PR DESCRIPTION
Implements execution-map slice **E1.2 — Workspace-qualified managed Object identity contract** (adoc side). Stacked on #149 (E1.1): the base branch is `feat/e1.1-graph-v6-semantic-hash`, so this diff shows only the E1.2 slice — merge after #149.

## What this adds

- **`crates/adoc-core/src/domain/managed.rs`** — the managed-identity domain distinguishing the five identity layers as types: workspace canonical identity, human-readable Object ID, immutable managed version ID, Source Assertion identity, and Source Binding (the semantic hash stays with E1.1). `import_artifact` retains colliding imports as distinct objects and emits a typed reconciliation candidate — never merging on ID, content hash, title, or similarity (RT-03/D36/ADR-0057). Managed repository records key on graph `repository_identity` ({kind, config_path} or explicit null), reserving the binding slot before the first artifact arrives; Object IDs stay repository-local on import. Blank/whitespace Object IDs fail closed (`ManagedIdentityError::BlankObjectId`, trim-based) before any state changes.
- **`docs/roadmap/v10/CONTRACT-REGISTRY.md`** — registers `adoc.reconciliation_candidate.v0` (owner adoc, playbook decision 8) and `adoc.managed_object_identity.v0` (owner cloud — the cloud E1.2 route makes the identity payload externally observable, so decision 8's registration condition holds; registry-first ordering per decision 15, this row must reach adoc main before cloud CI's contract-scan can pass).
- **`docs/roadmap/v10/COMPATIBILITY.md`** — the E1.2 row pins the first tested producer-consumer pair: adoc 0.4.0 (graph v6) · Cloud v0.1.0 (pre-release), matching the cloud compatibility fixture.
- **`CONTEXT.md`** — five new ubiquitous-language entries matching the code names verbatim.

## Tracer bullets → commits

- `E1.2.T1` — 5a9a979 five-layer identity and reconciliation candidates (failing test first)
- `E1.2.T2` — ca695ae negative fixtures: same semantic `content_hash` under two IDs stays two objects; identical titles/high similarity never unify
- `E1.2.T4` — 58aa345 repository-local identity + managed repository record keyed on `repository_identity`
- review follow-ups (bare `(E1.2)`): 13188de registry row for `adoc.managed_object_identity.v0` · 7419116 tested compatibility pair · b5547ff blank-Object-ID rejection on managed import

(`E1.2.T3` is the cloud cut — companion PR in agentdoc-dev/cloud.)

## Exit gate

- Exit tests verbatim, all green: same ID in two repos; same hash under two IDs; two imported repos collide; no automatic merge; reconciliation candidate produced.
- Every managed candidate/active version receives a unique immutable version ID; the Object ID is stable across revisions.
- Adversarial crafted colliding import attempting unification is rejected — candidate only.
- Cross-workspace identity linkage by unqualified Object ID fails closed (`canonical_identity_is_workspace_qualified`).
- Each commit individually green: `cargo fmt --all --check` · `cargo clippy --workspace --all-targets --locked -- -D warnings` · `cargo test --workspace --locked` (all doc guards included) · `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`.

## Out of scope (per the milestone card)

Reconciliation decision verbs (E1.3); Source Record/Assertion store (E4.1); membership/authorization (E2.1–E2.2).

https://claude.ai/code/session_014KAAWeoJLseTv1Jrtc32pm
