### PR TITLE
E2.1 — Reserve Cloud workspace wire codes

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -10,14 +10,8 @@ concurrency:
 
 jobs:
   claude-review:
-    name: claude-review (${{ matrix.model }})
+    name: claude-review (claude-opus-5)
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        # Every PR gets two independent reviews: one from Fable 5, one from
-        # Opus 5. fail-fast off so one model's failure never cancels the other.
-        model: [claude-fable-5, claude-opus-5]
     permissions:
       contents: read
       pull-requests: read
@@ -56,5 +50,5 @@ jobs:
             actions: read
 
           claude_args: |
-            --model ${{ matrix.model }}
+            --model claude-opus-5
             --allowed-tools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*)"

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -631,9 +631,10 @@ fn planned_rows_name_exactly_one_owner_repo() {
 }
 
 /// Backticked codes cited by the executable planning surface, one
-/// `(document, line, code)` per citation. Covers `gate.*`/`action.*` codes
-/// and envelope ids; `attestation.*` siblings are deliberately outside the
-/// net — E8.1.T1 registers them as a registry edit in that slice.
+/// `(document, line, code)` per citation. Covers `gate.*`/`action.*`/
+/// `workspace.*` codes and envelope ids; `attestation.*` siblings are
+/// deliberately outside the net — E8.1.T1 registers them as a registry edit
+/// in that slice.
 fn cited_codes() -> Vec<(String, usize, String)> {
     let dir = repo_root().join("docs/roadmap/v10");
     let mut cited = Vec::new();
@@ -653,12 +654,12 @@ fn cited_codes() -> Vec<(String, usize, String)> {
         }
         for (number, line) in support::doc_scan::structural_lines(&content) {
             for span in line.split('`').skip(1).step_by(2) {
-                let is_reason_code = ["gate.", "action."].iter().any(|prefix| {
+                let is_registered_code = ["gate.", "action.", "workspace."].iter().any(|prefix| {
                     span.strip_prefix(prefix).is_some_and(|rest| {
                         !rest.is_empty() && rest.chars().all(|c| c.is_ascii_lowercase() || c == '_')
                     })
                 });
-                if is_reason_code || is_envelope_id(span) {
+                if is_registered_code || is_envelope_id(span) {
                     cited.push((name.clone(), number, span.to_string()));
                 }
             }

--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -634,7 +634,8 @@ fn planned_rows_name_exactly_one_owner_repo() {
 /// `(document, line, code)` per citation. Covers `gate.*`/`action.*`/
 /// `workspace.*` codes and envelope ids; `attestation.*` siblings are
 /// deliberately outside the net — E8.1.T1 registers them as a registry edit
-/// in that slice.
+/// in that slice. `workspace.*` permission primitives belong under their own
+/// registry anchor, never `registry:cloud-codes`.
 fn cited_codes() -> Vec<(String, usize, String)> {
     let dir = repo_root().join("docs/roadmap/v10");
     let mut cited = Vec::new();
@@ -664,6 +665,12 @@ fn cited_codes() -> Vec<(String, usize, String)> {
                 }
             }
         }
+    }
+    for prefix in ["gate.", "action.", "workspace."] {
+        assert!(
+            cited.iter().any(|(_, _, code)| code.starts_with(prefix)),
+            "no `{prefix}*` citation found"
+        );
     }
     cited
 }

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -325,15 +325,15 @@ Contract codes for the four-mode gate evaluator (E5.3; check publication E5.4). 
 
 ## Cloud codes — owner `cloud`
 
-Operation labels of the private Cloud scaffold. The scaffold's `main` emits no wire code today (the E0.4 baseline: login/register tracers, workspaces table, creator/owner-only RLS); new Cloud wire codes register here before they ship — `workspace.bootstrap` pre-registers the label the in-flight identity-bootstrap work introduces, and `governance.decision_binding_missing` ships with the E1.3 reconciliation-decision route.
+Operation labels and typed failure codes owned by the private Cloud service. New Cloud wire codes register here before they ship: `workspace.bootstrap` names the identity-bootstrap operation, the E2.1 `workspace.*` failures cover repository registration and tenant isolation, and `governance.decision_binding_missing` belongs to the E1.3 reconciliation-decision route.
 
 <!-- registry:cloud-codes -->
 | code | status | meaning |
 | --- | --- | --- |
 | `workspace.bootstrap` | planned (in-flight scaffold work) | identity-bootstrap ledger operation label recorded when a workspace is created |
-| `workspace.repository_limit_reached` | planned (E2.1) | repository registration would exceed the Workspace's configured repository limit |
+| `workspace.repository_limit_reached` | planned (E2.1) | repository registration would exceed the Workspace's repository limit |
 | `workspace.duplicate_repository` | planned (E2.1) | the same external repository is already registered in the Workspace |
-| `workspace.cross_tenant_denied` | planned (E2.1) | a Workspace-scoped operation is outside the authenticated principal's memberships; foreign and nonexistent targets remain indistinguishable |
+| `workspace.cross_tenant_denied` | planned (E2.1) | a Workspace-scoped operation is outside the authenticated principal's memberships; a nonexistent target emits this same code, so foreign and nonexistent targets remain indistinguishable to the caller |
 | `governance.decision_binding_missing` | planned (E1.3, in-flight cloud cut) | Cloud reconciliation-decision route rejects a record whose subject/counterpart exact version binding or policy version is missing or padded (deny-by-default; MILESTONES §E1.3.T4); the principal binding is never client-supplied — the store binds the authenticated session, and absent authority context maps to the `insufficient_context` outcome value, envelope-governed vocabulary rather than a standalone code; E1.4 widens Cloud's contract-scan grep to the `governance.` family |
 <!-- /registry:cloud-codes -->
 

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -331,6 +331,9 @@ Operation labels of the private Cloud scaffold. The scaffold's `main` emits no w
 | code | status | meaning |
 | --- | --- | --- |
 | `workspace.bootstrap` | planned (in-flight scaffold work) | identity-bootstrap ledger operation label recorded when a workspace is created |
+| `workspace.repository_limit_reached` | planned (E2.1) | repository registration would exceed the Workspace's configured repository limit |
+| `workspace.duplicate_repository` | planned (E2.1) | the same external repository is already registered in the Workspace |
+| `workspace.cross_tenant_denied` | planned (E2.1) | a Workspace-scoped operation is outside the authenticated principal's memberships; foreign and nonexistent targets remain indistinguishable |
 | `governance.decision_binding_missing` | planned (E1.3, in-flight cloud cut) | Cloud reconciliation-decision route rejects a record whose subject/counterpart exact version binding or policy version is missing or padded (deny-by-default; MILESTONES §E1.3.T4); the principal binding is never client-supplied — the store binds the authenticated session, and absent authority context maps to the `insufficient_context` outcome value, envelope-governed vocabulary rather than a standalone code; E1.4 widens Cloud's contract-scan grep to the `governance.` family |
 <!-- /registry:cloud-codes -->
 


### PR DESCRIPTION
## Summary
- register the three stable E2.1 workspace error codes
- preserve foreign/nonexistent target indistinguishability in the code meaning
- guard every V10 `workspace.*` citation against the canonical registry

## Verification
- `cargo test -p adoc-mcp --test contract_registry_guard --locked`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- Cloud `scripts/contract-scan.sh` against this registry

## Consumer
- agentdoc-dev/cloud#16 emits these codes and remains gated on this registry reaching `main`.