### PR TITLE
docs(registry): reserve E4.6 ingestion wire codes

### DIFF
--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -492,6 +492,19 @@ fn e4_5_cloud_capability_trust_codes_are_registered_exactly() {
 }
 
 #[test]
+fn e4_6_ingestion_codes_are_registered_exactly() {
+    let registered = anchored_ids(&registry(), "registry:cloud-codes");
+    for code in [
+        "ingest.duplicate_delivery",
+        "ingest.stale_run",
+        "ingest.digest_mismatch",
+        "connect.permission_exceeds_manifest",
+    ] {
+        assert!(registered.contains(code), "E4.6 Cloud code missing: {code}");
+    }
+}
+
+#[test]
 fn test_only_use_does_not_split_the_scope() {
     let fixture = r#"
         #[cfg(test)]

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -480,7 +480,7 @@ Operation labels and typed failure codes owned by the private Cloud service. New
 | `api.internal_error` | planned (E4.4) | the external API could not durably complete its transport-level operation; request correlation is returned for support |
 | `api.rate_limited` | planned (E4.4) | a rate limit rejects an external request and carries standard `Retry-After` semantics; quota enforcement remains E8.7-owned |
 | `ingest.envelope_version_unsupported` | planned (E4.4) | assessment submission names an unknown or superseded exact operation/envelope version; remediation names the accepted version |
-| `ingest.duplicate_delivery` | planned (E4.6) | a byte-identical assessment delivery is acknowledged without another ingestion record, activation event, or latest-state mutation |
+| `ingest.duplicate_delivery` | planned (E4.6) | a byte-identical replay of an already-complete assessment delivery is acknowledged without another ingestion record, activation event, or latest-state mutation; redelivery may complete an explicitly partial record |
 | `ingest.stale_run` | planned (E4.6) | an older observed head is retained in history but cannot replace the repository's newer lineage head |
 | `ingest.digest_mismatch` | planned (E4.6) | a claimed assessment or receipt digest does not match the submitted envelope bytes; the attempt is recorded and the delivery rejected |
 | `connect.permission_exceeds_manifest` | planned (E4.6) | a connector grant exceeds its authenticated capability manifest; the connection becomes unhealthy and ingestion pauses until re-consent |

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -480,6 +480,10 @@ Operation labels and typed failure codes owned by the private Cloud service. New
 | `api.internal_error` | planned (E4.4) | the external API could not durably complete its transport-level operation; request correlation is returned for support |
 | `api.rate_limited` | planned (E4.4) | a rate limit rejects an external request and carries standard `Retry-After` semantics; quota enforcement remains E8.7-owned |
 | `ingest.envelope_version_unsupported` | planned (E4.4) | assessment submission names an unknown or superseded exact operation/envelope version; remediation names the accepted version |
+| `ingest.duplicate_delivery` | planned (E4.6) | a byte-identical assessment delivery is acknowledged without another ingestion record, activation event, or latest-state mutation |
+| `ingest.stale_run` | planned (E4.6) | an older observed head is retained in history but cannot replace the repository's newer lineage head |
+| `ingest.digest_mismatch` | planned (E4.6) | a claimed assessment or receipt digest does not match the submitted envelope bytes; the attempt is recorded and the delivery rejected |
+| `connect.permission_exceeds_manifest` | planned (E4.6) | a connector grant exceeds its authenticated capability manifest; the connection becomes unhealthy and ingestion pauses until re-consent |
 | `connector.manifest_invalid` | planned (E4.5) | connector capability manifest fails exact-version decoding or its adapter, connector, or authenticated-publisher binding is invalid |
 | `connector.publisher_unqualified` | planned (E4.5) | the authenticated publisher lacks trusted qualification for a claimed capability maturity; customer publishers cannot self-claim AgentDoc GA |
 | `connector.configuration_ineligible` | planned (E4.5) | a connector configuration cannot activate because its dependency closure, capability maturity, or new-use deprecation policy is unsatisfied; remediation carries eligible alternatives rather than weakening the requested gate |


### PR DESCRIPTION
## Summary
- reserve E4.6 ingestion and permission-drift wire codes before Cloud emits them
- pin the exact code set in the canonical registry guard

## Verification
- `cargo fmt --all -- --check`
- `cargo test -p adoc-mcp --test contract_registry_guard --locked`
- `git diff --check`

Stacked on #175.