### PR TITLE
E4.7: freeze G1A v5 recovery cohort

### DIFF
--- a/.github/workflows/g1a-v5-evidence.yml
+++ b/.github/workflows/g1a-v5-evidence.yml
@@ -51,13 +51,12 @@ jobs:
           set -euo pipefail
           marker="<!-- g1a-binding:v5:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${EXPECTED_HEAD} -->"
           for _ in $(seq 1 60); do
-            comments="$(curl --fail-with-body --silent --show-error --location \
+            comments="$(gh api --paginate --slurp \
               --header "Accept: application/vnd.github+json" \
-              --header "Authorization: Bearer $GH_TOKEN" \
               --header "X-GitHub-Api-Version: 2022-11-28" \
-              "https://api.github.com/repos/$REPOSITORY/issues/$PR_NUMBER/comments?per_page=100")"
+              "repos/$REPOSITORY/issues/$PR_NUMBER/comments?per_page=100")"
             binding_url="$(jq -r --arg marker "$marker" \
-              '[.[] | select(.body == $marker and
+              '[.[][] | select(.body == $marker and
                 (.author_association | IN("OWNER", "MEMBER", "COLLABORATOR")))] |
                last | .html_url // empty' <<< "$comments")"
             if [ -n "$binding_url" ]; then

--- a/.github/workflows/g1a-v5-evidence.yml
+++ b/.github/workflows/g1a-v5-evidence.yml
@@ -1,0 +1,137 @@
+name: G1A v5 Evidence
+
+on:
+  pull_request:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  bind:
+    name: Bind exact run tuple
+    if: github.event.label.name == 'g1a-v5-run'
+    runs-on: ubuntu-latest
+    timeout-minutes: 7
+    steps:
+      - name: Validate immutable pull request head
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [[ "$EXPECTED_HEAD" =~ ^[0-9a-f]{40}$ ]]
+          pull="$(curl --fail-with-body --silent --show-error --location \
+            --header "Accept: application/vnd.github+json" \
+            --header "Authorization: Bearer $GH_TOKEN" \
+            --header "X-GitHub-Api-Version: 2022-11-28" \
+            "https://api.github.com/repos/$REPOSITORY/pulls/$PR_NUMBER")"
+          jq -e --arg head "$EXPECTED_HEAD" --arg repo "$REPOSITORY" \
+            '.state == "open" and .head.sha == $head and
+             .base.repo.full_name == $repo and .head.repo.full_name == $repo' \
+            <<< "$pull" >/dev/null
+
+      - name: Wait for authorized binding marker
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_HEAD: ${{ github.event.pull_request.head.sha }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          marker="<!-- g1a-binding:v5:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}:${EXPECTED_HEAD} -->"
+          for _ in $(seq 1 60); do
+            comments="$(curl --fail-with-body --silent --show-error --location \
+              --header "Accept: application/vnd.github+json" \
+              --header "Authorization: Bearer $GH_TOKEN" \
+              --header "X-GitHub-Api-Version: 2022-11-28" \
+              "https://api.github.com/repos/$REPOSITORY/issues/$PR_NUMBER/comments?per_page=100")"
+            binding_url="$(jq -r --arg marker "$marker" \
+              '[.[] | select(.body == $marker and
+                (.author_association | IN("OWNER", "MEMBER", "COLLABORATOR")))] |
+               last | .html_url // empty' <<< "$comments")"
+            if [ -n "$binding_url" ]; then
+              printf 'Bound %s at %s\n' "$marker" "$binding_url"
+              exit 0
+            fi
+            sleep 5
+          done
+          echo "No authorized exact-tuple binding marker was observed" >&2
+          exit 1
+
+  assess:
+    name: Retained assessment
+    needs: bind
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - id: agentdoc
+        uses: agentdoc-dev/action@17da62659dc164b98ccdf0f4455c7628b58cd154 # E4.6 reviewed
+        with:
+          adoc-version: v0.3.4
+          enforcement: advisory
+          comment: false
+          propose: false
+
+      - name: Verify assessment evidence
+        if: always()
+        shell: bash
+        env:
+          ASSESSMENT_PATH: ${{ steps.agentdoc.outputs.assessment-path }}
+          ASSESSMENT_SHA256: ${{ steps.agentdoc.outputs.assessment-sha256 }}
+          INVOCATION_ID: ${{ steps.agentdoc.outputs.assessment-invocation-id }}
+          RECEIPT_PATH: ${{ steps.agentdoc.outputs.assessment-receipt-path }}
+          RECEIPT_SHA256: ${{ steps.agentdoc.outputs.assessment-receipt-sha256 }}
+        run: |
+          set -euo pipefail
+          test -n "$INVOCATION_ID"
+          test -n "$RECEIPT_PATH"
+          test -f "$RECEIPT_PATH"
+          test "sha256:$(sha256sum "$RECEIPT_PATH" | cut -d ' ' -f 1)" = "$RECEIPT_SHA256"
+          jq -e \
+            --arg action 17da62659dc164b98ccdf0f4455c7628b58cd154 \
+            --arg adoc v0.3.4 \
+            --arg run "$GITHUB_RUN_ID" \
+            --argjson attempt "$GITHUB_RUN_ATTEMPT" \
+            '.schema_version == "adoc.pr_assessment_receipt.v0" and
+             .ci.run_id == $run and .ci.run_attempt == $attempt and
+             .toolchain.action.resolved_commit == $action and
+             .toolchain.adoc.resolved_version == $adoc' \
+            "$RECEIPT_PATH" >/dev/null
+          if [ "$(jq -r .run_status "$RECEIPT_PATH")" = completed ]; then
+            test -n "$ASSESSMENT_PATH"
+            test -f "$ASSESSMENT_PATH"
+            test "sha256:$(sha256sum "$ASSESSMENT_PATH" | cut -d ' ' -f 1)" = "$ASSESSMENT_SHA256"
+            test "$(jq -r .assessment.sha256 "$RECEIPT_PATH")" = "$ASSESSMENT_SHA256"
+          else
+            jq -e '.run_status == "failed"' "$RECEIPT_PATH" >/dev/null
+            test -z "$ASSESSMENT_PATH"
+            test -z "$ASSESSMENT_SHA256"
+          fi
+
+      - name: Retain assessment evidence
+        if: always() && steps.agentdoc.outputs.assessment-receipt-path != '' && steps.agentdoc.outputs.assessment-invocation-id != ''
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: g1a-v5-${{ steps.agentdoc.outputs.assessment-invocation-id }}
+          path: |
+            ${{ steps.agentdoc.outputs.assessment-path }}
+            ${{ steps.agentdoc.outputs.assessment-receipt-path }}
+          if-no-files-found: error
+          retention-days: 90

--- a/crates/adoc-mcp/tests/evidence_contract.rs
+++ b/crates/adoc-mcp/tests/evidence_contract.rs
@@ -236,6 +236,7 @@ fn v5_workflow_cannot_assess_before_the_exact_tuple_is_bound() {
     assert!(workflow.contains("types: [labeled]"));
     assert!(workflow.contains("github.event.label.name == 'g1a-v5-run'"));
     assert!(workflow.contains("g1a-binding:v5:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"));
+    assert!(workflow.contains("gh api --paginate --slurp"));
     assert!(workflow.contains("needs: bind"));
     assert!(
         workflow.contains("uses: agentdoc-dev/action@17da62659dc164b98ccdf0f4455c7628b58cd154")

--- a/crates/adoc-mcp/tests/evidence_contract.rs
+++ b/crates/adoc-mcp/tests/evidence_contract.rs
@@ -11,7 +11,7 @@ fn root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../..")
 }
 
-const ACTIVE_CONTRACT: &str = "docs/pilots/g1a/evidence-contract-v4.yaml";
+const ACTIVE_CONTRACT: &str = "docs/pilots/g1a/evidence-contract-v5.yaml";
 const FROZEN_CONTRACTS: &[(&str, &str)] = &[
     (
         "docs/pilots/g1a/evidence-contract-v1.yaml",
@@ -26,8 +26,12 @@ const FROZEN_CONTRACTS: &[(&str, &str)] = &[
         "e3d70e6a16609bd595a14aa5246437307281090ecc8ab5aa116b50084fa00822",
     ),
     (
-        ACTIVE_CONTRACT,
+        "docs/pilots/g1a/evidence-contract-v4.yaml",
         "04baf920776603a538d66dc8214f27e624769b674527d3573b8bfcb1c75c3b5d",
+    ),
+    (
+        ACTIVE_CONTRACT,
+        "744aef51606455ee4c9ba77d8352349eacb5802bc945ea4a95fed0c9aea643ce",
     ),
 ];
 
@@ -206,7 +210,8 @@ fn real_run_set_is_precommitted_at_the_population_floor() {
         let rule = run["selection_rule"].as_str().expect("selection rule");
         rule.contains("(created_at, run_id, run_attempt)")
             && rule.contains("restricted to created_at at or after eligible_from")
-            && rule.contains("before job scheduling or outcome")
+            && rule.contains("g1a-v5-run")
+            && rule.contains("before assessment job scheduling or outcome")
             && rule.contains("unstarted")
             && rule.contains("incomplete evidence as a denominator failure")
     }));
@@ -221,6 +226,19 @@ fn real_run_set_is_precommitted_at_the_population_floor() {
         evidence["minimum_population"]["repositories"]
             .as_u64()
             .expect("repository floor")
+    );
+}
+
+#[test]
+fn v5_workflow_cannot_assess_before_the_exact_tuple_is_bound() {
+    let workflow = fs::read_to_string(root().join(".github/workflows/g1a-v5-evidence.yml"))
+        .expect("G1A v5 workflow is readable");
+    assert!(workflow.contains("types: [labeled]"));
+    assert!(workflow.contains("github.event.label.name == 'g1a-v5-run'"));
+    assert!(workflow.contains("g1a-binding:v5:${GITHUB_RUN_ID}:${GITHUB_RUN_ATTEMPT}"));
+    assert!(workflow.contains("needs: bind"));
+    assert!(
+        workflow.contains("uses: agentdoc-dev/action@17da62659dc164b98ccdf0f4455c7628b58cd154")
     );
 }
 

--- a/docs/pilots/g1a/cohort-v4-closure.md
+++ b/docs/pilots/g1a/cohort-v4-closure.md
@@ -1,0 +1,17 @@
+# G1A cohort v4 closure
+
+- Closed at: `2026-08-26T23:50:00Z`
+- Disposition: `failed_threshold`
+- Successor: [`evidence-contract-v5.yaml`](evidence-contract-v5.yaml)
+- Readout: [immutable Cloud revision](https://github.com/agentdoc-dev/cloud/blob/642485d4cc0158614f126510df0f138f69a9ab59/docs/pilots/g1a/evidence/v4/readout.json)
+
+The v4 digest-match rate was 2/3 against a frozen threshold of 1. The selected
+Cloud attempt completed before its exact tuple was bound, so it remains an
+invalid denominator failure and is never replaced. Downstream Cloud governance
+stays blocked by the v4 result.
+
+Version 5 changes the Cloud ingestion pin to the reviewed receipt-compatibility
+revision and requires a dedicated binding job to observe an exact, authorized
+comment marker before the assessment job can be scheduled. The original v4
+contract and readout remain unchanged for audit and contribute no evidence to
+v5.

--- a/docs/pilots/g1a/evidence-contract-v5.yaml
+++ b/docs/pilots/g1a/evidence-contract-v5.yaml
@@ -1,0 +1,115 @@
+evidence_contract:
+  id: g1a-technical-engineering-admission
+  version: 5
+  frozen_at: "2026-08-26T23:55:00Z"
+  eligible_from: "2026-08-27T00:30:00Z"
+  cohort_definition:
+    kind: internal_real_assessments_and_controlled_suites
+    repositories:
+      - agentdoc-dev/adoc
+      - agentdoc-dev/action
+      - agentdoc-dev/cloud
+    run_set:
+      - id: g1a-v5-adoc-001
+        repository: agentdoc-dev/adoc
+        selection_rule: First G1A v5 pull-request workflow attempt triggered by the g1a-v5-run label and using the frozen Action revision in ascending total order by GitHub Actions (created_at, run_id, run_attempt), restricted to created_at at or after eligible_from; its binding job must observe an owner, member, or collaborator comment marker for that exact tuple and head before assessment job scheduling or outcome, and count cancelled, unstarted, missing, invalid, failed, or incomplete evidence as a denominator failure.
+      - id: g1a-v5-action-001
+        repository: agentdoc-dev/action
+        selection_rule: First G1A v5 pull-request workflow attempt triggered by the g1a-v5-run label and using the frozen Action revision in ascending total order by GitHub Actions (created_at, run_id, run_attempt), restricted to created_at at or after eligible_from; its binding job must observe an owner, member, or collaborator comment marker for that exact tuple and head before assessment job scheduling or outcome, and count cancelled, unstarted, missing, invalid, failed, or incomplete evidence as a denominator failure.
+      - id: g1a-v5-cloud-001
+        repository: agentdoc-dev/cloud
+        selection_rule: First G1A v5 pull-request workflow attempt triggered by the g1a-v5-run label and using the frozen Action revision in ascending total order by GitHub Actions (created_at, run_id, run_attempt), restricted to created_at at or after eligible_from; its binding job must observe an owner, member, or collaborator comment marker for that exact tuple and head before assessment job scheduling or outcome, and count cancelled, unstarted, missing, invalid, failed, or incomplete evidence as a denominator failure.
+    action_revision: 17da62659dc164b98ccdf0f4455c7628b58cd154
+    cloud_ingestion_revision: 642485d4cc0158614f126510df0f138f69a9ab59
+    agentdoc_version: v0.3.4
+    material_rule_change: close_cohort_and_increment_version
+  minimum_population:
+    real_internal_assessments: 3
+    repositories: 3
+    metric_denominators:
+      digest_match_rate: 3
+      duplicate_governance_event_count: 5
+      stale_overwrite_count: 1
+      isolation_rejection_rate: 2
+  minimum_duration: PT0S
+  metrics:
+    - id: digest_match_rate
+      source: real_internal_runs
+      value_kind: rate
+      numerator: Eligible assessments whose Action-emitted assessment and receipt digests both equal the Cloud-stored byte digests.
+      denominator: All precommitted eligible internal assessment attempts, including cancelled, unstarted, missing, invalid, failed, or incomplete deliveries.
+    - id: duplicate_governance_event_count
+      source: controlled_suite
+      value_kind: count
+      numerator: Governance events appended by repeated deliveries after the first accepted delivery.
+      denominator: Five exact redeliveries of one already accepted delivery.
+    - id: stale_overwrite_count
+      source: controlled_suite
+      value_kind: count
+      numerator: Older-head deliveries that replace the repository latest-assessment pointer.
+      denominator: Completed older-head-after-newer-head ordering attempts.
+    - id: isolation_rejection_rate
+      source: controlled_suite
+      value_kind: rate
+      numerator: Cross-Workspace submission attempts rejected before observation storage.
+      denominator: All precommitted cross-Workspace submission attempts.
+  numerator_denominator_rules:
+    - metric_id: digest_match_rate
+      denominator_floor: 3
+      missing_or_invalid_attempt: count_in_denominator_as_failure
+      below_floor: descriptive_insufficient_evidence_no_promotion
+    - metric_id: duplicate_governance_event_count
+      denominator_floor: 5
+      missing_or_invalid_attempt: count_in_denominator_as_failure
+      below_floor: descriptive_insufficient_evidence_no_promotion
+    - metric_id: stale_overwrite_count
+      denominator_floor: 1
+      missing_or_invalid_attempt: count_in_denominator_as_failure
+      below_floor: descriptive_insufficient_evidence_no_promotion
+    - metric_id: isolation_rejection_rate
+      denominator_floor: 2
+      missing_or_invalid_attempt: count_in_denominator_as_failure
+      below_floor: descriptive_insufficient_evidence_no_promotion
+  exclusions:
+    - id: fixture_or_synthetic_assessment
+      rule: Fixtures and synthetic assessment documents never count as real internal assessments.
+    - id: before_eligibility
+      rule: Observations before eligible_from are excluded and may not be reclassified later.
+    - id: unpinned_runtime
+      rule: Runs not using the frozen AgentDoc, Action, and Cloud ingestion revisions are excluded.
+    - id: changed_contract
+      rule: Observations under materially changed rules belong to a new contract version and cohort.
+  thresholds:
+    - metric_id: digest_match_rate
+      operator: equal
+      value: 1
+    - metric_id: duplicate_governance_event_count
+      operator: equal
+      value: 0
+    - metric_id: stale_overwrite_count
+      operator: equal
+      value: 0
+    - metric_id: isolation_rejection_rate
+      operator: equal
+      value: 1
+  stop_ship_conditions:
+    - id: suite_failure
+      rule: Any contract, idempotency, digest, stale-ordering, or isolation suite is not green.
+    - id: accepted_digest_mismatch
+      rule: Cloud accepts any assessment or receipt whose claimed digest differs from its exact bytes.
+    - id: duplicate_governance_event
+      rule: Exact delivery replay appends any duplicate governance event.
+    - id: stale_overwrite
+      rule: An older head replaces newer repository assessment state.
+    - id: cross_workspace_disclosure
+      rule: Any cross-Workspace attempt reads or stores another Workspace's assessment data.
+    - id: false_success
+      rule: A required processing failure is represented as success.
+    - id: material_contract_rewrite
+      rule: Criteria are materially edited after eligible evidence exists without closing this cohort version.
+  approved_by:
+    - principal: alex-bako
+      roles:
+        - product_owner
+        - engineering_owner
+        - security_owner

--- a/docs/roadmap/v10/RELEASE-EVIDENCE.md
+++ b/docs/roadmap/v10/RELEASE-EVIDENCE.md
@@ -144,7 +144,7 @@ Separate evidence lines for executor quality, workflow usefulness, gate behavior
 
 Freeze before first eligible internal tracer run. Includes replay/stale-run/digest/idempotency/isolation suites plus a small precommitted set of real internal assessments. Passing G1A allows governance implementation to proceed internally.
 
-G1A contract v4 is frozen in [`docs/pilots/g1a/evidence-contract-v4.yaml`](../../pilots/g1a/evidence-contract-v4.yaml) and validates against the single reusable [`agentdoc.evidence_contract.v0`](../../agent/v0/schema/agentdoc.evidence_contract.v0.schema.json) schema. The flawed [v1](../../pilots/g1a/cohort-v1-closure.md), [v2](../../pilots/g1a/cohort-v2-closure.md), and [v3](../../pilots/g1a/cohort-v3-closure.md) cohorts are closed without promotion, preserving their contracts and observations rather than rewriting them. The v4 readout remains a separate pass/fail artifact; publishing the criteria does not claim the gate passed.
+G1A contract v5 is frozen in [`docs/pilots/g1a/evidence-contract-v5.yaml`](../../pilots/g1a/evidence-contract-v5.yaml) and validates against the single reusable [`agentdoc.evidence_contract.v0`](../../agent/v0/schema/agentdoc.evidence_contract.v0.schema.json) schema. The flawed [v1](../../pilots/g1a/cohort-v1-closure.md), [v2](../../pilots/g1a/cohort-v2-closure.md), and [v3](../../pilots/g1a/cohort-v3-closure.md) cohorts and the threshold-failing [v4](../../pilots/g1a/cohort-v4-closure.md) cohort are closed without promotion, preserving their contracts and observations rather than rewriting them. The v5 readout remains a separate pass/fail artifact; publishing the criteria does not claim the gate passed.
 
 ### G1B — external Pilot Candidate admission
 

--- a/scripts/verify-evidence-contract-seal.sh
+++ b/scripts/verify-evidence-contract-seal.sh
@@ -2,8 +2,8 @@
 set -euo pipefail
 export TZ=UTC
 
-signer_digest=d9eed215042cf31eea101ef005a5ecb78e537ded
-rekor_timestamp=2026-08-26T20:50:49Z
+signer_digest=ad4d58e167f6723c4eff92f5fa15fb7fb5004931
+rekor_timestamp=2026-08-26T23:59:41Z
 
 for contract in docs/pilots/g1a/evidence-contract-v*.yaml; do
   gh attestation verify "$contract" \
@@ -11,7 +11,7 @@ for contract in docs/pilots/g1a/evidence-contract-v*.yaml; do
     --signer-workflow agentdoc-dev/adoc/.github/workflows/evidence-contract-seal.yml \
     --signer-digest "$signer_digest" \
     --source-digest "$signer_digest" \
-    --source-ref refs/pull/177/merge \
+    --source-ref refs/pull/178/merge \
     --format json |
     jq -e --arg timestamp "$rekor_timestamp" '
       length > 0 and any(.[].verificationResult.verifiedTimestamps;


### PR DESCRIPTION
## Summary
- preserve the threshold-failing v4 cohort and immutable readout
- freeze v5 against the reviewed receipt-compatible Cloud ingestion revision
- require an authorized exact-tuple binding job before assessment scheduling
- add one focused regression test for the binding gate

## Verification
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `actionlint .github/workflows/g1a-v5-evidence.yml`
- `yq eval . docs/pilots/g1a/evidence-contract-v5.yaml >/dev/null`
- `git diff --check`

Stacked on #177. v4 remains failed and unchanged; no v5 run is triggered by this prep PR.