### PR TITLE
E4.7: run AgentDoc G1A v5 assessment

### DIFF
--- a/docs/pilots/g1a/evidence/v5/adoc-run.md
+++ b/docs/pilots/g1a/evidence/v5/adoc-run.md
@@ -1,0 +1,13 @@
+# AgentDoc G1A v5 retained run
+
+This reviewed tracer change is reserved for `g1a-v5-adoc-001` under
+[`evidence-contract-v5.yaml`](../../evidence-contract-v5.yaml).
+
+- Contract SHA-256: `744aef51606455ee4c9ba77d8352349eacb5802bc945ea4a95fed0c9aea643ce`
+- Action revision: `17da62659dc164b98ccdf0f4455c7628b58cd154`
+- AgentDoc version: `v0.3.4`
+- Workflow: `G1A v5 Evidence`
+
+The `g1a-v5-run` label may be applied only after exact-head review and the
+contract's `eligible_from`. The authorized exact-tuple binding marker must be
+posted while the binding job is waiting. This file records no run result.


### PR DESCRIPTION
## Summary
- reserve this reviewed tracer change for `g1a-v5-adoc-001`
- record the frozen contract, Action, and AgentDoc pins
- make no outcome claim before the retained workflow runs

## Gate
The `g1a-v5-run` label will be applied only after exact-head Codex review and `eligible_from`. The exact tuple marker will be posted while the binding job waits.

Stacked on #178.