### PR TITLE
E4.7: run AgentDoc G1A v6 assessment

### DIFF
--- a/docs/pilots/g1a/evidence/v6/adoc-run.md
+++ b/docs/pilots/g1a/evidence/v6/adoc-run.md
@@ -1,0 +1,13 @@
+# AgentDoc G1A v6 retained run
+
+This reviewed tracer change is reserved for `g1a-v6-adoc-001` under
+[`evidence-contract-v6.yaml`](../../evidence-contract-v6.yaml).
+
+- Contract SHA-256: `0dadeb22f570a3eca80a3f1da6e0635837251a580c87949204d7cfb29534cb2c`
+- Action revision: `17da62659dc164b98ccdf0f4455c7628b58cd154`
+- AgentDoc version: `v0.3.4`
+- Workflow: `G1A v6 Evidence`
+
+The pull request may be opened only after the contract's `eligible_from`. Its
+authorized exact-tuple binding marker may be posted only after exact-head review
+and deterministic checks pass. This file records no run result.


### PR DESCRIPTION
## Summary
- reserve this reviewed tracer change for `g1a-v6-adoc-001`
- record the frozen contract, Action, and AgentDoc pins
- make no outcome claim before the retained workflow runs

## Gate
The opened-event workflow must remain in its binding job until exact-head Codex review and deterministic checks pass. Only then will the authorized exact-tuple marker schedule assessment.

Stacked on #180.