### PR TITLE
test(g1a): retain AgentDoc v9 assessment (E4.7)

### DIFF
--- a/docs/pilots/g1a/evidence/v9/adoc-run.md
+++ b/docs/pilots/g1a/evidence/v9/adoc-run.md
@@ -1,0 +1,14 @@
+# AgentDoc G1A v9 retained run
+
+This reviewed tracer change is reserved for `g1a-v9-adoc-001` under
+[`evidence-contract-v9.yaml`](../../evidence-contract-v9.yaml).
+
+- Contract SHA-256: `78d3ddde08ad93bb5ea4c1bdc223218ff6527a36e8b3337db0ac9d7957bda802`
+- Action revision: `17da62659dc164b98ccdf0f4455c7628b58cd154`
+- Cloud ingestion revision: `c4c8da00556eb950423102ede55407877ebc6a8b`
+- AgentDoc version: `v0.3.4`
+- Workflow: `G1A v9 Evidence`
+
+The pull request may be opened only after the contract's `eligible_from`. Its
+authorized exact-tuple binding marker may be posted only after exact-head review
+and deterministic checks pass. This file records no run result.


### PR DESCRIPTION
## Summary

- reserve the reviewed AgentDoc tracer for `g1a-v9-adoc-001`
- bind the immutable v9 contract, Action revision, Cloud ingestion revision, and AgentDoc version
- intentionally create the first eligible opened-event v9 attempt only after hosted billing recovered

## Validation

- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets --locked -- -D warnings`
- `cargo test --workspace --locked`
- `cargo build --workspace --locked`
- `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps --locked`
- FastEmbed retrieval pilot: 9 passed
- frozen evidence-contract seal verified
- exact-head Codex review: clean (`5492789767`), zero review threads

The authorized marker below binds this immutable head to the first eligible v9 workflow tuple. Claude review is intentionally skipped because its token allowance is exhausted.

<!-- g1a-binding:v9:33499141031:1:4d47c401965ee38b7f1362f45b0288d4b6aa3730 -->