### PR TITLE
docs: defer G1A pilot gate

### DIFF
--- a/docs/roadmap/ROADMAP-V10-REVISION.md
+++ b/docs/roadmap/ROADMAP-V10-REVISION.md
@@ -1,6 +1,6 @@
 # ROADMAP-V10 Revision 1 — Product V1 Reconciliation
 
-**Status:** Draft, normative planning revision  
+**Status:** Draft, normative planning revision; G1A scope superseded by D40
 **Date:** 2026-08-12  
 **Supersedes conflicting statements in:** [`ROADMAP-V10.md`](ROADMAP-V10.md)  
 **Locked product boundary:** `docs/product/PRD-v1.0.md` / ADR-0055, as amended by [`../product/PRD-v1.1-amendment.md`](../product/PRD-v1.1-amendment.md) / ADR-0056  
@@ -444,7 +444,7 @@ Only the active primary affects product workflow; shadow output never gates or c
 
 ### 18.2 G1A / G1B split
 
-- **G1A technical admission:** contract/digest/replay/stale/idempotency/isolation suites plus small precommitted internal real-run population. Passing allows internal governance implementation.
+- **G1A technical admission:** measured internal cohort deferred by D40. Deterministic contract/digest/replay/stale/idempotency/isolation suites remain required; G1A does not gate E4 merges or internal governance implementation.
 - **G1B external admission:** stronger real-run ingestion population required before external Pilot Candidate rollout/required Cloud enforcement.
 
 The original V10 hard rule that all V10.4+ governance engineering must stop until a large external-like G1 population exists is superseded.
@@ -491,7 +491,7 @@ The following original-draft consistency issues are explicitly corrected and mus
 
 ### Pilot Candidate
 
-9. G1A and internal dogfood.
+9. E4.6 deterministic acceptance and internal dogfood; no measured G1A cohort.
 10. GitHub connector/source ACL ceiling + production authz decision path.
 11. Native Cloud review/approval and hash-bound invalidation.
 12. Basic egress/retention policy and Cloud validation receipts.

--- a/docs/roadmap/v10/COMPATIBILITY.md
+++ b/docs/roadmap/v10/COMPATIBILITY.md
@@ -44,7 +44,6 @@ E8.5's GitLab CI component has no named home repository yet; its row covers the 
 | `E4.4` | adoc, cloud | cloud | adoc 0.3.4 (graph v5) · Cloud scaffold (pre-release) | cloud |
 | `E4.5` | adoc, action, cloud | adoc | adoc 0.3.4 (graph v5) · Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |
 | `E4.6` | action, cloud | cloud | Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |
-| `E4.7` | adoc, action, cloud | adoc | adoc 0.3.4 (graph v5) · Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |
 | `E5.1` | adoc, action, cloud | cloud | adoc 0.3.4 (graph v5) · Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |
 | `E5.3` | adoc, cloud | adoc | adoc 0.3.4 (graph v5) · Cloud scaffold (pre-release) | cloud |
 | `E5.4` | action, cloud | action | Action v2.0.0-alpha.19 · Cloud scaffold (pre-release) | cloud |

--- a/docs/roadmap/v10/DECISION-REGISTER.md
+++ b/docs/roadmap/v10/DECISION-REGISTER.md
@@ -1,10 +1,10 @@
 # V10 / Product V1 Decision Register
 
-**Status:** Founder-approved decisions through 2026-08-13  
+**Status:** Founder-approved decisions through 2026-09-01
 **Product amendment:** [`../../product/PRD-v1.1-amendment.md`](../../product/PRD-v1.1-amendment.md) / ADR-0056  
 **Executable plan:** [`EXECUTION-MAP.md`](EXECUTION-MAP.md)
 
-The 2026-08-12 planning session produced D01–D35. The 2026-08-13 red-team produced D36–D39 and second-order closure requirements. B1–B6 are no longer pending: ADR-0056 accepts them. ADR-0057 accepts D36–D39.
+The 2026-08-12 planning session produced D01–D35. The 2026-08-13 red-team produced D36–D39 and second-order closure requirements. The 2026-09-01 pilot-scope review produced D40. B1–B6 are no longer pending: ADR-0056 accepts them. ADR-0057 accepts D36–D39.
 
 ## Detailed annexes
 
@@ -72,6 +72,10 @@ The 2026-08-12 planning session produced D01–D35. The 2026-08-13 red-team prod
 - **D37:** content versions are immutable; governance/verification/effectivity/freshness/integrity/sync transitions are append-only events over content versions.
 - **D38:** authorization uses one deterministic precedence with source ACL as ceiling, scope specificity, expiry, explicit restrictions, and fail-closed consequential uncertainty.
 - **D39:** human semantic assessment may self-assess only where policy allows; an independent-review obligation requires a distinct eligible principal.
+
+## D40 — pilot evidence scope
+
+- **D40:** the measured internal G1A cohort is deferred and does not gate E4 merges or E5 implementation; E4.6 deterministic invariants remain required, G1B still gates external Pilot Candidate admission, and no historical G1A run promotes anything. This supersedes the G1A portion of D31.
 
 ## Executable decision obligations
 

--- a/docs/roadmap/v10/EXECUTION-MAP.md
+++ b/docs/roadmap/v10/EXECUTION-MAP.md
@@ -40,7 +40,7 @@ A repository-specific plan may subdivide a slice but cannot alter its contracts,
 | Stage | Target | Meaning |
 | --- | --- | --- |
 | Internal Integrated Tracer | 2026-09-30 | internal end-to-end product architecture exercised; not external production |
-| V1 Pilot Candidate / Private Alpha | 2026-11-30 | selected design partners; pilot-grade security/operations; G1A/G1B passed |
+| V1 Pilot Candidate / Private Alpha | 2026-11-30 | selected design partners; pilot-grade security/operations; G1B passed |
 | V1 Feature Complete / RC / Beta | 2027-02-28 | all accepted V1 P0 capabilities implemented at declared maturity |
 | Earliest V1 GA | 2027-04-30 | evidence-backed public release; date slips on evidence failure |
 
@@ -285,12 +285,15 @@ Dates never override stop-ship invariants.
 **Goal:** exact-SHA deterministic/semantic/receipt submission to Cloud without duplicate/stale overwrite.  
 **Exit:** duplicate delivery, out-of-order run, head update, partial failure, retry, tenant-isolation fixtures pass.
 
-## E4.7 — G1A technical engineering-admission gate
+## E4.7 — Deferred G1A engineering admission
 
-**Repos:** all implementation repos  
-**Depends on:** E4.6  
-**Goal:** freeze/publish evidence contract before first eligible internal run.  
-**Exit:** contract/idempotency/digest/stale/isolation tests + precommitted small real internal run set pass; only then governance tracer proceeds.
+**Repos:** `adoc`
+
+**Depends on:** E4.6
+
+**Goal:** defer internal G1A measurement infrastructure; E4.6 deterministic tests remain the technical acceptance basis.
+
+**Exit:** deferral recorded; G1A is not an E4 merge or E5 implementation gate, and no evidence cohort is promoted.
 
 ---
 

--- a/docs/roadmap/v10/MILESTONES.md
+++ b/docs/roadmap/v10/MILESTONES.md
@@ -476,7 +476,7 @@ Digest-bound semantic context and assessment contracts, executor qualification, 
 
 ## Milestone E4 — Cloud Source Records, Canonical Store, and API
 
-Stand up the Cloud's immutable source-observation store, the PostgreSQL canonical managed graph, connector-authority policy, the versioned `/api/v1` surface, capability-manifest trust, and GitHub ingestion — everything the governance tracer consumes. **Milestone exit:** E4.7 — G1A evidence contract frozen/published before first eligible internal run; contract/idempotency/digest/stale/isolation tests plus the precommitted small real internal run set pass; only then does the governance tracer proceed. **Release anchor:** feeds Internal Integrated Tracer, 2026-09-30 — via the E4.7 G1A gate, which must be green first.
+Stand up the Cloud's immutable source-observation store, the PostgreSQL canonical managed graph, connector-authority policy, the versioned `/api/v1` surface, capability-manifest trust, and GitHub ingestion — everything the governance tracer consumes. **Milestone exit:** E4.1–E4.6 acceptance is green, including the deterministic contract/idempotency/digest/stale/isolation suites. E4.7 records the decision to defer a measured G1A cohort and is not an E4 merge gate. **Release anchor:** feeds Internal Integrated Tracer, 2026-09-30.
 
 ### E4.1 — Source Record / Assertion / Binding / ACL Snapshot store
 **Repos:** `cloud`, schemas/contracts `adoc` · **Depends on:** E1.2, E2.6
@@ -586,20 +586,18 @@ Stand up the Cloud's immutable source-observation store, the PostgreSQL canonica
 - No ingestion path upgrades a failed/partial outcome to success.
 **Out of scope:** gate evaluation over ingested facts (E5.3); check publication (E5.4); GitLab ingestion (E8.5).
 
-### E4.7 — G1A technical engineering-admission gate
-**Repos:** all implementation repos · **Depends on:** E4.6
-**Read first:** [RELEASE-EVIDENCE.md](RELEASE-EVIDENCE.md) (evidence-contract YAML, G1A/G1B split) · [RED-TEAM-CLOSURE.md](RED-TEAM-CLOSURE.md) (RT-20 frozen cohorts) · provenance: V10.1.7 G1 shape (non-executable)
+### E4.7 — Deferred G1A engineering admission
+**Repos:** `adoc` · **Depends on:** E4.6
+**Read first:** [RELEASE-EVIDENCE.md](RELEASE-EVIDENCE.md) (G1A deferral, G1B external admission) · [DECISION-REGISTER.md](DECISION-REGISTER.md) (D40) · provenance: V10.1.7 G1 shape (non-executable)
 **Tracer bullets:**
-1. `E4.7.T1` — Evidence contract authored as versioned YAML (id, version, frozen_at, eligible_from, cohort_definition, minimum_population, minimum_duration, metrics, numerator_denominator_rules, exclusions, thresholds, stop_ship_conditions, approved_by) + schema validation; lands failing CI check that `frozen_at` precedes the earliest eligible observation. This slice is the single owner of the evidence-contract YAML schema — E7.6.T1/E9.1.T1 freeze contract instances validating against it, never re-land the schema.
-2. `E4.7.T2` — Evidence collection over internal runs: digest-match rate (Action-emitted vs Cloud-stored bytes), duplicate-governance-event count under 5× replay, stale-overwrite count, isolation results — every rate names its denominator; lands failing test: report generator marks any rate with denominator below the frozen floor as descriptive + `insufficient_evidence`, promoting nothing.
-3. `E4.7.T3` — Run the precommitted small real internal run set and publish the G1A readout; a red result is a falsification checkpoint that stops downstream Cloud governance build (local product and standalone Action unaffected — every envelope is locally producible).
+1. `E4.7.T1` — Record that the pilot does not require a measured internal G1A cohort; do not merge the speculative evidence schema, evaluator, collection workflows, or retained run artifacts.
+2. `E4.7.T2` — Keep the product invariants under E4.6's deterministic test suites; local and GitHub-hosted CI may run those tests without an evidence-cohort service.
+3. `E4.7.T3` — Preserve no-promotion: no historical G1A run authorizes enforcement or claims pilot readiness. Revisit measured engineering admission only when observed pilot scale or a release decision requires it.
 **Acceptance:**
-- Contract frozen and published before the first eligible internal run; any material rule change after `eligible_from` closes the cohort version and forks a new one — it never rewrites criteria.
-- Contract/idempotency/digest/stale/isolation suites green (exit gate).
-- Precommitted internal run set passes under the frozen thresholds (exit gate).
-- Adversarial: attempted threshold edit mid-cohort rejected; historical evidence never reinterpreted.
-- Fixture runs are excluded by the contract's exclusion rules and never cited as real use.
-**Out of scope:** G1B external real-run evidence contract (E7.6); shadow/real/required-gate cohorts (E9.2–E9.4).
+- E4.7 is not an E4 merge gate or an E5 implementation gate.
+- E4.6's deterministic contract/idempotency/digest/stale/isolation suites remain green.
+- No G1A cohort, result, or fixture is promoted as release evidence.
+**Out of scope:** G1B external real-run evidence contract (E7.6); qualification/shadow/real/required-gate evidence (E9.1–E9.4).
 
 ## Milestone E5 — Internal Integrated Governance Tracer
 
@@ -679,7 +677,7 @@ Cut the first end-to-end governed flow — proposal, native approval, four-mode 
 ### E5.5 — Internal integrated tracer
 **Repos:** `adoc`, `action`, `cloud` · **Depends on:** E5.1–E5.4
 **Read first:** [EXECUTION-MAP.md](EXECUTION-MAP.md) (Phase E5, stop-ship invariants) · [RELEASE-EVIDENCE.md](RELEASE-EVIDENCE.md) · provenance: V10 Test Matrix + Stage 0/1 rollout (non-executable)
-**Gate note:** Requires E4.6 accepted and the E4.7 G1A readout green before the tracer run — the map's E4.7 exit outranks the Depends-on list.
+**Gate note:** Requires E4.6 accepted. E4.7 records a deferral and adds no tracer gate.
 **Tracer bullets:**
 1. `E5.5.T1` — Thinnest full tracer on one internal repo with synthetic data: GitHub change → deterministic assessment → one qualified semantic executor → proposal → Cloud candidate → native approval → active managed version → check → durable receipt/audit as the terminal step; lands failing E2E test asserting a digest-linked exact trace across every contract in the chain.
 2. `E5.5.T2` — Adversarial injections inside the same tracer run, from the carried E2E checklist: hash stability, replay/out-of-order delivery, tenant-isolation probe, approval invalidation both directions, bot rejection, negative verdict + acceptance, promotion gating; each lands as a failing tracer assertion before wiring.
@@ -893,7 +891,7 @@ Move standalone Git-canonical repos into managed Cloud governance without dual a
 **Repos:** all · **Depends on:** E7.2–E7.5
 **Read first:** [RELEASE-EVIDENCE.md R7](RELEASE-EVIDENCE.md#r7-g1a--g1b-ingestion-gates) · [RELEASE-EVIDENCE.md R8](RELEASE-EVIDENCE.md#r8-versioned-layer-specific-evidence-contracts) · [RED-TEAM-CLOSURE.md RT-20](RED-TEAM-CLOSURE.md#rt-20--evidence-and-release-gate-integrity) · [ADR-0042](../../adr/0042-pilot-readiness-thresholds.md)
 **Tracer bullets:**
-1. `E7.6.T1` — Ratify-or-amend the G1B proposal BEFORE freeze (original: ~≥25 assessments across ≥2 repos, perfect digest integrity, zero duplicate/stale corruption), then freeze the versioned evidence contract as a YAML instance validating against the E4.7.T1 schema (which owns the field set) before the first eligible observation; failing check: schema-validating the frozen contract against E4.7.T1.
+1. `E7.6.T1` — Ratify-or-amend the G1B proposal BEFORE freeze (original: ~≥25 assessments across ≥2 repos, perfect digest integrity, zero duplicate/stale corruption), then define and freeze its versioned evidence contract and schema before the first eligible observation; failing check: the frozen contract validates against that schema.
 2. `E7.6.T2` — Precommit the real-run population across ≥2 repositories; collection harness records per run: digest acceptance, duplicate Governance Events, stale overwrites, isolation/idempotency properties; fixture runs marked ineligible and never cited as real use.
 3. `E7.6.T3` — Evaluation readout: every rate names its denominator; a percentage under the denominator floor is descriptive + insufficient_evidence and cannot promote enforcement or contracts (provenance: original V10 evidence discipline, non-executable); pass/fail recorded as a decision record.
 **Acceptance:**
@@ -910,7 +908,7 @@ Move standalone Git-canonical repos into managed Cloud governance without dual a
 1. `E7.7.T1` — End-to-end design-partner rehearsal of the R2 Pilot Candidate minimum workflow on a partner-like repo: connect → ingest → assess → propose → approve → effective → retrieve → audit, with an exact trace across all contracts; the failing check is the trace-completeness assertion, cross-repo per the E0.4 compatibility table (requires E0.4 accepted).
 2. `E7.7.T2` — Capability/maturity/limitations labeling pass: per-capability manifest authoritative for policy/config validity (overall maturity label is onboarding only); `web` claims audited — no Preview/Beta capability claims GA; Cloud-connected Action features labeled Beta while standalone Action v2 GA stays independent.
 3. `E7.7.T3` — Stop-ship sweep: full security acceptance suite (fork-no-secrets, injection, path-escape/symlink corpus, stale head, oversized/malformed provider JSON, model-creates-authority attempt, checksum mismatch, tenant isolation, replay, credential canary, wire egress) green; any zero-tolerance invariant violation blocks the stage regardless of aggregate metrics.
-4. `E7.7.T4` — Go/no-go decision record citing G1A/G1B results, stop-ship sweep, and disclosures; a missed threshold moves the date — it never shrinks accepted V1 scope or rewrites thresholds.
+4. `E7.7.T4` — Go/no-go decision record citing E4.6 deterministic acceptance, G1B results, stop-ship sweep, and disclosures; a missed threshold moves the date — it never shrinks accepted V1 scope or rewrites thresholds.
 **Acceptance:**
 - R2 workflow completes with full receipt/audit trace for at least one real design-partner-shaped run.
 - Zero stop-ship violations across the full security acceptance suite, including the model-creates-authority and replayed-worker-result attempts.
@@ -1069,7 +1067,7 @@ Convert the frozen layered evidence program into an explicit GA decision: qualif
 **Repos:** `adoc`, `cloud` · **Depends on:** E3.3
 **Read first:** [RELEASE-EVIDENCE R6/R8](RELEASE-EVIDENCE.md#r6-layered-evidence-program) · [SEMANTICS S5](SEMANTICS.md#s5-capability-specific-executor-qualification) · [RED-TEAM-CLOSURE RT-18](RED-TEAM-CLOSURE.md#rt-18--evidence-anti-bias-controls) · provenance: V10.1.7 G2 in [original roadmap](../ROADMAP-V10-2026-08-12-original.md)
 **Tracer bullets:**
-1. `E9.1.T1` — Qualification evidence contracts frozen as YAML instances validating against the E4.7.T1 schema (which owns the schema; E4.7 is outside this slice's Depends-on closure — an explicit out-of-closure dependency, E4.7.T1 must be accepted first) with a failing validation test; frozen-before-first-eligible-observation enforced by the E4.7.T1 check.
+1. `E9.1.T1` — Define and freeze qualification evidence contracts and their schema before the first eligible observation, with a failing validation test; no dependency on the deferred E4.7 cohort machinery.
 2. `E9.1.T2` — Cloud qualification record store binding an executor configuration (model/task/context/tool/runtime digests) to a current qualification result; failing fixture: proposal-style required gate modes stay unavailable without a current record.
 3. `E9.1.T3` — Requalification triggers: material model/task/context/tool/runtime change invalidates the record (one fixture per trigger); a defect closes the cohort version and starts a new one — never rewrites criteria.
 4. `E9.1.T4` — Layer-1 qualification content as an executable suite: protocol conformance, closed citations, exact context, malformed outputs, prompt injection, fallback, no-model-authority, capability benchmarks (provenance: V10.1.7 G2 shape — schema-valid ≥95% over ≥30 runs, 100% invalid outputs visibly fell_back/failed).

--- a/docs/roadmap/v10/RED-TEAM-CLOSURE.md
+++ b/docs/roadmap/v10/RED-TEAM-CLOSURE.md
@@ -297,7 +297,7 @@ Limits and cost controls cannot silently weaken required governance policy.
 
 Permanent stop-ship invariants remain zero-tolerance for cross-workspace disclosure, unauthorized promotion/approval, model-created authority, restricted-content leakage, stale semantic approval after content change, accepted digest mismatch, required failure represented as success, and ACL uncertainty widening access.
 
-G1A gates engineering admission; G1B gates external Pilot Candidate. Other evidence layers freeze their own versioned contracts before first eligible observation.
+G1A engineering admission is deferred for the pilot and does not gate E4 merges or E5 implementation; E4.6 deterministic invariants remain required. G1B gates external Pilot Candidate. Other evidence layers freeze their own versioned contracts before first eligible observation.
 
 A material measurement defect closes the affected cohort version and starts a new one; it does not retroactively change success criteria.
 

--- a/docs/roadmap/v10/RELEASE-EVIDENCE.md
+++ b/docs/roadmap/v10/RELEASE-EVIDENCE.md
@@ -140,9 +140,9 @@ Separate evidence lines for executor quality, workflow usefulness, gate behavior
 
 ## R7. G1A / G1B ingestion gates
 
-### G1A — technical engineering admission
+### G1A — deferred technical engineering admission
 
-Freeze before first eligible internal tracer run. Includes replay/stale-run/digest/idempotency/isolation suites plus a small precommitted set of real internal assessments. Passing G1A allows governance implementation to proceed internally.
+The pilot does not require a measured internal G1A cohort. E4.6's deterministic replay/stale-run/digest/idempotency/isolation suites remain required, but no evidence contract, retained run set, or G1A readout gates E4 merges or internal governance implementation. No historical G1A run authorizes promotion. Reconsider the measured cohort only when observed pilot scale or a release decision requires it.
 
 ### G1B — external Pilot Candidate admission
 
@@ -218,7 +218,7 @@ They become feature-complete Beta at Product V1 RC and GA-supported only after P
 Targets do not override evidence:
 
 - **2026-09-30 — internal integrated tracer.** GitHub change → deterministic assessment → one qualified semantic executor → Cloud candidate → native approval → check. Internal/synthetic data acceptable. Not external.
-- **2026-11-30 — V1 Pilot Candidate / Private Alpha.** Selected design partners; source-neutral auth, Cloud canonical flow, provider-neutral semantics, GitHub native approval/checks, egress basics, tenant isolation, backup/restore/monitoring/rollback/incident readiness, G1A/G1B green.
+- **2026-11-30 — V1 Pilot Candidate / Private Alpha.** Selected design partners; source-neutral auth, Cloud canonical flow, provider-neutral semantics, GitHub native approval/checks, egress basics, tenant isolation, backup/restore/monitoring/rollback/incident readiness, G1B green.
 - **2027-02-28 — V1 Feature Complete / RC.** Every locked V1 P0 implemented, including second approval mode, trusted forks, migration, permission-aware retrieval/sensitive audit, privacy workflows, GitLab Preview, connector manifests, managed state/proof model, compatibility/security matrices.
 - **2027-04-30 — earliest credible V1 GA.** Only after real-pilot, qualification, required-gate, review-burden, operations, and critical-defect evidence passes.
 


### PR DESCRIPTION
## Summary

- record D40: defer the measured internal G1A cohort for this pilot
- keep E4.6 deterministic invariants as the technical acceptance basis
- remove G1A as an E4 merge or E5 implementation gate
- leave G1B as the external Pilot Candidate admission gate

This replaces the speculative G1A evidence stack in #177-#182 and #189-#190. It adds no runtime, schema, workflow, or dependency.

## Tests

- cargo test -p adoc-mcp --test roadmap_sync_guard --test compat_baseline_guard
- git diff --check