### PR TITLE
docs(contracts): reserve Action receipt successors

### DIFF
--- a/crates/adoc-mcp/tests/contract_registry_guard.rs
+++ b/crates/adoc-mcp/tests/contract_registry_guard.rs
@@ -105,6 +105,20 @@ const ANCHORS: &[&str] = &[
     "registry:proof-obligation-stages",
 ];
 
+/// Tables whose ids are section-scoped bare words, not globally unique ids.
+/// Namespaced vocabularies such as `registry:managed-state-dimensions` stay
+/// outside this list and remain subject to the disposition collision check.
+const VOCABULARY_ANCHORS: &[&str] = &[
+    "registry:group-binding-modes",
+    "registry:group-source-kinds",
+    "registry:group-membership-unavailability-states",
+    "registry:untrusted-change-states",
+    "registry:retention-classes",
+    "registry:replay-postures",
+    "registry:proof-obligation-states",
+    "registry:proof-obligation-stages",
+];
+
 /// True for `adoc.<path>.v<digits>` or `agentdoc.<path>.v<digits>` — the envelope
 /// schema-version id shape and nothing else.
 fn is_envelope_id(candidate: &str) -> bool {
@@ -294,6 +308,31 @@ fn all_anchors_present() {
     let registry = registry();
     for anchor in ANCHORS {
         anchored_ids(&registry, anchor); // panics on a missing anchor
+    }
+}
+
+#[test]
+fn vocabulary_anchors_are_declared_anchors() {
+    for anchor in VOCABULARY_ANCHORS {
+        assert!(
+            ANCHORS.contains(anchor),
+            "{anchor:?} is not a declared registry anchor — a stale or typo'd \
+             exclusion would silently weaken the disposition check"
+        );
+    }
+}
+
+#[test]
+fn vocabulary_anchors_hold_bare_words() {
+    let registry = registry();
+    for anchor in VOCABULARY_ANCHORS {
+        for id in anchored_ids(&registry, anchor) {
+            assert!(
+                !id.contains('.'),
+                "{anchor}: {id:?} is namespaced, not a section-scoped bare word — \
+                 a namespaced table belongs in the disposition scan"
+            );
+        }
     }
 }
 
@@ -501,6 +540,35 @@ fn e4_6_ingestion_codes_are_registered_exactly() {
         "connect.permission_exceeds_manifest",
     ] {
         assert!(registered.contains(code), "E4.6 Cloud code missing: {code}");
+    }
+}
+
+#[test]
+fn planned_delivery_and_connect_codes_stay_with_their_owner() {
+    let registry = registry();
+    let action = anchored_ids(&registry, "registry:action-codes");
+    let cloud = anchored_ids(&registry, "registry:cloud-codes");
+
+    let action_owned = "delivery.fork_branch_read_only";
+    assert!(
+        action.contains(action_owned),
+        "E3.8 Action code missing: {action_owned}"
+    );
+    assert!(
+        !cloud.contains(action_owned),
+        "E3.8 Action code owned by Cloud: {action_owned}"
+    );
+    for (slice, code) in [
+        ("E8.2", "delivery.reference_missing"),
+        ("E8.2", "delivery.reference_stale"),
+        ("E7.3", "connect.unknown_config_field"),
+        ("E7.3", "connect.credential_store_violation"),
+    ] {
+        assert!(cloud.contains(code), "{slice} Cloud code missing: {code}");
+        assert!(
+            !action.contains(code),
+            "{slice} Cloud code owned by Action: {code}"
+        );
     }
 }
 
@@ -1514,10 +1582,11 @@ fn group_retention_rules_match_the_e2_4_authority() {
 
 /// Backticked codes cited by the executable planning surface, one
 /// `(document, line, code)` per citation. Covers `gate.*`/`action.*`/
-/// `workspace.*` codes and envelope ids; `attestation.*` siblings are
-/// deliberately outside the net — E8.1.T1 registers them as a registry edit
-/// in that slice. `workspace.*` permission primitives belong under their own
-/// registry anchor, never `registry:cloud-codes`.
+/// `workspace.*`/`delivery.*`/`connect.*` codes and envelope ids. `delivery.*`
+/// intentionally spans the Action and Cloud owner tables. `attestation.*`
+/// siblings are deliberately outside the net — E8.1.T1 registers them as a
+/// registry edit in that slice. `workspace.*` permission primitives belong
+/// under their own registry anchor, never `registry:cloud-codes`.
 fn cited_codes() -> Vec<(String, usize, String)> {
     let dir = repo_root().join("docs/roadmap/v10");
     let mut cited = Vec::new();
@@ -1537,18 +1606,22 @@ fn cited_codes() -> Vec<(String, usize, String)> {
         }
         for (number, line) in support::doc_scan::structural_lines(&content) {
             for span in line.split('`').skip(1).step_by(2) {
-                let is_registered_code = ["gate.", "action.", "workspace."].iter().any(|prefix| {
-                    span.strip_prefix(prefix).is_some_and(|rest| {
-                        !rest.is_empty() && rest.chars().all(|c| c.is_ascii_lowercase() || c == '_')
-                    })
-                });
+                let is_registered_code =
+                    ["gate.", "action.", "workspace.", "delivery.", "connect."]
+                        .iter()
+                        .any(|prefix| {
+                            span.strip_prefix(prefix).is_some_and(|rest| {
+                                !rest.is_empty()
+                                    && rest.chars().all(|c| c.is_ascii_lowercase() || c == '_')
+                            })
+                        });
                 if is_registered_code || is_envelope_id(span) {
                     cited.push((name.clone(), number, span.to_string()));
                 }
             }
         }
     }
-    for prefix in ["gate.", "action.", "workspace."] {
+    for prefix in ["gate.", "action.", "workspace.", "delivery.", "connect."] {
         assert!(
             cited.iter().any(|(_, _, code)| code.starts_with(prefix)),
             "no `{prefix}*` citation found"
@@ -1642,6 +1715,28 @@ fn guard_fires_on_a_duplicated_close_marker() {
 }
 
 #[test]
+fn disposed_ids_are_not_registered_elsewhere() {
+    let registry = registry();
+    let dispositions = anchored_ids(&registry, "registry:dispositions");
+    let still_registered: Vec<_> = ANCHORS
+        .iter()
+        .filter(|anchor| {
+            **anchor != "registry:dispositions" && !VOCABULARY_ANCHORS.contains(*anchor)
+        })
+        .flat_map(|anchor| {
+            anchored_ids(&registry, anchor)
+                .into_iter()
+                .filter(|id| dispositions.contains(id))
+                .map(move |id| format!("{anchor}: {id}"))
+        })
+        .collect();
+    assert!(
+        still_registered.is_empty(),
+        "disposed ids may not remain registered elsewhere: {still_registered:?}"
+    );
+}
+
+#[test]
 fn semantic_failed_has_exactly_one_disposition() {
     let registry = registry();
     let dispositions = anchored_ids(&registry, "registry:dispositions");
@@ -1661,10 +1756,6 @@ fn semantic_failed_has_exactly_one_disposition() {
     assert!(
         action_codes.contains("action.semantic_review_failed"),
         "the surviving code must itself be a registered Action code"
-    );
-    assert!(
-        !action_codes.contains("action.semantic_failed"),
-        "a removed code may never also appear as a registered Action code"
     );
 }
 

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -109,6 +109,9 @@ Reserved ids for the accepted V1 contract set (E0.3.T2). Each row names its owni
 | id | owner | planned by | notes |
 | --- | --- | --- | --- |
 | `adoc.pr_assessment_receipt.v1` | action | E2.5 | exact-match successor adding server-bound GitHub Actions workload identity; v0 remains shipped until the successor is released |
+| `adoc.pr_assessment_receipt.v2` | action | E3.5 | exact-match successor adding validator-bound semantic assessment, closed status `required` / `completed` / `skipped` / `fell_back` / `failed`, and one independently eligible fallback with both provider identities on `fell_back`; v1 remains available if released, otherwise moves to Dispositions as never shipped |
+| `adoc.pr_assessment_receipt.v3` | action | E3.7 | exact-match successor adding the authenticated Cloud work-result hand-off outcome and surfacing the registered `action.cloud_sync_failed` failure code; v2 remains available if released, otherwise moves to Dispositions as never shipped |
+| `adoc.pr_assessment_receipt.v4` | action | E3.8 | exact-match successor adding split untrusted/trusted phase provenance, the registered S8 untrusted-change states, and the fork-safe write-path refusal code `delivery.fork_branch_read_only`; v3 remains available if released, otherwise moves to Dispositions as never shipped |
 | `adoc.connector_acl_policy.v0` | adoc | E2.6 | activation-time ACL acquisition, freshness, refresh, revocation, outage, and cache/session invalidation declaration; contract-tested schema `adoc.connector_acl_policy.v0.schema.json` |
 | `adoc.source_acl_snapshot.v0` | adoc | E2.6 | immutable historical ACL provenance only; `source_acl_ceiling.snapshot_id` records the consulted snapshot while the nested `current_authorization` input in `adoc.authorization_decision.v0` independently proves freshness-bounded current access; contract-tested schema `adoc.source_acl_snapshot.v0.schema.json` |
 | `adoc.sensitive_access.v0` | adoc | E6.3 | name held until a final registered successor (RT-08) |
@@ -350,6 +353,7 @@ Shared row values for shipped rows: producer Action v2.0.0-alpha.19 (workflow an
 | `action.unsupported_event` | shipped | unsupported triggering event |
 | `action.cloud_sync_failed` | shipped | Action v2 E3.7 Cloud hand-off failed; local assessment preserved and annotated, never failed retroactively |
 | `action.attestation_bot_rejected` | planned (E8.1) | Action check wrapper for the canonical Cloud code `attestation.bot_approver_rejected` — one documented mapping, no competing suffix |
+| `delivery.fork_branch_read_only` | planned (E3.8) | Action refuses writes to a fork branch and names the separate base-repository PR alternative |
 <!-- /registry:action-codes -->
 
 ## Gate codes — planned, owner `adoc`
@@ -485,11 +489,15 @@ Operation labels and typed failure codes owned by the private Cloud service. New
 | `ingest.stale_run` | planned (E4.6) | an older observed head is retained in history but cannot replace the repository's newer lineage head |
 | `ingest.digest_mismatch` | planned (E4.6) | a claimed assessment or receipt digest does not match the submitted envelope bytes; the attempt is recorded and the delivery rejected |
 | `connect.permission_exceeds_manifest` | planned (E4.6) | a connector grant exceeds its authenticated capability manifest; the connection becomes unhealthy and ingestion pauses until re-consent |
+| `connect.unknown_config_field` | planned (E7.3) | strict settings parsing rejects an unknown field instead of silently accepting it |
+| `connect.credential_store_violation` | planned (E7.3) | a service identity attempts to read both semantic-provider and source/write credential stores |
 | `connector.manifest_invalid` | planned (E4.5) | connector capability manifest fails exact-version decoding or its adapter, connector, or authenticated-publisher binding is invalid |
 | `connector.publisher_unqualified` | planned (E4.5) | the authenticated publisher lacks trusted qualification for a claimed capability maturity; customer publishers cannot self-claim AgentDoc GA |
 | `connector.configuration_ineligible` | planned (E4.5) | a connector configuration cannot activate because its dependency closure, capability maturity, or new-use deprecation policy is unsatisfied; remediation carries eligible alternatives rather than weakening the requested gate |
 | `connector.capability_ineligible` | planned (E4.5) | runtime policy rejects a required capability after applying its current per-capability maturity, any immediate incident demotion/suspension, and a current scoped exception |
 | `connector.exception_invalid` | planned (E4.5) | a maturity exception is missing immutable scope, expiry, current permission approval, or receipt binding, or attempts to authorize after expiry |
+| `delivery.reference_missing` | planned (E8.2) | Cloud rejects a proposal record whose Action-owned knowledge-PR reference block is absent or incomplete |
+| `delivery.reference_stale` | planned (E8.2) | Cloud rejects a proposal record whose reference block is bound to a superseded assessment head |
 <!-- /registry:cloud-codes -->
 
 ## Attestation codes — planned, owner `cloud`
@@ -504,10 +512,10 @@ The canonical bot-attestation code family root (RT-21, E0.3.T3). The Action neve
 
 ## Dispositions
 
-Codes resolved out of existence (RT-21). A disposition is permanent: the id is never reused with another meaning.
+Codes and contract ids resolved out of existence (RT-21). A disposition is permanent: the id is never reused with another meaning.
 
 <!-- registry:dispositions -->
-| code | disposition |
+| code or id | disposition |
 | --- | --- |
 | `action.semantic_failed` | removed — appeared only in pre-V10 planning text and never shipped (no occurrence in Action v2.0.0-alpha.19 sources); the shipped registered code `action.semantic_review_failed` is the single canonical Action semantic-failure reason code, and any gate-matrix or planning reference resolves there |
 <!-- /registry:dispositions -->

--- a/docs/roadmap/v10/EXECUTION-MAP.md
+++ b/docs/roadmap/v10/EXECUTION-MAP.md
@@ -215,7 +215,7 @@ Dates never override stop-ship invariants.
 ## E3.5 — Fallback eligibility chain
 
 **Repos:** `action`, `cloud`  
-**Depends on:** E3.4  
+**Depends on:** E2.5, E3.4  
 **Goal:** one optional fallback only when independently eligible under capability/maturity/risk/egress/residency/retention/org policy.  
 **Exit:** local/zero-egress primary cannot silently fall back to public provider; no eligible fallback → honest failure.
 
@@ -228,7 +228,7 @@ Dates never override stop-ship invariants.
 ## E3.7 — External work request/result authenticity
 
 **Repos:** `adoc`, `cloud`, `action`  
-**Depends on:** E2.5, E0.3  
+**Depends on:** E2.5, E0.3, E3.5  
 **Contracts:** versioned work request/result with repository/workspace/revision, nonce, digest, expiry, workload identity, runtime/capability versions, replay/idempotency state.  
 **Exit:** replay/cross-workspace/cross-revision/cross-request substitution fixtures fail.
 

--- a/docs/roadmap/v10/MILESTONES.md
+++ b/docs/roadmap/v10/MILESTONES.md
@@ -411,7 +411,7 @@ Digest-bound semantic context and assessment contracts, executor qualification, 
 **Out of scope:** fallback chain (E3.5), qualification evidence cohorts (E9.1), AgentDoc-hosted executor (P3). External providers remain adapters, never permanent architectural dependencies.
 
 ### E3.5 — Fallback eligibility chain
-**Repos:** `action`, `cloud` · **Depends on:** E3.4
+**Repos:** `action`, `cloud` · **Depends on:** E2.5, E3.4
 **Read first:** [RED-TEAM-CLOSURE.md RT-10](RED-TEAM-CLOSURE.md#rt-10--semantic-fallback-equivalence) · [SEMANTICS.md §S7](SEMANTICS.md#s7-per-repository-git-processing-mode) · [PRD v1.1 §10](../../product/PRD-v1.1-amendment.md#10-provider-neutral-semantic-execution)
 **Tracer bullets:**
 1. `E3.5.T1` — Closed semantic status vocabulary `required|completed|skipped|fell_back|failed` as durable envelope/receipt data; failing tests: unknown status rejected; `completed` reachable only through a validator-accepted envelope (provenance: V10.2.3).
@@ -441,7 +441,7 @@ Digest-bound semantic context and assessment contracts, executor qualification, 
 **Out of scope:** native approval flow (E5.2), gate evaluator (E5.3), separation-of-duties/quorum (P4).
 
 ### E3.7 — External work request/result authenticity
-**Repos:** `adoc`, `cloud`, `action` · **Depends on:** E2.5, E0.3
+**Repos:** `adoc`, `cloud`, `action` · **Depends on:** E2.5, E0.3, E3.5
 **Read first:** [RED-TEAM-CLOSURE.md RT-16](RED-TEAM-CLOSURE.md#rt-16--external-workerresult-authenticity) · [PRD v1.1 §13](../../product/PRD-v1.1-amendment.md#13-git-processing-modes) · [SEMANTICS.md §S7](SEMANTICS.md#s7-per-repository-git-processing-mode)
 **Tracer bullets:**
 1. `E3.7.T1` — Versioned work-request envelope in `adoc`: workspace/repo/source, exact revision/change request, request ID + nonce, request digest, contract/capability requirements, expiry, authorized workload identity/audience; failing test: digest-stable round trip; unknown envelope version rejected with remediation.


### PR DESCRIPTION
## Summary\n- reserve exact-match Action receipt v2 for E3.5 semantic assessment and fallback evidence\n- reserve v3 for E3.7 authenticated Cloud work-result hand-off state\n- reserve v4 for E3.8 split trusted-phase and fork-safe delivery provenance\n- preserve v0 as shipped and v1 as the existing planned successor; no release status changes\n- pin receipt ordering plus Cloud/Action ownership and disposition invariants\n\n## Verification\n- cargo test -p adoc-mcp --test contract_registry_guard (47 passed)\n- cargo fmt --check\n- diff whitespace check excluding the two intentional Execution Map Markdown hard breaks; hard breaks inspected directly