### PR TITLE
feat(core): surface authority promotions (E5.3.T6)

### DIFF
--- a/crates/adoc-cli/tests/assess_changes_cli.rs
+++ b/crates/adoc-cli/tests/assess_changes_cli.rs
@@ -197,6 +197,71 @@ fn assess_changes_emits_one_complete_body_free_record_per_changed_path() {
 }
 
 #[test]
+fn direct_authority_promotion_emits_one_typed_record() {
+    let workspace = repo();
+    workspace.write(
+        "docs/billing.adoc",
+        concat!(
+            "# Billing @doc(team.billing)\n\n",
+            "::claim billing.credits\n",
+            "status: draft\n",
+            "owner: billing-platform\n",
+            "source: src/billing.rs\n",
+            "impacts: [src/billing.rs]\n",
+            "--\nCredits settle after payment.\n::\n",
+        ),
+    );
+    git(&workspace, &["add", "docs/billing.adoc"]);
+    git(&workspace, &["commit", "-m", "make claim provisional"]);
+    workspace.write(
+        "docs/billing.adoc",
+        concat!(
+            "# Billing @doc(team.billing)\n\n",
+            "::claim billing.credits\n",
+            "status: verified\n",
+            "owner: billing-platform\n",
+            "verified_at: 2026-07-01\n",
+            "source: src/billing.rs\n",
+            "impacts: [src/billing.rs]\n",
+            "--\nCredits settle after payment.\n::\n",
+        ),
+    );
+
+    let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args([
+            "assess-changes",
+            "--base",
+            "HEAD",
+            "--as-of",
+            "2026-07-22",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("adoc assess-changes runs");
+
+    assert!(
+        output.status.success(),
+        "assessment failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let value: serde_json::Value = serde_json::from_slice(&output.stdout).expect("assessment JSON");
+    assert_eq!(
+        value["authority_promotions"]["value"],
+        serde_json::json!([{
+            "id": "billing.credits",
+            "content_hash": value["knowledge_changes"]["value"]["changed"][0]["head_content_hash"],
+            "kind": "claim",
+            "before_kind": "claim",
+            "before_status": "draft",
+            "after_status": "verified"
+        }])
+    );
+}
+
+#[test]
 fn empty_change_set_with_healthy_knowledge_passes() {
     let workspace = repo();
     let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
@@ -285,6 +350,7 @@ fn unresolved_base_emits_error_not_evaluated_envelope_and_exits_two() {
     assert_eq!(value["completeness"], "error");
     assert_eq!(value["outcome"], "not_evaluated");
     assert_eq!(value["paths"]["status"], "unavailable");
+    assert_eq!(value["authority_promotions"]["status"], "unavailable");
     assert_eq!(value["diagnostics"][0]["code"], "assessment.ref_unresolved");
 }
 
@@ -370,6 +436,7 @@ fn invalid_head_emits_error_invalid_without_fake_empty_graph_sections() {
     assert_eq!(value["outcome"], "invalid");
     assert_eq!(value["knowledge_snapshot"]["status"], "unavailable");
     assert_eq!(value["objects"]["status"], "unavailable");
+    assert_eq!(value["authority_promotions"]["status"], "unavailable");
 }
 
 #[test]

--- a/crates/adoc-core/src/application/change_assessment.rs
+++ b/crates/adoc-core/src/application/change_assessment.rs
@@ -245,6 +245,16 @@ pub struct KnowledgeChanges {
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct AuthorityPromotion {
+    pub id: String,
+    pub content_hash: String,
+    pub kind: String,
+    pub before_kind: Option<String>,
+    pub before_status: Option<String>,
+    pub after_status: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PolicyChanges {
     pub status: String,
     pub changed: bool,
@@ -298,6 +308,7 @@ pub struct ChangeAssessmentEnvelope {
     pub paths: Availability<Vec<AssessedPath>>,
     pub objects: Availability<Vec<AssessmentObject>>,
     pub knowledge_changes: Availability<KnowledgeChanges>,
+    pub authority_promotions: Availability<Vec<AuthorityPromotion>>,
     pub policy_changes: PolicyChanges,
     pub required_reviewers: Vec<AssessmentReviewer>,
     pub proof_obligations: Vec<AssessmentObligation>,
@@ -733,6 +744,7 @@ fn complete_envelope(input: CompleteInput<'_>) -> ChangeAssessmentEnvelope {
         })
         .collect::<Vec<_>>();
     let knowledge_changes = knowledge_changes(&diff);
+    let authority_promotions = authority_promotions(&diff);
     let (reviewers, obligations) =
         review_requirements(&objects, &knowledge_changes, policy_changed);
     let signals = lifecycle_signals(&head_objects);
@@ -805,6 +817,7 @@ fn complete_envelope(input: CompleteInput<'_>) -> ChangeAssessmentEnvelope {
         paths: available(paths),
         objects: available(objects),
         knowledge_changes: available(knowledge_changes),
+        authority_promotions: available(authority_promotions),
         policy_changes: PolicyChanges {
             status: "available".to_string(),
             changed: policy_changed,
@@ -1038,6 +1051,39 @@ fn knowledge_changes(diff: &ObjectDiff) -> KnowledgeChanges {
             .map(|node| knowledge_change(node, Some(&node.content_hash), None, "deleted"))
             .collect(),
     }
+}
+
+fn authority_promotions(diff: &ObjectDiff) -> Vec<AuthorityPromotion> {
+    let mut promotions = diff
+        .created
+        .iter()
+        .filter_map(|node| {
+            let after_status = node.status.as_ref()?;
+            is_authoritative_subject(&node.kind, Some(after_status)).then(|| AuthorityPromotion {
+                id: node.id.clone(),
+                content_hash: node.content_hash.clone(),
+                kind: node.kind.clone(),
+                before_kind: None,
+                before_status: None,
+                after_status: after_status.clone(),
+            })
+        })
+        .chain(diff.changed.iter().filter_map(|change| {
+            let after_status = change.head.status.as_ref()?;
+            (is_authoritative_subject(&change.head.kind, Some(after_status))
+                && !is_authoritative_subject(&change.base.kind, change.base.status.as_deref()))
+            .then(|| AuthorityPromotion {
+                id: change.id.clone(),
+                content_hash: change.head.content_hash.clone(),
+                kind: change.head.kind.clone(),
+                before_kind: Some(change.base.kind.clone()),
+                before_status: change.base.status.clone(),
+                after_status: after_status.clone(),
+            })
+        }))
+        .collect::<Vec<_>>();
+    promotions.sort_by(|left, right| left.id.cmp(&right.id));
+    promotions
 }
 
 fn knowledge_change(
@@ -1528,6 +1574,7 @@ fn empty_envelope(
         paths: unavailable(),
         objects: unavailable(),
         knowledge_changes: unavailable(),
+        authority_promotions: unavailable(),
         policy_changes: PolicyChanges {
             status: "unavailable".to_string(),
             changed: false,
@@ -1740,9 +1787,10 @@ fn compact_json<T: Serialize>(value: &T) -> Result<Vec<u8>, serde_json::Error> {
 #[cfg(test)]
 mod tests {
     use super::{
-        compact_json, graph_schema_version, is_authoritative_subject, lifecycle_signals,
-        object_set_json, path_matches_exclusion, reviewers_of,
+        authority_promotions, compact_json, graph_schema_version, is_authoritative_subject,
+        lifecycle_signals, object_set_json, path_matches_exclusion, reviewers_of,
     };
+    use crate::domain::review::object_diff::ObjectDiff;
     use crate::domain::review::object_diff::test_support::test_node;
     use serde::ser::Error as _;
 
@@ -1817,6 +1865,126 @@ mod tests {
         ] {
             assert!(!is_authoritative_subject(pair.0, pair.1), "{pair:?}");
         }
+    }
+
+    #[test]
+    fn promotions_into_each_authority_pair_are_detected() {
+        for (kind, before, after) in [
+            ("claim", "draft", "verified"),
+            ("decision", "proposed", "accepted"),
+            ("api", "draft", "verified"),
+            ("policy", "draft", "active"),
+            ("procedure", "draft", "verified"),
+        ] {
+            let mut base = test_node(&format!("billing.{kind}"), "sha256:base");
+            base.kind = kind.to_string();
+            base.status = Some(before.to_string());
+            let mut head = base.clone();
+            head.content_hash = "sha256:head".to_string();
+            head.status = Some(after.to_string());
+
+            let promotions = authority_promotions(&ObjectDiff::compute(&[base], &[head]));
+
+            assert_eq!(promotions.len(), 1, "{kind}/{after}");
+            assert_eq!(promotions[0].id, format!("billing.{kind}"));
+            assert_eq!(promotions[0].content_hash, "sha256:head");
+            assert_eq!(promotions[0].kind, kind);
+            assert_eq!(promotions[0].before_kind.as_deref(), Some(kind));
+            assert_eq!(promotions[0].before_status.as_deref(), Some(before));
+            assert_eq!(promotions[0].after_status, after);
+        }
+    }
+
+    #[test]
+    fn kind_only_transition_into_authority_is_detected() {
+        let mut base = test_node("billing.credits", "sha256:base");
+        base.kind = "example".to_string();
+        base.status = Some("verified".to_string());
+        let mut head = base.clone();
+        head.kind = "claim".to_string();
+        head.content_hash = "sha256:head".to_string();
+
+        let promotions = authority_promotions(&ObjectDiff::compute(&[base], &[head]));
+
+        assert_eq!(promotions.len(), 1);
+        assert_eq!(promotions[0].kind, "claim");
+        assert_eq!(promotions[0].before_kind.as_deref(), Some("example"));
+        assert_eq!(promotions[0].before_status.as_deref(), Some("verified"));
+        assert_eq!(promotions[0].after_status, "verified");
+    }
+
+    #[test]
+    fn created_authoritative_object_is_a_promotion_with_empty_before_status() {
+        let mut created = test_node("billing.ready", "sha256:ready");
+        created.status = Some("verified".to_string());
+
+        let promotions = authority_promotions(&ObjectDiff::compute(&[], &[created]));
+
+        assert_eq!(promotions.len(), 1);
+        assert_eq!(promotions[0].id, "billing.ready");
+        assert_eq!(promotions[0].before_kind, None);
+        assert_eq!(promotions[0].before_status, None);
+        assert_eq!(promotions[0].after_status, "verified");
+        assert_eq!(
+            serde_json::to_value(&promotions[0]).expect("promotion serializes")["before_status"],
+            serde_json::Value::Null
+        );
+    }
+
+    #[test]
+    fn non_authority_same_status_and_existing_authority_changes_are_not_promotions() {
+        let mut non_authority_base = test_node("billing.draft", "sha256:draft-base");
+        non_authority_base.status = Some("draft".to_string());
+        let mut non_authority_head = non_authority_base.clone();
+        non_authority_head.content_hash = "sha256:draft-head".to_string();
+        non_authority_head.status = Some("deprecated".to_string());
+
+        let mut same_status_base = test_node("billing.same", "sha256:same-base");
+        same_status_base.status = Some("verified".to_string());
+        let mut same_status_head = same_status_base.clone();
+        same_status_head.content_hash = "sha256:same-head".to_string();
+
+        let mut authority_base = test_node("billing.authority", "sha256:authority-base");
+        authority_base.status = Some("verified".to_string());
+        let mut authority_head = authority_base.clone();
+        authority_head.kind = "decision".to_string();
+        authority_head.status = Some("accepted".to_string());
+        authority_head.content_hash = "sha256:authority-head".to_string();
+
+        let promotions = authority_promotions(&ObjectDiff::compute(
+            &[non_authority_base, same_status_base, authority_base],
+            &[non_authority_head, same_status_head, authority_head],
+        ));
+
+        assert!(promotions.is_empty());
+    }
+
+    #[test]
+    fn promotions_are_byte_stable_in_object_id_order() {
+        let base = test_node("a.changed", "sha256:a-base");
+        let mut head = base.clone();
+        head.content_hash = "sha256:a-head".to_string();
+        head.status = Some("verified".to_string());
+        let mut created = test_node("z.created", "sha256:z-head");
+        created.status = Some("verified".to_string());
+
+        let first = authority_promotions(&ObjectDiff::compute(
+            std::slice::from_ref(&base),
+            &[created.clone(), head.clone()],
+        ));
+        let second = authority_promotions(&ObjectDiff::compute(&[base], &[head, created]));
+
+        assert_eq!(
+            first
+                .iter()
+                .map(|entry| entry.id.as_str())
+                .collect::<Vec<_>>(),
+            ["a.changed", "z.created"]
+        );
+        assert_eq!(
+            compact_json(&first).expect("promotions serialize"),
+            compact_json(&second).expect("promotions serialize")
+        );
     }
 
     #[test]

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -18,11 +18,11 @@ pub use application::change_assessment::{
     AssessedPath, AssessmentCompleteness, AssessmentConfig, AssessmentDiagnostic, AssessmentMatch,
     AssessmentObject, AssessmentObjectReason, AssessmentObligation, AssessmentOutcome,
     AssessmentPolicy, AssessmentReviewer, AssessmentSignal, AssessmentSnapshot,
-    AssessmentSnapshots, AssessmentSource, AssessmentSummary, AssessmentValidation, Availability,
-    CHANGE_ASSESSMENT_SCHEMA_VERSION, ChangeAssessmentEnvelope, ChangeAssessmentInput,
-    KnowledgeChange, KnowledgeChanges, KnowledgeSnapshot, PathClassification, PolicyChanges,
-    REPOSITORY_BASELINE_SCHEMA_VERSION, RepositoryBaselineEnvelope, RepositoryBaselineReadiness,
-    SnapshotConfig,
+    AssessmentSnapshots, AssessmentSource, AssessmentSummary, AssessmentValidation,
+    AuthorityPromotion, Availability, CHANGE_ASSESSMENT_SCHEMA_VERSION, ChangeAssessmentEnvelope,
+    ChangeAssessmentInput, KnowledgeChange, KnowledgeChanges, KnowledgeSnapshot,
+    PathClassification, PolicyChanges, REPOSITORY_BASELINE_SCHEMA_VERSION,
+    RepositoryBaselineEnvelope, RepositoryBaselineReadiness, SnapshotConfig,
 };
 pub use application::compile::{
     BuildArtifacts, BuildEmbeddingMode, BuildInput, CompileInput, CompileResult,

--- a/crates/adoc-mcp/tests/contract_schemas.rs
+++ b/crates/adoc-mcp/tests/contract_schemas.rs
@@ -1242,7 +1242,14 @@ fn validates_complete_and_error_change_assessments_and_rejects_illegal_tuples() 
             .envelope,
     )
     .expect("complete envelope serializes");
+    assert_eq!(complete["authority_promotions"]["status"], "available");
     assert_valid("adoc.change_assessment.v0.schema.json", &complete);
+    let mut prior_shape = complete.clone();
+    prior_shape
+        .as_object_mut()
+        .expect("assessment is an object")
+        .remove("authority_promotions");
+    assert_valid("adoc.change_assessment.v0.schema.json", &prior_shape);
 
     run_git(root, &["add", "-A"]);
     run_git(root, &["commit", "-m", "code change"]);
@@ -1265,6 +1272,7 @@ fn validates_complete_and_error_change_assessments_and_rejects_illegal_tuples() 
     )
     .expect("partial envelope serializes");
     assert_eq!(partial["completeness"], "partial");
+    assert_eq!(partial["authority_promotions"]["status"], "unavailable");
     assert_valid("adoc.change_assessment.v0.schema.json", &partial);
 
     let error = serde_json::to_value(
@@ -1280,12 +1288,70 @@ fn validates_complete_and_error_change_assessments_and_rejects_illegal_tuples() 
     .expect("error envelope serializes");
     assert_valid("adoc.change_assessment.v0.schema.json", &error);
 
-    let mut illegal = complete;
+    let mut illegal = complete.clone();
     illegal["completeness"] = json!("partial");
     illegal["outcome"] = json!("pass");
     let schema = schema("adoc.change_assessment.v0.schema.json");
     let validator = jsonschema::validator_for(&schema).expect("schema compiles");
     assert!(!validator.is_valid(&illegal));
+
+    let mut kind_only_promotion = complete.clone();
+    kind_only_promotion["authority_promotions"] = json!({"status": "available", "value": [{
+        "id": "billing.credits",
+        "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+        "kind": "claim",
+        "before_kind": "example",
+        "before_status": "verified",
+        "after_status": "verified"
+    }]});
+    assert_valid(
+        "adoc.change_assessment.v0.schema.json",
+        &kind_only_promotion,
+    );
+
+    for authority_promotions in [
+        json!({"status": "available"}),
+        json!({"status": "unavailable", "value": []}),
+        json!({"status": "available", "value": [{
+            "id": "billing.policy",
+            "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "kind": "policy",
+            "before_kind": "policy",
+            "before_status": "draft",
+            "after_status": "verified"
+        }]}),
+        json!({"status": "available", "value": [{
+            "id": "billing.credits",
+            "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "kind": "decision",
+            "before_kind": "policy",
+            "before_status": "active",
+            "after_status": "accepted"
+        }]}),
+        json!({"status": "available", "value": [{
+            "id": "billing.credits",
+            "content_hash": "sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+            "kind": "claim",
+            "before_kind": "claim",
+            "before_status": "verified",
+            "after_status": "verified"
+        }]}),
+    ] {
+        let mut forged = complete.clone();
+        forged["authority_promotions"] = authority_promotions;
+        assert!(
+            !validator.is_valid(&forged),
+            "forged promotion facts passed"
+        );
+    }
+
+    let mut unavailable_complete = complete.clone();
+    unavailable_complete["authority_promotions"] = json!({"status": "unavailable"});
+    assert!(!validator.is_valid(&unavailable_complete));
+
+    let mut available_error = error;
+    available_error["authority_promotions"] = json!({"status": "available", "value": []});
+    assert!(!validator.is_valid(&available_error));
 }
 
 /// V8.1.2/V8.1.3: the `adoc migrate` report envelope — built at the same

--- a/docs/adr/0050-local-change-assessment-contract.md
+++ b/docs/adr/0050-local-change-assessment-contract.md
@@ -86,11 +86,13 @@ The schema version is `adoc.change_assessment.v0`. The stable top-level sections
 - `summary` and validation attribution counts;
 - one classified record per changed path;
 - body-free implicated head `objects` and body-free `knowledge_changes`, including deletion tombstones;
+- additive-optional `authority_promotions` for crossings into authoritative kind/status pairs;
 - `policy_changes`, assessment-specific reviewers and proof obligations;
 - lifecycle, contradiction, anchor, and validation signals;
 - stable diagnostics.
 
 Unavailable sections are represented explicitly and are never replaced by a misleading empty collection. Collections are ordered deterministically by their identifying fields.
+For `adoc.change_assessment.v0` wire compatibility with older producers, `authority_promotions` may be absent; absence means promotion facts were not evaluated and must never be read as an available empty set.
 
 The envelope contains no timestamp, GitHub repository or actor, raw diff, object body, prompt, or model data. It has no self digest. V9.2.2 hashes the exact final serialized bytes.
 

--- a/docs/agent/v0/schema/adoc.change_assessment.v0.schema.json
+++ b/docs/agent/v0/schema/adoc.change_assessment.v0.schema.json
@@ -23,6 +23,7 @@
     "paths": { "$ref": "#/$defs/pathAvailability" },
     "objects": { "$ref": "#/$defs/objectAvailability" },
     "knowledge_changes": { "$ref": "#/$defs/knowledgeChangesAvailability" },
+    "authority_promotions": { "$ref": "#/$defs/authorityPromotionsAvailability" },
     "policy_changes": { "$ref": "#/$defs/policyChanges" },
     "required_reviewers": { "type": "array", "items": { "$ref": "#/$defs/reviewer" } },
     "proof_obligations": { "type": "array", "items": { "$ref": "#/$defs/obligation" } },
@@ -32,19 +33,29 @@
   "allOf": [
     {
       "if": { "properties": { "completeness": { "const": "complete" } }, "required": ["completeness"] },
-      "then": { "properties": { "outcome": { "enum": ["pass", "review_required", "uncovered"] } } }
+      "then": { "properties": {
+        "outcome": { "enum": ["pass", "review_required", "uncovered"] },
+        "authority_promotions": { "properties": { "status": { "const": "available" } } }
+      } }
     },
     {
       "if": { "properties": { "completeness": { "const": "partial" } }, "required": ["completeness"] },
-      "then": { "properties": { "outcome": { "const": "not_evaluated" } } }
+      "then": { "properties": {
+        "outcome": { "const": "not_evaluated" },
+        "authority_promotions": { "properties": { "status": { "const": "unavailable" } } }
+      } }
     },
     {
       "if": { "properties": { "completeness": { "const": "error" } }, "required": ["completeness"] },
-      "then": { "properties": { "outcome": { "enum": ["invalid", "not_evaluated"] } } }
+      "then": { "properties": {
+        "outcome": { "enum": ["invalid", "not_evaluated"] },
+        "authority_promotions": { "properties": { "status": { "const": "unavailable" } } }
+      } }
     }
   ],
   "$defs": {
     "sha256": { "type": "string", "pattern": "^sha256:[0-9a-f]{64}$" },
+    "objectId": { "type": "string", "pattern": "^[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?(?:\\.[a-z0-9]+(?:[a-z0-9-]*[a-z0-9])?)+$" },
     "commit": { "type": "string", "pattern": "^[0-9a-f]{40}$" },
     "availability": { "type": "string", "enum": ["available", "unavailable"] },
     "snapshot": {
@@ -255,6 +266,54 @@
         "status": { "$ref": "#/$defs/availability" },
         "value": { "$ref": "#/$defs/knowledgeChanges" }
       }
+    },
+    "authorityPromotion": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["id", "content_hash", "kind", "before_kind", "before_status", "after_status"],
+      "properties": {
+        "id": { "$ref": "#/$defs/objectId" },
+        "content_hash": { "$ref": "#/$defs/sha256" },
+        "kind": { "enum": ["claim", "decision", "api", "policy", "procedure"] },
+        "before_kind": { "oneOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }] },
+        "before_status": { "oneOf": [{ "type": "string", "minLength": 1 }, { "type": "null" }] },
+        "after_status": { "enum": ["verified", "accepted", "active"] }
+      },
+      "oneOf": [
+        { "properties": { "kind": { "const": "claim" }, "after_status": { "const": "verified" } } },
+        { "properties": { "kind": { "const": "decision" }, "after_status": { "const": "accepted" } } },
+        { "properties": { "kind": { "const": "api" }, "after_status": { "const": "verified" } } },
+        { "properties": { "kind": { "const": "policy" }, "after_status": { "const": "active" } } },
+        { "properties": { "kind": { "const": "procedure" }, "after_status": { "const": "verified" } } }
+      ],
+      "allOf": [
+        {
+          "if": { "properties": { "before_kind": { "type": "null" } } },
+          "then": { "properties": { "before_status": { "type": "null" } } }
+        },
+        {
+          "not": { "anyOf": [
+            { "properties": { "before_kind": { "const": "claim" }, "before_status": { "const": "verified" } } },
+            { "properties": { "before_kind": { "const": "decision" }, "before_status": { "const": "accepted" } } },
+            { "properties": { "before_kind": { "const": "api" }, "before_status": { "const": "verified" } } },
+            { "properties": { "before_kind": { "const": "policy" }, "before_status": { "const": "active" } } },
+            { "properties": { "before_kind": { "const": "procedure" }, "before_status": { "const": "verified" } } }
+          ] }
+        }
+      ]
+    },
+    "authorityPromotionsAvailability": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["status"],
+      "properties": {
+        "status": { "$ref": "#/$defs/availability" },
+        "value": { "type": "array", "items": { "$ref": "#/$defs/authorityPromotion" }, "uniqueItems": true }
+      },
+      "oneOf": [
+        { "properties": { "status": { "const": "available" } }, "required": ["value"] },
+        { "properties": { "status": { "const": "unavailable" } }, "not": { "required": ["value"] } }
+      ]
     },
     "policyChanges": {
       "type": "object",

--- a/docs/agent/v0/schema/change-assessment.md
+++ b/docs/agent/v0/schema/change-assessment.md
@@ -12,13 +12,15 @@ Complete outcomes are advisory data and the command exits 0. Partial and error e
 
 ## Availability
 
-Sections that could not be established carry `status: unavailable` and omit `value`. An unavailable collection is not equivalent to an available empty collection. In particular, a partial assessment retains the trustworthy head graph and head objects, marks their `changed_in_pr` value `unknown`, and leaves `knowledge_changes` unavailable.
+Sections that could not be established carry `status: unavailable` and omit `value`. An unavailable collection is not equivalent to an available empty collection. In particular, a partial assessment retains the trustworthy head graph and head objects, marks their `changed_in_pr` value `unknown`, and leaves `knowledge_changes` and `authority_promotions` unavailable.
 
 ## Paths and authority
 
 Every changed path occurs once in a complete envelope. Classification is `excluded`, `covered`, `provisional`, or `uncovered`. An `impacts:` entry matches an exact file or, when it ends in `/`, a component-aware directory prefix. Source-code/test evidence paths remain exact. There are no globs.
 
 Authoritative kind/status pairs are closed: verified claim, accepted decision, verified API, active policy, and verified procedure. Every other match is provisional. `agent_instruction` never grants runtime authority.
+
+`authority_promotions` records kind and/or status changes entering one of those five pairs from a non-authoritative base, plus objects created directly at one. Transitions between two authoritative pairs remain authoritative and are not promotions. Created records carry `before_kind: null` and `before_status: null`; changed records carry the base kind and status. Records use the head `content_hash`, are ordered by object ID, and contain no authorship data. The section remains optional for additive v0 wire compatibility; absence means the producer did not establish promotion facts and must never be read as an available empty set.
 
 `required_reviewers` contains only identities authored on Knowledge Objects. Policy changes emit a human-review proof obligation for `agentdoc.config.yaml`; repository CODEOWNERS supplies the reviewer identity.
 


### PR DESCRIPTION
## Summary
- emit deterministic authority-promotion facts for status edits and objects created at the five authoritative pairs
- keep incomplete assessments fail-closed while retaining prior-v0 schema compatibility
- publish strict promotion schema constraints and adversarial parity coverage

## Verification
- prek run
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo test --workspace --locked
- specialized scope, contract/security, and Ponytail reviews: clear
- local Codex review finding addressed and re-reviewed
- local Claude Opus review was bounded to 60 seconds and produced no verdict

## Stack
Base: feat/e5.3-gate-result-contract (PR #196)