### PR TITLE
test(tracer): keep workspace Clippy green

### DIFF
--- a/crates/adoc-core/tests/internal_tracer_producer_contracts.rs
+++ b/crates/adoc-core/tests/internal_tracer_producer_contracts.rs
@@ -149,6 +149,7 @@ fn revision(value: &str) -> ExactRevision {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
 fn context_input(
     assessment_digest: &str,
     graph_digest: &str,


### PR DESCRIPTION
## Summary
- narrowly permit the eight independent bindings required by the internal tracer fixture constructor
- keep workspace-wide all-target Clippy strict everywhere else

## Verification
- cargo test -p adoc-core --test internal_tracer_producer_contracts --locked
- cargo clippy --workspace --all-targets --locked -- -D warnings
- cargo fmt --all -- --check
- git diff --check
- local Claude Opus 5 review: PASS
- local Codex review: PASS
- specialist review: PASS