### PR TITLE
feat(core): enforce retrieval policy before indexing (E6.1.T1)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -368,10 +368,10 @@ _Avoid_: infinite path enumeration, graph mutation, graph visualization as the c
 
 **Retrieval Record**:
 The stable JSON shape returned by `adoc why --format json` and `adoc search --format json`. Contained inside an `adoc.retrieval.v0` envelope. A projection of a graph Knowledge Object node, including its `content_hash`, plus a small `match` block carrying `mode`, ranks, and (when relevant) `cosine_score`.
-_Avoid_: vectors in the retrieval envelope, per-record permissions in V1
+_Avoid_: vectors in the retrieval envelope, adapter-local permission filters
 
 **Retrieval Session**:
-The immutable value the V1 application layer assembles from a loaded graph artifact, an optional loaded search artifact, and built indexes. CLI commands construct one session per invocation; there is no global retrieval state.
+The immutable value the application layer assembles from a loaded graph artifact, explicit retrieval policy, an optional loaded search artifact, and built indexes. Permission filtering precedes index construction (ADR-0065). CLI commands construct one session per invocation; there is no global retrieval state.
 _Avoid_: long-lived retrieval daemon in V1, mutable shared session
 
 **Graph Index**:

--- a/crates/adoc-cli/tests/explicit_artifact_config_cli.rs
+++ b/crates/adoc-cli/tests/explicit_artifact_config_cli.rs
@@ -1,0 +1,167 @@
+mod support;
+
+use std::fs;
+
+use serde_json::{Value, json};
+use support::{TestWorkspace, adoc_command, fixture_path, stderr};
+
+#[test]
+fn explicit_artifacts_ignore_broken_config_only_for_non_policy_drivers() {
+    let workspace = TestWorkspace::new("explicit-artifact-config");
+    let graph_text = fs::read_to_string(fixture_path("v1_1_why/valid_artifact.graph.json"))
+        .expect("graph fixture readable");
+    workspace.write("dist/docs.graph.json", &graph_text);
+    let graph: Value = serde_json::from_str(&graph_text).expect("graph JSON");
+    let target = "billing.refunds.issue-credit";
+    let object = graph["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["id"] == target)
+        .unwrap();
+    workspace.write(
+        "patch.json",
+        &json!({
+            "schema_version": "adoc.patch.v0",
+            "op": "replace_body",
+            "target": target,
+            "base_hash": object["content_hash"],
+            "changes": {"body": "Refunds issue a credit after review."},
+            "reason": "Clarify refund behavior."
+        })
+        .to_string(),
+    );
+
+    for (args, needs_policy) in [
+        (vec!["graph", target], false),
+        (vec!["stale"], false),
+        (vec!["contradictions"], false),
+        (vec!["impacted-by", "src/billing.rs"], false),
+        (vec!["patch", "--check", "patch.json"], false),
+        (vec!["why", target], true),
+        (vec!["search", target, "--lexical"], true),
+    ] {
+        let run = |explicit_artifact| {
+            let mut command = adoc_command();
+            command.current_dir(&workspace.root).args(&args);
+            if explicit_artifact {
+                command.args(["--artifact", "dist/docs.graph.json"]);
+            }
+            command
+                .args(["--format", "json"])
+                .output()
+                .expect("CLI runs")
+        };
+        let baseline = run(true);
+        assert!(baseline.status.success(), "{args:?}: {}", stderr(&baseline));
+        workspace.write("agentdoc.config.yaml", "version: [\n");
+        let explicit = run(true);
+        if needs_policy {
+            assert!(!explicit.status.success(), "{args:?} must discover policy");
+            assert!(stderr(&explicit).contains("config.parse"));
+        } else {
+            assert!(explicit.status.success(), "{args:?}: {}", stderr(&explicit));
+            assert_eq!(
+                serde_json::from_slice::<Value>(&explicit.stdout).unwrap(),
+                serde_json::from_slice::<Value>(&baseline.stdout).unwrap(),
+                "{args:?} must preserve the explicit-artifact result",
+            );
+        }
+        let implicit = run(false);
+        assert!(
+            !implicit.status.success(),
+            "{args:?} must resolve config defaults"
+        );
+        assert!(stderr(&implicit).contains("config.parse"));
+        fs::remove_file(workspace.root.join("agentdoc.config.yaml")).unwrap();
+    }
+}
+
+#[test]
+fn explicit_search_paths_preserve_provider_defaults_while_loading_policy() {
+    let pilot = support::v1_4::build_v1_4_pilot();
+    let workspace = &pilot._workspace;
+    for (name, path) in [
+        ("docs.graph.json", &pilot.artifact_path),
+        ("docs.search.json", &pilot.search_path),
+    ] {
+        workspace.write(
+            &format!("configured/{name}"),
+            &fs::read_to_string(path).unwrap(),
+        );
+    }
+    fs::rename(workspace.root.join("dist"), workspace.root.join("explicit")).unwrap();
+    let config = concat!(
+        "version: 1\nmode: strict\ndocs_path: .\n",
+        "outputs:\n  graph: configured/docs.graph.json\n  search: configured/docs.search.json\n",
+        "embeddings:\n  provider: deterministic\n",
+        "retrieval_policy:\n  audience: public\n  allowed_visibilities: [public]\n",
+        "  excluded_object_ids: [billing.credits.ledger-source]\n",
+    );
+
+    for semantic in [false, true] {
+        let run = |graph_explicit, search_explicit, test_provider: bool| {
+            let mut command = adoc_command();
+            command
+                .current_dir(&workspace.root)
+                .args(["search", "billing", "--format", "json"]);
+            if !test_provider {
+                // Local resolves only its fastembed header: it mismatches the
+                // deterministic artifact before any model can be loaded.
+                command.env_remove("ADOC_TEST_EMBEDDING_PROVIDER");
+            }
+            if semantic {
+                command.arg("--semantic");
+            }
+            if graph_explicit {
+                command.args(["--artifact", "explicit/docs.graph.json"]);
+            }
+            if search_explicit {
+                command.args(["--search-artifact", "explicit/docs.search.json"]);
+            }
+            command.output().expect("CLI runs")
+        };
+        let baseline = run(true, true, false);
+        assert_eq!(baseline.status.code(), Some(2));
+        let baseline: Value = serde_json::from_slice(&baseline.stdout).unwrap();
+        assert_eq!(baseline["diagnostics"][0]["code"], "search.model_mismatch");
+        workspace.write("agentdoc.config.yaml", config);
+        let explicit = run(true, true, false);
+        assert_eq!(
+            explicit.status.code(),
+            Some(2),
+            "semantic={semantic}: {explicit:?}"
+        );
+        assert_eq!(
+            serde_json::from_slice::<Value>(&explicit.stdout).unwrap(),
+            baseline
+        );
+
+        // A missing path still enables configured paths and provider. With
+        // both paths explicit, the existing test provider lets us also prove
+        // that policy was loaded despite skipping non-policy config defaults.
+        for (graph_explicit, search_explicit) in
+            [(false, false), (true, false), (false, true), (true, true)]
+        {
+            let output = run(
+                graph_explicit,
+                search_explicit,
+                graph_explicit && search_explicit,
+            );
+            assert!(output.status.success(), "{output:?}");
+            let envelope: Value = serde_json::from_slice(&output.stdout).unwrap();
+            let records = envelope["records"].as_array().unwrap();
+            assert!(!records.is_empty());
+            assert!(
+                records
+                    .iter()
+                    .all(|record| record["id"] != "billing.credits.ledger-source")
+            );
+            assert!(
+                records.iter().all(|record| record["match"]["mode"]
+                    == if semantic { "semantic" } else { "hybrid" })
+            );
+        }
+        fs::remove_file(workspace.root.join("agentdoc.config.yaml")).unwrap();
+    }
+}

--- a/crates/adoc-cli/tests/permission_retrieval_cli.rs
+++ b/crates/adoc-cli/tests/permission_retrieval_cli.rs
@@ -1,0 +1,208 @@
+mod support;
+
+use std::fs;
+use std::process::Command;
+
+use support::{TestWorkspace, fixture_path};
+
+#[test]
+fn carried_source_errors_refuse_search_and_why_without_raw_diagnostics() {
+    use serde_json::{Value, json};
+
+    let workspace = TestWorkspace::new("permission-carried-errors");
+    let object = |id, visibility| {
+        json!({
+            "type": "knowledge_object", "id": id, "kind": "claim", "status": "draft",
+            "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+            "body": "Shared credits.", "page_id": "billing",
+            "source_span": {"path": "docs/billing.adoc", "line": 1, "column": 1},
+            "visibility": visibility, "fields": {},
+            "relations": {"depends_on": [], "supersedes": [], "related_to": []}
+        })
+    };
+    workspace.write("dist/docs.graph.json", &json!({
+        "schema_version": "adoc.graph.v6", "repository_identity": null,
+        "nodes": [object("billing.public", "public"), object("billing.internal", "internal")],
+        "edges": [], "diagnostics": [
+            {"code": "schema.unknown_field", "severity": "error", "object_id": "billing.public",
+             "message": "private-schema-sentinel billing.internal", "help": "private-schema-sentinel"},
+            {"code": "schema.unknown_field", "severity": "error", "object_id": "billing.internal",
+             "message": "private-schema-sentinel"}
+        ]
+    }).to_string());
+
+    let run = |command, format| {
+        let mut process = Command::new(env!("CARGO_BIN_EXE_adoc"));
+        process.current_dir(&workspace.root).args([
+            command,
+            "billing.public",
+            "--artifact",
+            "dist/docs.graph.json",
+            "--format",
+            format,
+        ]);
+        if command == "search" {
+            process.arg("--lexical");
+        }
+        process.output().expect("CLI runs")
+    };
+    for command in ["search", "why"] {
+        let output = run(command, "json");
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        let envelope: Value = serde_json::from_slice(&output.stdout).expect("retrieval JSON");
+        let records = envelope["records"].as_array().expect("records");
+        assert!(records.is_empty(), "{command} returned records: {envelope}");
+        let diagnostics = envelope["diagnostics"].as_array().expect("diagnostics");
+        assert_eq!(diagnostics.len(), 1, "{envelope}");
+        assert_eq!(diagnostics[0]["code"], "retrieval.visibility_unavailable");
+        assert_eq!(diagnostics[0]["severity"], "error");
+        let help = diagnostics[0]["help"].as_str().expect("safe help");
+        assert!(
+            help.contains("adoc check") && help.contains("adoc build"),
+            "{help}"
+        );
+        for text in [&output.stdout, &output.stderr] {
+            let text = String::from_utf8_lossy(text);
+            assert!(!text.contains("private-schema-sentinel"), "{text}");
+            assert!(!text.contains("billing.internal"), "{text}");
+        }
+        let plain = run(command, "plain");
+        assert_eq!(plain.status.code(), Some(2));
+        let stdout = String::from_utf8_lossy(&plain.stdout);
+        let stderr = String::from_utf8_lossy(&plain.stderr);
+        assert!(
+            stdout.is_empty(),
+            "{command} returned plain records: {plain:?}"
+        );
+        assert_eq!(
+            stderr
+                .matches("error[retrieval.visibility_unavailable]")
+                .count(),
+            1
+        );
+        assert!(stderr.contains("adoc check") && stderr.contains("adoc build"));
+        for text in [&stdout, &stderr] {
+            assert!(
+                !text.contains("billing.internal") && !text.contains("private-schema-sentinel")
+            );
+        }
+    }
+
+    // The same carried errors refuse an all-public corpus without policy too.
+    let path = workspace.root.join("dist/docs.graph.json");
+    let mut graph: Value = serde_json::from_str(&fs::read_to_string(&path).unwrap()).unwrap();
+    graph["nodes"][1]["visibility"] = json!("public");
+    fs::write(path, graph.to_string()).unwrap();
+    for command in ["search", "why"] {
+        let output = run(command, "json");
+        assert_eq!(output.status.code(), Some(2), "{output:?}");
+        let envelope: Value = serde_json::from_slice(&output.stdout).expect("retrieval JSON");
+        assert!(
+            envelope["records"].as_array().unwrap().is_empty(),
+            "{envelope}"
+        );
+        let diagnostics = envelope["diagnostics"].as_array().unwrap();
+        assert_eq!(diagnostics.len(), 2, "{envelope}");
+        assert!(
+            diagnostics.iter().all(|diagnostic| {
+                diagnostic["code"] == "schema.unknown_field" && diagnostic["severity"] == "error"
+            }),
+            "{envelope}"
+        );
+        let plain = run(command, "plain");
+        assert_eq!(plain.status.code(), Some(2));
+        assert!(plain.stdout.is_empty(), "{plain:?}");
+    }
+}
+
+#[test]
+fn project_policy_excludes_search_and_why_even_with_explicit_artifact() {
+    let workspace = TestWorkspace::new("permission-retrieval");
+    workspace.write(
+        "dist/docs.graph.json",
+        &fs::read_to_string(fixture_path("v1_1_why/valid_artifact.graph.json"))
+            .expect("fixture readable"),
+    );
+    let config = "version: 1\nmode: strict\ndocs_path: .\nretrieval_policy:\n  audience: public\n  allowed_visibilities: [public]\n  excluded_object_ids: [billing.refunds.issue-credit]\n";
+    workspace.write("agentdoc.config.yaml", config);
+
+    // Transitional T1 behavior: graph still reads the unfiltered artifact.
+    // Replace this control with policy exclusion when E6.1.T3 closes graph reads.
+    let graph = Command::new(env!("CARGO_BIN_EXE_adoc"))
+        .current_dir(&workspace.root)
+        .args([
+            "graph",
+            "billing.refunds.issue-credit",
+            "--artifact",
+            "dist/docs.graph.json",
+            "--format",
+            "json",
+        ])
+        .output()
+        .expect("graph CLI runs");
+    assert!(graph.status.success(), "{graph:?}");
+    let graph: serde_json::Value = serde_json::from_slice(&graph.stdout).expect("graph JSON");
+    assert_eq!(graph["root"], "billing.refunds.issue-credit");
+    assert!(
+        graph["nodes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|node| node["id"] == "billing.refunds.issue-credit"),
+        "{graph}"
+    );
+
+    for command in ["search", "why"] {
+        let run = |object_id| {
+            let mut process = Command::new(env!("CARGO_BIN_EXE_adoc"));
+            process.current_dir(&workspace.root).args([
+                command,
+                object_id,
+                "--artifact",
+                "dist/docs.graph.json",
+                "--format",
+                "json",
+            ]);
+            if command == "search" {
+                process.arg("--lexical");
+            }
+            process.output().expect("CLI runs")
+        };
+        let denied = run("billing.refunds.issue-credit");
+        assert_eq!(
+            denied.status.code(),
+            Some(if command == "why" { 3 } else { 0 })
+        );
+        let denied: serde_json::Value = serde_json::from_slice(&denied.stdout)
+            .expect("policy refusal remains a structured retrieval response");
+        assert!(
+            denied["records"]
+                .as_array()
+                .expect("records")
+                .iter()
+                .all(|record| record["id"] != "billing.refunds.issue-credit")
+        );
+        let sibling = run("billing.refunds.fraud-window");
+        assert!(sibling.status.success(), "{sibling:?}");
+        let sibling: serde_json::Value = serde_json::from_slice(&sibling.stdout).expect("JSON");
+        assert!(
+            sibling["records"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .any(|record| record["id"] == "billing.refunds.fraud-window")
+        );
+        fs::remove_file(workspace.root.join("agentdoc.config.yaml")).expect("remove policy");
+        let allowed = run("billing.refunds.issue-credit");
+        assert!(allowed.status.success(), "{:?}", allowed);
+        let allowed: serde_json::Value = serde_json::from_slice(&allowed.stdout).expect("JSON");
+        assert!(
+            allowed["records"]
+                .as_array()
+                .expect("records")
+                .iter()
+                .any(|record| record["id"] == "billing.refunds.issue-credit")
+        );
+        workspace.write("agentdoc.config.yaml", config);
+    }
+}

--- a/crates/adoc-cli/tests/semantic_stale_vectors_cli.rs
+++ b/crates/adoc-cli/tests/semantic_stale_vectors_cli.rs
@@ -1,0 +1,132 @@
+mod support;
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use serde_json::Value;
+use support::v1_4::build_v1_4_pilot;
+
+#[test]
+fn semantic_search_warns_on_partial_staleness_and_refuses_fully_stale_vectors() {
+    let pilot = build_v1_4_pilot();
+    let run = |artifact: &Path, semantic| {
+        let mut command = Command::new(env!("CARGO_BIN_EXE_adoc"));
+        command
+            .current_dir(&pilot._workspace.root)
+            .args(["search", "credits", "--format", "json", "--artifact"])
+            .arg(artifact)
+            .arg("--search-artifact")
+            .arg(&pilot.search_path)
+            .env("ADOC_TEST_EMBEDDING_PROVIDER", "deterministic");
+        if semantic {
+            command.arg("--semantic");
+        }
+        command.output().expect("semantic search runs")
+    };
+    let fresh = run(&pilot.artifact_path, true);
+    assert!(fresh.status.success(), "{fresh:?}");
+    let fresh: Value = serde_json::from_slice(&fresh.stdout).expect("retrieval JSON");
+    assert!(!fresh["records"].as_array().unwrap().is_empty());
+
+    // Rebuild graphs from changed source while retaining the real old search
+    // artifact. All three objects remain public throughout.
+    let source_path = pilot._workspace.root.join("billing.adoc");
+    let source = fs::read_to_string(&source_path).expect("source readable");
+    assert_eq!(source.matches("--\n").count(), 3);
+    let rebuild = |contents: &str, directory: &str| {
+        fs::write(&source_path, contents).expect("update object bodies");
+        let changed_dir = pilot._workspace.root.join(directory);
+        let build = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .current_dir(&pilot._workspace.root)
+            .arg("build")
+            .arg(&source_path)
+            .arg("--out")
+            .arg(&changed_dir)
+            .arg("--no-embeddings")
+            .output()
+            .expect("graph rebuild runs");
+        assert!(build.status.success(), "{build:?}");
+        changed_dir.join("docs.graph.json")
+    };
+
+    let partial_graph = rebuild(
+        &source.replacen("--\n", "--\nUpdated policy. ", 1),
+        "partial-dist",
+    );
+    let partial = run(&partial_graph, true);
+    assert!(partial.status.success(), "{partial:?}");
+    let partial: Value = serde_json::from_slice(&partial.stdout).expect("retrieval JSON");
+    let records = partial["records"].as_array().unwrap();
+    assert!(!records.is_empty(), "{partial}");
+    let changed_id = "billing.credits.ledger-source";
+    assert!(
+        records.iter().all(|record| record["id"] != changed_id),
+        "{partial}"
+    );
+    let hybrid = run(&partial_graph, false);
+    assert!(hybrid.status.success(), "{hybrid:?}");
+    let hybrid: Value = serde_json::from_slice(&hybrid.stdout).expect("retrieval JSON");
+    assert!(
+        hybrid["records"].as_array().unwrap().iter().any(|record| {
+            record["id"] == changed_id
+                && record["match"]["lexical_rank"].is_number()
+                && record["match"]["vector_rank"].is_null()
+        }),
+        "{hybrid}"
+    );
+    let warning = partial["diagnostics"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|diagnostic| diagnostic["code"] == "search.hash_drift")
+        .expect("stale vectors produce a drift warning");
+    assert_eq!(warning["severity"], "warning");
+    assert!(
+        warning["message"]
+            .as_str()
+            .unwrap()
+            .to_lowercase()
+            .contains("semantic results may be incomplete"),
+        "{warning}"
+    );
+
+    let changed_graph = rebuild(
+        &source.replace("--\n", "--\nUpdated policy. "),
+        "changed-dist",
+    );
+    let hybrid = run(&changed_graph, false);
+    assert!(hybrid.status.success(), "{hybrid:?}");
+    let hybrid: Value = serde_json::from_slice(&hybrid.stdout).expect("retrieval JSON");
+    let records = hybrid["records"].as_array().unwrap();
+    assert!(!records.is_empty(), "{hybrid}");
+    assert!(
+        records
+            .iter()
+            .all(|record| record["match"]["mode"] == "lexical"),
+        "{hybrid}"
+    );
+    assert!(
+        hybrid["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .all(|diagnostic| diagnostic["severity"] != "error"),
+        "{hybrid}"
+    );
+
+    let stale = run(&changed_graph, true);
+    assert_eq!(stale.status.code(), Some(2), "{stale:?}");
+    let stale: Value = serde_json::from_slice(&stale.stdout).expect("retrieval JSON");
+    assert!(stale["records"].as_array().unwrap().is_empty(), "{stale}");
+    assert!(
+        stale["diagnostics"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|diagnostic| {
+                diagnostic["code"] == "search.artifact_missing" && diagnostic["severity"] == "error"
+            }),
+        "{stale}"
+    );
+}

--- a/crates/adoc-cli/tests/why_cli.rs
+++ b/crates/adoc-cli/tests/why_cli.rs
@@ -378,8 +378,8 @@ fn why_rejects_v5_artifact_exact_match_with_rebuild_guidance() {
         .as_str()
         .expect("diagnostic message is a string");
     assert!(
-        message.contains("adoc.graph.v5"),
-        "rejection must name the unsupported version exactly; got: {message}"
+        !message.contains("adoc.graph.v5"),
+        "retrieval must not echo artifact-controlled version text; got: {message}"
     );
     let help = value["diagnostics"][0]["help"]
         .as_str()

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -1,20 +1,21 @@
 use std::collections::{BTreeMap, BTreeSet};
 use std::num::NonZeroUsize;
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 use crate::application::graph::GraphSession;
-use crate::domain::artifact::{SearchArtifactDocument, SearchModelHeader};
+use crate::domain::artifact::{SearchArtifactDocument, SearchEntryKind, SearchModelHeader};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
-use crate::domain::graph::{GraphArtifactDocument, GraphIndex, GraphTraversalQuery};
+use crate::domain::graph::{GraphArtifactDocument, GraphIndex, GraphNode, GraphTraversalQuery};
 use crate::domain::identity::{OBJECT_ID_GRAMMAR_HELP, ObjectId};
 use crate::domain::knowledge_object::question::{ANSWERED_STATUS, RESOLVED_BY_FIELD};
 use crate::domain::ports::artifact_reader::ArtifactReader;
 pub use crate::domain::retrieval::SearchFilters;
 use crate::domain::retrieval::hybrid_ranker::{HybridRanker, merge_pinned_then_scored};
 use crate::domain::retrieval::lexical_index::LexicalIndex;
+use crate::domain::retrieval::metadata;
 use crate::domain::retrieval::vector_index::VectorIndex;
 use crate::domain::retrieval::{
-    ProseRecord, RetrievalEntry, RetrievalMatch, RetrievalRecord, SearchMode,
+    ProseRecord, RetrievalEntry, RetrievalMatch, RetrievalPolicy, RetrievalRecord, SearchMode,
 };
 
 pub const RETRIEVAL_SCHEMA_VERSION: &str = "adoc.retrieval.v1";
@@ -33,6 +34,8 @@ pub enum SearchRecordScope {
 pub struct RetrievalInput {
     pub artifact_path: PathBuf,
     pub search_artifact_path: Option<PathBuf>,
+    /// Absent policy permits public (including unclassified) objects only.
+    pub policy: Option<RetrievalPolicy>,
 }
 
 #[derive(Debug, Clone)]
@@ -175,12 +178,20 @@ where
     S: ArtifactReader<Output = SearchArtifactDocument>,
     G: ArtifactReader<Output = GraphArtifactDocument>,
 {
-    let document = match graph_reader.read(&input.artifact_path) {
+    if let Some(policy) = &input.policy
+        && let Err(diagnostic) = policy.validate()
+    {
+        return RetrievalLoadResult {
+            session: None,
+            diagnostics: vec![*diagnostic],
+        };
+    }
+    let mut document = match graph_reader.read(&input.artifact_path) {
         Ok(document) => document,
         Err(diagnostics) => {
             return RetrievalLoadResult {
                 session: None,
-                diagnostics,
+                diagnostics: safe_artifact_diagnostics(&input.artifact_path, diagnostics),
             };
         }
     };
@@ -190,6 +201,13 @@ where
         .to_pretty_json()
         .expect("graph artifact serialization should not fail")
         .into_bytes();
+
+    if let Err(diagnostic) = filter_retrieval_document(&mut document, input.policy.as_ref()) {
+        return RetrievalLoadResult {
+            session: None,
+            diagnostics: vec![*diagnostic],
+        };
+    }
 
     let document_diagnostics = document.diagnostics.clone();
     let graph_session = match GraphIndex::from_document(document) {
@@ -224,7 +242,7 @@ where
                         ),
                     ));
                 } else {
-                    diagnostics.extend(diags);
+                    diagnostics.extend(safe_artifact_diagnostics(search_path, diags));
                 }
             }
             Ok(doc) => {
@@ -235,14 +253,8 @@ where
                     diagnostics.push(Diagnostic::error(
                         DiagnosticCode::SearchModelMismatch,
                         format!(
-                            "Search artifact `{}` was built with model `{}/{}` (dim {}); active provider is `{}/{}` (dim {}).",
-                            search_path.display(),
-                            doc.model.provider,
-                            doc.model.id,
-                            doc.model.dim,
-                            active.provider,
-                            active.id,
-                            active.dim,
+                            "Search artifact `{}` was built with a different embedding model; the active provider is `{}/{}` (dim {}). Rebuild it.",
+                            search_path.display(), active.provider, active.id, active.dim,
                         ),
                     ));
                     artifact_unloadable = true;
@@ -250,24 +262,59 @@ where
 
                 if !artifact_unloadable {
                     let actual_hash = crate::domain::hashing::sha256_prefixed(&canonical_bytes);
-                    if actual_hash != doc.graph_artifact_hash {
+
+                    let mut has_stale_vectors = false;
+                    let vectors: Vec<_> = doc
+                        .embeddings
+                        .into_iter()
+                        .filter(|entry| {
+                            let composition = match entry.entry_kind {
+                                SearchEntryKind::KnowledgeObject => {
+                                    ObjectId::new(entry.id.as_str())
+                                        .ok()
+                                        .and_then(|id| graph_session.object(&id))
+                                        .map(metadata::embedding_input)
+                                }
+                                SearchEntryKind::Prose => {
+                                    graph_session.prose_block(&entry.id).map(|block| {
+                                        metadata::prose_embedding_input(
+                                            &block.content_text(),
+                                            &block.page_id,
+                                        )
+                                    })
+                                }
+                            };
+                            let Some(input) = composition else {
+                                // A wrong-kind entry for a permitted ID is stale;
+                                // a hidden or absent ID cannot change availability.
+                                has_stale_vectors |= graph_session.prose_block(&entry.id).is_some()
+                                    || ObjectId::new(entry.id.as_str())
+                                        .ok()
+                                        .and_then(|id| graph_session.object(&id))
+                                        .is_some();
+                                return false;
+                            };
+                            let current = crate::domain::hashing::sha256_prefixed(input.as_bytes())
+                                == entry.content_hash;
+                            has_stale_vectors |= !current;
+                            current
+                        })
+                        .map(|e| (e.id, e.vector))
+                        .collect();
+                    if actual_hash != doc.graph_artifact_hash || has_stale_vectors {
                         diagnostics.push(Diagnostic::warning(
                             DiagnosticCode::SearchHashDrift,
                             format!(
-                                "Search artifact `{}` references graph_artifact_hash `{}` but the loaded graph artifact hashes to `{}`.",
-                                search_path.display(),
-                                doc.graph_artifact_hash,
-                                actual_hash,
+                                "Search artifact `{}` does not match the loaded graph; semantic results may be incomplete; rebuild it.",
+                                search_path.display()
                             ),
                         ));
                     }
 
-                    vector_index = Some(VectorIndex::new(
-                        doc.embeddings
-                            .into_iter()
-                            .map(|e| (e.id, e.vector))
-                            .collect(),
-                    ));
+                    // Only stale permitted carriers disable semantic retrieval.
+                    // Permission-filtered emptiness must still behave like absence.
+                    vector_index = (!vectors.is_empty() || !has_stale_vectors)
+                        .then(|| VectorIndex::new(vectors));
                 }
             }
         }
@@ -281,6 +328,146 @@ where
         }),
         diagnostics,
     }
+}
+
+// Decoding can fail before visibility is known. Never echo payload values
+// from a deserializer; retain the stable error code and safe remediation.
+fn safe_artifact_diagnostics(path: &Path, diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+    diagnostics
+        .into_iter()
+        .map(|diagnostic| match diagnostic.code {
+            DiagnosticCode::IoArtifactMalformed | DiagnosticCode::SchemaUnsupportedVersion => {
+                let safe = Diagnostic::error(
+                    diagnostic.code,
+                    format!("Artifact `{}` could not be loaded.", path.display()),
+                );
+                if let Some(help) = diagnostic.help {
+                    safe.with_help(help)
+                } else {
+                    safe
+                }
+            }
+            _ => diagnostic,
+        })
+        .collect()
+}
+
+fn filter_retrieval_document(
+    document: &mut GraphArtifactDocument,
+    policy: Option<&RetrievalPolicy>,
+) -> Result<(), Box<Diagnostic>> {
+    // A producer may have dropped invalid classification metadata. Do not
+    // interpret that absence as public, even when no other nodes are excluded.
+    if document
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.code == DiagnosticCode::SchemaVisibilityInvalid)
+    {
+        return Err(Box::new(
+            Diagnostic::error(
+                DiagnosticCode::RetrievalVisibilityUnavailable,
+                "The artifact reports invalid visibility; retrieval classification is unavailable.",
+            )
+            .with_help(
+                "Run `adoc check` to repair visibility and `adoc build` to rebuild the artifact.",
+            ),
+        ));
+    }
+    let mut excluded = policy
+        .map(|p| p.excluded_object_ids.clone())
+        .unwrap_or_default();
+    for object in document
+        .nodes
+        .iter()
+        .filter_map(GraphNode::as_knowledge_object)
+    {
+        if !RetrievalPolicy::permits(policy, object)? {
+            excluded.insert(object.id.clone());
+        }
+    }
+    if excluded.is_empty() {
+        return Ok(());
+    }
+    // ponytail: one extra clone/index preserves validation before redaction;
+    // extract borrowed validation if the E6.1.T3 corpus benchmark requires it.
+    if document
+        .diagnostics
+        .iter()
+        .any(|diagnostic| diagnostic.severity == crate::domain::diagnostic::Severity::Error)
+        || GraphIndex::from_document(document.clone()).is_err()
+    {
+        return Err(Box::new(Diagnostic::error(
+            DiagnosticCode::RetrievalVisibilityUnavailable,
+            "The graph artifact contains errors; a trusted retrieval projection is unavailable.",
+        ).with_help("Run `adoc check` to inspect source errors and `adoc build` to rebuild the artifact.")));
+    }
+    // Artifact diagnostics describe the unfiltered corpus and can quote content
+    // without an Object ID. They cannot safely accompany this projection.
+    document.diagnostics.clear();
+    // ponytail: repeated projection scans cover citation chains; use a reverse
+    // reference index if the worst-case cubic cost fails the E6.1.T3 corpus guard.
+    loop {
+        // ponytail: conservative ID substring matching can withhold a larger text
+        // unit; provenance-aware field projection belongs to E6.2.
+        let mentions_excluded = |text: &str| excluded.iter().any(|id| text.contains(id));
+        document.nodes.retain(|node| {
+            if let Some(object) = node.as_knowledge_object() {
+                return !excluded.contains(&object.id);
+            }
+            if let Some((_, block)) = node.as_prose_block() {
+                return !excluded.contains(&block.id);
+            }
+            true
+        });
+        document
+            .edges
+            .retain(|edge| !excluded.contains(&edge.source) && !excluded.contains(&edge.target));
+        for object in document.nodes.iter_mut().filter_map(|node| {
+            if let GraphNode::KnowledgeObject(object) = node {
+                Some(object)
+            } else {
+                None
+            }
+        }) {
+            if object
+                .effective_reason
+                .as_deref()
+                .is_some_and(|reason| reason.starts_with("contradiction:"))
+            {
+                object.effective_status = None;
+                object.effective_reason = None;
+            }
+        }
+        crate::domain::graph::apply_contradiction_effective_status(&mut document.nodes);
+        // Hashes and embeddings commit source metadata even when a field is
+        // absent from RetrievalRecord. Withhold the whole source carrier rather
+        // than redact fields and expose their old hash/vector (field reads: E6.2).
+        // Derived contradiction status above is not hash- or embedding-covered.
+        let mut referenced = BTreeSet::new();
+        for node in &document.nodes {
+            let (id, encoded) = if let Some(object) = node.as_knowledge_object() {
+                (&object.id, serde_json::to_string(object))
+            } else if let Some((_, block)) = node.as_prose_block() {
+                (&block.id, serde_json::to_string(block))
+            } else {
+                continue;
+            };
+            let encoded = encoded.map_err(|_| {
+                Box::new(Diagnostic::error(
+                    DiagnosticCode::RetrievalVisibilityUnavailable,
+                    "The retrieval projection could not be classified safely.",
+                ))
+            })?;
+            if mentions_excluded(&encoded) {
+                referenced.insert(id.clone());
+            }
+        }
+        if referenced.is_empty() {
+            break;
+        }
+        excluded.extend(referenced);
+    }
+    Ok(())
 }
 
 pub fn why_object(session: &RetrievalSession, id: &str) -> WhyResult {
@@ -544,7 +731,7 @@ fn search_semantic_impl(session: &RetrievalSession, query: SearchQuery) -> Searc
             records: Vec::new(),
             diagnostics: vec![Diagnostic::error(
                 DiagnosticCode::SearchArtifactMissing,
-                "Semantic search requested but no search artifact is loaded.",
+                "Semantic search requested but no usable search index is loaded.",
             )],
         };
     };
@@ -908,6 +1095,7 @@ mod tests {
 
         let result = load_retrieval_session_with_readers(
             RetrievalInput {
+                policy: None,
                 artifact_path: PathBuf::from("ignored.graph.json"),
                 search_artifact_path: None,
             },
@@ -941,6 +1129,7 @@ mod tests {
 
         let result = load_retrieval_session_with_readers(
             RetrievalInput {
+                policy: None,
                 artifact_path: PathBuf::from("ignored.graph.json"),
                 search_artifact_path: None,
             },
@@ -980,6 +1169,7 @@ mod tests {
 
         let result = load_retrieval_session_with_readers(
             RetrievalInput {
+                policy: None,
                 artifact_path: PathBuf::from("ignored.graph.json"),
                 search_artifact_path: Some(PathBuf::from("ignored.search.json")),
             },
@@ -1024,6 +1214,395 @@ mod tests {
         );
     }
 
+    #[test]
+    fn search_diagnostics_never_echo_payloads_or_reveal_hidden_corpus() {
+        for mismatch in [false, true] {
+            let mut observed = Vec::new();
+            for hidden_present in [false, true] {
+                let mut hidden = object("billing.hidden", "Private credits.");
+                hidden.visibility = Some("restricted".to_string());
+                let mut search_artifact = search_document("sha256:billing.hidden");
+                if mismatch {
+                    search_artifact.model.provider = "billing.hidden".to_string();
+                    search_artifact.model.id = "private-provider-payload".to_string();
+                }
+                let loaded = load_retrieval_session_with_readers(
+                    RetrievalInput {
+                        artifact_path: "ignored.graph.json".into(),
+                        search_artifact_path: Some("ignored.search.json".into()),
+                        policy: None,
+                    },
+                    &StubSearchArtifactReader {
+                        document: search_artifact,
+                    },
+                    &StubGraphArtifactReader {
+                        document: graph_document(
+                            if hidden_present { vec![hidden] } else { vec![] },
+                            vec![],
+                        ),
+                    },
+                    Some(SearchModelHeader {
+                        id: "hash-v1".into(),
+                        provider: "deterministic".into(),
+                        dim: 2,
+                    }),
+                );
+                assert_eq!(
+                    loaded.diagnostics[0].code,
+                    if mismatch {
+                        DiagnosticCode::SearchModelMismatch
+                    } else {
+                        DiagnosticCode::SearchHashDrift
+                    }
+                );
+                let encoded = serde_json::to_string(&loaded.diagnostics).unwrap();
+                assert!(!encoded.contains("billing.hidden"), "{encoded}");
+                assert!(!encoded.contains("private-provider-payload"), "{encoded}");
+                if mismatch {
+                    assert!(encoded.contains("deterministic/hash-v1"), "{encoded}");
+                }
+                observed.push(encoded);
+            }
+            assert_eq!(observed[0], observed[1]);
+        }
+    }
+
+    #[test]
+    fn carried_visibility_errors_refuse_even_without_policy_or_classified_nodes() {
+        for explicit_policy in [false, true] {
+            let mut document =
+                graph_document(vec![object("billing.target", "Private credits.")], vec![]);
+            document.diagnostics.push(
+                Diagnostic::error(
+                    DiagnosticCode::SchemaVisibilityInvalid,
+                    "private-classification-payload",
+                )
+                .with_object_id("billing.target"),
+            );
+            let loaded = load_retrieval_session_with_readers(
+                RetrievalInput {
+                    artifact_path: "ignored.graph.json".into(),
+                    search_artifact_path: None,
+                    policy: explicit_policy.then(|| RetrievalPolicy {
+                        audience: "public".into(),
+                        allowed_visibilities: BTreeSet::from(["public".into()]),
+                        excluded_object_ids: BTreeSet::new(),
+                    }),
+                },
+                &StubSearchArtifactReader {
+                    document: search_document("sha256:unused"),
+                },
+                &StubGraphArtifactReader { document },
+                None,
+            );
+            assert!(
+                loaded.session.is_none(),
+                "untrusted classification must refuse: policy={explicit_policy}"
+            );
+            assert_eq!(loaded.diagnostics.len(), 1);
+            assert_eq!(
+                loaded.diagnostics[0].code,
+                DiagnosticCode::RetrievalVisibilityUnavailable
+            );
+            let encoded = serde_json::to_string(&loaded.diagnostics).unwrap();
+            assert!(!encoded.contains("private-classification-payload"));
+            assert!(!encoded.contains("billing.target"));
+        }
+    }
+
+    #[test]
+    fn denied_metadata_withholds_original_hash_and_embedding() {
+        let mut carrier = object("billing.target", "Shared credits.");
+        carrier
+            .fields
+            .insert("owner".to_string(), "billing.hidden".to_string());
+        carrier.content_hash =
+            crate::infrastructure::artifact::graph_json::graph_knowledge_object_content_hash(
+                &carrier,
+            );
+        let original_hash = carrier.content_hash.clone();
+        let document = graph_document(vec![carrier], Vec::new());
+        let graph_hash = sha256_prefixed(document.to_pretty_json().unwrap().as_bytes());
+        let mut search_artifact = search_document(&graph_hash);
+        search_artifact.embeddings[0].content_hash = sha256_prefixed(
+            metadata::embedding_input(document.nodes[0].as_knowledge_object().unwrap()).as_bytes(),
+        );
+        let loaded = load_retrieval_session_with_readers(
+            RetrievalInput {
+                artifact_path: "ignored.graph.json".into(),
+                search_artifact_path: Some("ignored.search.json".into()),
+                policy: Some(RetrievalPolicy {
+                    audience: "public".into(),
+                    allowed_visibilities: BTreeSet::from(["public".into()]),
+                    excluded_object_ids: BTreeSet::from(["billing.hidden".into()]),
+                }),
+            },
+            &StubSearchArtifactReader {
+                document: search_artifact,
+            },
+            &StubGraphArtifactReader { document },
+            None,
+        );
+        assert!(loaded.diagnostics.is_empty());
+        let session = loaded.session.unwrap();
+        let why = why_object(&session, "billing.target");
+        let hash_withheld = !serde_json::to_string(&RetrievalEnvelope::from(why))
+            .unwrap()
+            .contains(&original_hash);
+        let vector_withheld = session
+            .vector_index()
+            .unwrap()
+            .rank(&[1.0, 0.0], 10)
+            .is_empty();
+        assert!(
+            hash_withheld && vector_withheld,
+            "hash withheld: {hash_withheld}; vector withheld: {vector_withheld}"
+        );
+    }
+
+    #[test]
+    fn excluded_and_absent_corpora_keep_the_same_empty_semantic_index() {
+        let mut observed = Vec::new();
+        for hidden_present in [false, true] {
+            let mut hidden = object("billing.target", "Target body.");
+            hidden.visibility = Some("restricted".into());
+            let document =
+                graph_document(if hidden_present { vec![hidden] } else { vec![] }, vec![]);
+            let mut vectors = search_document(&sha256_prefixed(
+                document.to_pretty_json().unwrap().as_bytes(),
+            ));
+            if !hidden_present {
+                vectors.embeddings.clear();
+            }
+            let loaded = load_retrieval_session_with_readers(
+                RetrievalInput {
+                    artifact_path: "ignored.graph.json".into(),
+                    search_artifact_path: Some("ignored.search.json".into()),
+                    policy: None,
+                },
+                &StubSearchArtifactReader { document: vectors },
+                &StubGraphArtifactReader { document },
+                None,
+            );
+            assert!(loaded.diagnostics.is_empty());
+            let session = loaded.session.unwrap();
+            assert!(session.has_semantic_index());
+            let mut query = lexical_search_query("credits", SearchRecordScope::ObjectsOnly);
+            query.mode = SearchMode::Semantic;
+            query.query_vector = Some(vec![1.0, 0.0]);
+            let result = search(&session, query);
+            assert!(result.records.is_empty());
+            assert!(result.diagnostics.is_empty());
+            observed.push(serde_json::to_string(&RetrievalEnvelope::from(result)).unwrap());
+        }
+        assert_eq!(observed[0], observed[1]);
+    }
+
+    #[test]
+    fn a_matching_manifest_does_not_validate_individual_vector_bindings() {
+        for wrong_kind in [false, true] {
+            let current = object("billing.target", "Shared current credits.");
+            let document = graph_document(vec![current.clone()], vec![]);
+            let current_graph_hash = sha256_prefixed(document.to_pretty_json().unwrap().as_bytes());
+            // The manifest can name the current graph while an individual entry
+            // still carries old metadata. It is an assertion, not an attestation.
+            let mut vectors = search_document(&current_graph_hash);
+            assert_eq!(vectors.graph_artifact_hash, current_graph_hash);
+            let old = object("billing.target", "Private billing.hidden credits.");
+            vectors.embeddings[0].content_hash = sha256_prefixed(
+                metadata::embedding_input(if wrong_kind { &current } else { &old }).as_bytes(),
+            );
+            if wrong_kind {
+                vectors.embeddings[0].entry_kind = SearchEntryKind::Prose;
+            }
+            let loaded = load_retrieval_session_with_readers(
+                RetrievalInput {
+                    artifact_path: "ignored.graph.json".into(),
+                    search_artifact_path: Some("ignored.search.json".into()),
+                    policy: Some(RetrievalPolicy {
+                        audience: "public".into(),
+                        allowed_visibilities: BTreeSet::from(["public".into()]),
+                        excluded_object_ids: BTreeSet::from(["billing.hidden".into()]),
+                    }),
+                },
+                &StubSearchArtifactReader { document: vectors },
+                &StubGraphArtifactReader { document },
+                None,
+            );
+            let session = loaded.session.unwrap();
+            assert_eq!(why_object(&session, "billing.target").records.len(), 1);
+            assert!(!session.has_semantic_index(), "wrong_kind={wrong_kind}");
+            assert_eq!(loaded.diagnostics.len(), 1);
+            assert_eq!(loaded.diagnostics[0].code, DiagnosticCode::SearchHashDrift);
+            assert!(
+                !serde_json::to_string(&loaded.diagnostics)
+                    .unwrap()
+                    .contains("billing.hidden")
+            );
+        }
+    }
+
+    #[test]
+    fn fully_stale_permitted_vectors_disable_semantic_but_preserve_lexical_fallback() {
+        let loaded = load_retrieval_session_with_readers(
+            RetrievalInput {
+                artifact_path: "ignored.graph.json".into(),
+                search_artifact_path: Some("ignored.search.json".into()),
+                policy: None,
+            },
+            &StubSearchArtifactReader {
+                document: search_document("sha256:older-graph"),
+            },
+            &StubGraphArtifactReader {
+                document: graph_document(
+                    vec![object("billing.target", "Shared updated credits.")],
+                    vec![],
+                ),
+            },
+            None,
+        );
+        let session = loaded.session.unwrap();
+        assert!(
+            !session.has_semantic_index(),
+            "a fully stale permitted index is unavailable"
+        );
+        assert_eq!(loaded.diagnostics[0].code, DiagnosticCode::SearchHashDrift);
+        let mut query = lexical_search_query("credits", SearchRecordScope::ObjectsOnly);
+        query.mode = SearchMode::Semantic;
+        let result = search(&session, query.clone());
+        assert!(result.records.is_empty());
+        assert_eq!(
+            result.diagnostics[0].code,
+            DiagnosticCode::SearchArtifactMissing
+        );
+        assert_eq!(
+            result.diagnostics[0].severity,
+            crate::domain::diagnostic::Severity::Error
+        );
+        query.mode = SearchMode::Hybrid;
+        let result = search(&session, query);
+        assert!(result.diagnostics.is_empty());
+        assert_eq!(result.records[0].id(), "billing.target");
+    }
+
+    #[test]
+    fn vector_admission_checks_current_composition_and_kind_on_drift() {
+        use crate::domain::retrieval::metadata;
+        for change in ["owner", "body", "kind", "unchanged"] {
+            let mut old = object("billing.target", "Shared credits.");
+            old.fields
+                .insert("owner".to_string(), "public-team".to_string());
+            if change == "owner" {
+                old.fields
+                    .insert("owner".to_string(), "billing.hidden".to_string());
+            }
+            if change == "body" {
+                old.body = "Private billing.hidden credits.".to_string();
+            }
+            let mut current = object("billing.target", "Shared credits.");
+            current
+                .fields
+                .insert("owner".to_string(), "public-team".to_string());
+            let mut search_artifact = search_document("sha256:older-graph");
+            search_artifact.embeddings[0].content_hash =
+                sha256_prefixed(metadata::embedding_input(&old).as_bytes());
+            if change == "kind" {
+                search_artifact.embeddings[0].entry_kind = SearchEntryKind::Prose;
+            }
+            let loaded = load_retrieval_session_with_readers(
+                RetrievalInput {
+                    artifact_path: "ignored.graph.json".into(),
+                    search_artifact_path: Some("ignored.search.json".into()),
+                    policy: Some(RetrievalPolicy {
+                        audience: "public".into(),
+                        allowed_visibilities: BTreeSet::from(["public".into()]),
+                        excluded_object_ids: BTreeSet::from(["billing.hidden".into()]),
+                    }),
+                },
+                &StubSearchArtifactReader {
+                    document: search_artifact,
+                },
+                &StubGraphArtifactReader {
+                    document: graph_document(vec![current], Vec::new()),
+                },
+                None,
+            );
+            assert_eq!(loaded.diagnostics[0].code, DiagnosticCode::SearchHashDrift);
+            let session = loaded.session.unwrap();
+            assert_eq!(why_object(&session, "billing.target").records.len(), 1);
+            assert_eq!(
+                session.has_semantic_index(),
+                change == "unchanged",
+                "{change}"
+            );
+            let hits = session
+                .vector_index()
+                .map(|index| index.rank(&[1.0, 0.0], 10))
+                .unwrap_or_default();
+            assert_eq!(hits.len(), usize::from(change == "unchanged"), "{change}");
+        }
+    }
+
+    #[test]
+    fn prose_vector_admission_checks_current_composition_and_kind() {
+        use crate::domain::retrieval::metadata;
+        for change in ["body", "page", "kind", "unchanged"] {
+            let text = "Shared credit rules are public now.";
+            let page = "guides.page";
+            let document: GraphArtifactDocument = serde_json::from_value(serde_json::json!({
+                "schema_version":"adoc.graph.v6", "repository_identity":null,
+                "nodes":[{"type":"paragraph", "id":"guides.page#block-1", "page_id":page,"order":1,"text":text,"source_span":{"path":"docs/public.adoc","line":1,"column":1}}],
+                "edges":[],"diagnostics":[]
+            })).unwrap();
+            let old_text = if change == "body" {
+                "Private billing.hidden credit rules used to apply."
+            } else {
+                text
+            };
+            let old_page = if change == "page" {
+                "billing.hidden"
+            } else {
+                page
+            };
+            let mut search_artifact = search_document("sha256:older-graph");
+            search_artifact.embeddings[0].id = "guides.page#block-1".into();
+            search_artifact.embeddings[0].entry_kind = if change == "kind" {
+                SearchEntryKind::KnowledgeObject
+            } else {
+                SearchEntryKind::Prose
+            };
+            search_artifact.embeddings[0].content_hash =
+                sha256_prefixed(metadata::prose_embedding_input(old_text, old_page).as_bytes());
+            let loaded = load_retrieval_session_with_readers(
+                RetrievalInput {
+                    artifact_path: "ignored.graph.json".into(),
+                    search_artifact_path: Some("ignored.search.json".into()),
+                    policy: None,
+                },
+                &StubSearchArtifactReader {
+                    document: search_artifact,
+                },
+                &StubGraphArtifactReader { document },
+                None,
+            );
+            assert_eq!(loaded.diagnostics[0].code, DiagnosticCode::SearchHashDrift);
+            let session = loaded.session.unwrap();
+            assert_eq!(
+                session.has_semantic_index(),
+                change == "unchanged",
+                "{change}"
+            );
+            assert_eq!(
+                session
+                    .vector_index()
+                    .map(|index| index.rank(&[1.0, 0.0], 10).len())
+                    .unwrap_or(0),
+                usize::from(change == "unchanged"),
+                "{change}"
+            );
+        }
+    }
+
     fn search_document(graph_artifact_hash: &str) -> SearchArtifactDocument {
         SearchArtifactDocument {
             schema_version: "adoc.search.v2".to_string(),
@@ -1036,9 +1615,57 @@ mod tests {
             embeddings: vec![SearchEmbedding {
                 id: "billing.target".to_string(),
                 entry_kind: SearchEntryKind::KnowledgeObject,
-                content_hash: "sha256:content".to_string(),
+                content_hash: sha256_prefixed(
+                    metadata::embedding_input(&object("billing.target", "Target body.")).as_bytes(),
+                ),
                 vector: vec![1.0, 0.0],
             }],
+        }
+    }
+
+    #[test]
+    fn retrieval_policy_excludes_vectors_before_index_construction() {
+        let loaded = load_retrieval_session_with_readers(
+            RetrievalInput {
+                artifact_path: PathBuf::from("ignored.graph.json"),
+                search_artifact_path: Some(PathBuf::from("ignored.search.json")),
+                policy: Some(RetrievalPolicy {
+                    audience: "public".to_string(),
+                    allowed_visibilities: BTreeSet::from(["public".to_string()]),
+                    excluded_object_ids: BTreeSet::from(["billing.target".to_string()]),
+                }),
+            },
+            &StubSearchArtifactReader {
+                document: search_document("sha256:hidden-corpus"),
+            },
+            &StubGraphArtifactReader {
+                document: graph_document(
+                    vec![object("billing.target", "Secret credits.")],
+                    Vec::new(),
+                ),
+            },
+            None,
+        );
+        assert_eq!(loaded.diagnostics[0].code, DiagnosticCode::SearchHashDrift);
+        assert!(!loaded.diagnostics[0].message.contains("sha256:"));
+        let session = loaded.session.expect("filtered session loads");
+        assert!(
+            session
+                .vector_index()
+                .unwrap()
+                .rank(&[1.0, 0.0], 10)
+                .is_empty()
+        );
+        for mode in [
+            SearchMode::Lexical,
+            SearchMode::Semantic,
+            SearchMode::Hybrid,
+        ] {
+            let mut query = empty_search_query();
+            query.mode = mode;
+            query.text = "billing.target".to_string();
+            query.query_vector = Some(vec![1.0, 0.0]);
+            assert!(search(&session, query).records.is_empty());
         }
     }
 
@@ -1102,6 +1729,7 @@ mod tests {
     fn load_session_from_document(document: GraphArtifactDocument) -> RetrievalSession {
         load_retrieval_session_with_readers(
             RetrievalInput {
+                policy: None,
                 artifact_path: PathBuf::from("ignored.graph.json"),
                 search_artifact_path: None,
             },
@@ -1123,6 +1751,33 @@ mod tests {
             top: NonZeroUsize::new(10).expect("non-zero"),
             query_vector: None,
             scope: SearchRecordScope::default(),
+        }
+    }
+
+    #[test]
+    fn retrieval_without_policy_denies_nonpublic_objects_before_search_and_why() {
+        let public = object("billing.public", "Shared credits.");
+        let mut restricted = object("billing.restricted", "Secret credits.");
+        restricted.visibility = Some("restricted".to_string());
+        let mut internal = object("billing.internal", "Internal credits.");
+        internal.visibility = Some("internal".to_string());
+        let session = load_session_from_document(graph_document(
+            vec![public, restricted, internal],
+            Vec::new(),
+        ));
+
+        let result = search(&session, empty_search_query());
+        assert_eq!(
+            result.records.iter().map(|r| r.id()).collect::<Vec<_>>(),
+            ["billing.public"]
+        );
+        for id in ["billing.restricted", "billing.internal"] {
+            let result = why_object(&session, id);
+            assert!(result.records.is_empty());
+            assert_eq!(
+                result.diagnostics[0].code,
+                DiagnosticCode::RetrievalObjectNotFound
+            );
         }
     }
 

--- a/crates/adoc-core/src/application/signals.rs
+++ b/crates/adoc-core/src/application/signals.rs
@@ -16,7 +16,7 @@ use chrono::NaiveDate;
 use serde::Serialize;
 
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode};
-use crate::domain::graph::GraphKnowledgeObjectNode;
+use crate::domain::graph::{GraphKnowledgeObjectNode, unresolved_contradiction_claim_index};
 use crate::domain::obligation::ProofObligation;
 use crate::domain::ports::changed_files::ChangedFilesError;
 use crate::domain::review::impact::{ImpactReasonKind, impacted_objects};
@@ -24,9 +24,7 @@ use crate::domain::review::obligation_rules::obligation_for_impacted_node;
 use crate::domain::value_objects::rel_path::RelPath;
 use crate::domain::value_objects::review_interval::ReviewInterval;
 use crate::domain::value_objects::severity::Severity;
-use crate::infrastructure::artifact::graph_json::{
-    derive_effective_status_from_fields, unresolved_contradiction_claim_index,
-};
+use crate::infrastructure::artifact::graph_json::derive_effective_status_from_fields;
 
 use super::graph::GraphSession;
 use super::local_today;

--- a/crates/adoc-core/src/domain/diagnostic.rs
+++ b/crates/adoc-core/src/domain/diagnostic.rs
@@ -141,6 +141,12 @@ diagnostic_codes! {
         "Rebuild the artifact after removing duplicate object IDs from the source.";
     RetrievalObjectNotFound = "retrieval.object_not_found" =>
         "Use an object ID present in the loaded retrieval artifact.";
+    RetrievalPolicyInvalid = "retrieval.policy_invalid" =>
+        "Use canonical allowed visibilities and valid excluded Object IDs in retrieval_policy.";
+    RetrievalAudienceUnresolved = "retrieval.audience_unresolved" =>
+        "Set retrieval_policy.audience to public, internal, or restricted.";
+    RetrievalVisibilityUnavailable = "retrieval.visibility_unavailable" =>
+        "Rebuild the graph from valid source, fixing artifact errors and invalid object visibility.";
     SearchInvalidFilter = "search.invalid_filter" =>
         "Change or remove the filter so it matches at least one object field in the artifact.";
     SearchInvalidScope = "search.invalid_scope" =>

--- a/crates/adoc-core/src/domain/graph/mod.rs
+++ b/crates/adoc-core/src/domain/graph/mod.rs
@@ -985,6 +985,89 @@ fn invalid_content_hash_diagnostic(node: &GraphKnowledgeObjectNode) -> Diagnosti
     .with_help("Graph Artifact v2 content_hash values must start with `sha256:` and include a non-empty suffix.")
 }
 
+/// Reverse index over `contradiction_claims`: claim id → the sorted ids of
+/// every **unresolved** contradiction node that references it.
+///
+/// Shared core of the build-time `effective_status: "contradicted"` post-pass
+/// and the V6.2 `adoc contradictions` read-time evaluation in
+/// `application/signals.rs`. Values are sorted ascending so element `[0]` is
+/// the lexicographically smallest implicating contradiction id.
+pub(crate) fn unresolved_contradiction_claim_index<'a>(
+    objects: impl Iterator<Item = &'a crate::domain::graph::GraphKnowledgeObjectNode>,
+) -> BTreeMap<String, Vec<String>> {
+    let mut index: BTreeMap<String, Vec<String>> = BTreeMap::new();
+
+    for ko in objects {
+        if ko.kind != "contradiction" {
+            continue;
+        }
+        if ko.status.as_deref() != Some("unresolved") {
+            continue;
+        }
+        for claim_id in &ko.contradiction_claims {
+            index
+                .entry(claim_id.clone())
+                .or_default()
+                .push(ko.id.clone());
+        }
+    }
+
+    for ids in index.values_mut() {
+        ids.sort();
+        ids.dedup();
+    }
+
+    index
+}
+
+/// Cross-object post-pass: propagate `effective_status: "contradicted"` to claim
+/// nodes referenced by an **unresolved** contradiction node.
+///
+/// # Precedence
+///
+/// If a claim node already has `effective_status` set (e.g. `"stale"` from the
+/// TB2 expiry pass), it is **not** overwritten. Stale is the stronger lifecycle
+/// signal and always wins.
+///
+/// # Determinism with multiple contradictions
+///
+/// When more than one unresolved contradiction references the same claim, the
+/// `effective_reason` is set to `"contradiction:<id>"` where `<id>` is the
+/// **lexicographically smallest** contradiction id among those referencing the
+/// claim. This ensures the output is byte-stable regardless of iteration order.
+pub(crate) fn apply_contradiction_effective_status(nodes: &mut [crate::domain::graph::GraphNode]) {
+    use crate::domain::graph::GraphNode;
+
+    let contradicted = unresolved_contradiction_claim_index(nodes.iter().filter_map(|node| {
+        let GraphNode::KnowledgeObject(ko) = node else {
+            return None;
+        };
+        Some(ko)
+    }));
+
+    if contradicted.is_empty() {
+        return;
+    }
+
+    // Apply to each claim node that has no existing effective_status.
+    for node in nodes.iter_mut() {
+        let GraphNode::KnowledgeObject(ko) = node else {
+            continue;
+        };
+        if ko.kind != "claim" {
+            continue;
+        }
+        if ko.effective_status.is_some() {
+            // Stale (or any pre-set status) wins — do not overwrite.
+            continue;
+        }
+        if let Some(ids) = contradicted.get(&ko.id) {
+            ko.effective_status = Some("contradicted".to_string());
+            ko.effective_reason = Some(format!("contradiction:{}", ids[0]));
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/adoc-core/src/domain/project_config.rs
+++ b/crates/adoc-core/src/domain/project_config.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
+use super::retrieval::RetrievalPolicy;
 use super::source::LogicalPath;
 
 #[derive(Debug, Clone)]
@@ -12,6 +13,7 @@ pub struct ParsedProjectConfig {
     pub embeddings_provider: EmbeddingsProvider,
     pub mcp_patch_apply_enabled: bool,
     pub assessment_exclude_paths: Vec<String>,
+    pub retrieval_policy: Option<RetrievalPolicy>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -51,6 +53,7 @@ struct RawProjectConfig {
     embeddings: Option<RawEmbeddings>,
     mcp: Option<RawMcp>,
     assessment: Option<RawAssessment>,
+    retrieval_policy: Option<RetrievalPolicy>,
 }
 
 #[derive(Debug, Deserialize, Default)]
@@ -135,6 +138,7 @@ pub fn parse_project_config(text: &str) -> Result<ParsedProjectConfig, ProjectCo
         embeddings_provider,
         mcp_patch_apply_enabled,
         assessment_exclude_paths,
+        retrieval_policy: raw.retrieval_policy,
     })
 }
 

--- a/crates/adoc-core/src/domain/retrieval/mod.rs
+++ b/crates/adoc-core/src/domain/retrieval/mod.rs
@@ -6,6 +6,74 @@ mod retrieval_record;
 pub(crate) mod vector_index;
 
 pub use filter::SearchFilters;
+
+/// Explicit local retrieval authority. The audience is a visibility ceiling;
+/// allowed visibilities narrow it, and explicit Object ID exclusions win.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Deserialize, serde::Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct RetrievalPolicy {
+    pub audience: String,
+    pub allowed_visibilities: std::collections::BTreeSet<String>,
+    #[serde(default)]
+    pub excluded_object_ids: std::collections::BTreeSet<String>,
+}
+
+impl RetrievalPolicy {
+    pub(crate) fn validate(&self) -> Result<(), Box<super::diagnostic::Diagnostic>> {
+        use super::diagnostic::{Diagnostic, DiagnosticCode};
+        if canonical_visibility(&self.audience).is_none() {
+            return Err(Box::new(Diagnostic::error(
+                DiagnosticCode::RetrievalAudienceUnresolved,
+                "Retrieval audience must be public, internal, or restricted.",
+            )));
+        }
+        if self
+            .allowed_visibilities
+            .iter()
+            .any(|v| canonical_visibility(v).is_none())
+            || self
+                .excluded_object_ids
+                .iter()
+                .any(|id| super::identity::ObjectId::new(id.as_str()).is_err())
+        {
+            return Err(Box::new(Diagnostic::error(
+                DiagnosticCode::RetrievalPolicyInvalid,
+                "Retrieval policy requires canonical visibilities and valid excluded Object IDs.",
+            )));
+        }
+        Ok(())
+    }
+
+    /// One permission predicate, evaluated before any retrieval index exists.
+    pub(crate) fn permits(
+        policy: Option<&Self>,
+        object: &super::graph::GraphKnowledgeObjectNode,
+    ) -> Result<bool, Box<super::diagnostic::Diagnostic>> {
+        use super::diagnostic::{Diagnostic, DiagnosticCode};
+        use super::value_objects::visibility::Visibility;
+        let visibility = canonical_visibility(object.visibility.as_deref().unwrap_or("public"))
+            .ok_or_else(|| {
+                Diagnostic::error(
+                    DiagnosticCode::RetrievalVisibilityUnavailable,
+                    "Retrieval object visibility cannot be resolved.",
+                )
+            })?;
+        let Some(policy) = policy else {
+            return Ok(visibility == Visibility::Public);
+        };
+        Ok(!policy.excluded_object_ids.contains(&object.id)
+            && policy.allowed_visibilities.contains(visibility.as_str())
+            && canonical_visibility(&policy.audience)
+                .is_some_and(|audience| visibility <= audience))
+    }
+}
+
+fn canonical_visibility(value: &str) -> Option<super::value_objects::visibility::Visibility> {
+    super::value_objects::visibility::Visibility::try_new(value)
+        .ok()
+        .filter(|visibility| visibility.as_str() == value)
+}
+
 pub use retrieval_record::{
     ProseRecord, RetrievalEntry, RetrievalMatch, RetrievalRecord, RetrievalRelations,
     RetrievalSource, SearchMode,

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -12,6 +12,7 @@ use crate::domain::graph::{
     GraphArtifactDocument, GraphBlockNode, GraphEdge, GraphEdgeKind, GraphEvidence,
     GraphKnowledgeObjectNode, GraphNode, GraphPageNode, GraphRelationKind, GraphRelations,
     GraphRepositoryIdentity, GraphSourceBinding, GraphSourceSpan,
+    apply_contradiction_effective_status,
 };
 use crate::domain::hashing::sha256_prefixed;
 use crate::domain::inline::{InlineSegment, to_source};
@@ -598,89 +599,6 @@ pub(crate) fn derive_effective_status_from_fields(
         Some(("stale".to_string(), format!("expired:{expires_at_date}")))
     } else {
         None
-    }
-}
-
-/// Reverse index over `contradiction_claims`: claim id → the sorted ids of
-/// every **unresolved** contradiction node that references it.
-///
-/// Shared core of the build-time `effective_status: "contradicted"` post-pass
-/// and the V6.2 `adoc contradictions` read-time evaluation in
-/// `application/signals.rs`. Values are sorted ascending so element `[0]` is
-/// the lexicographically smallest implicating contradiction id.
-pub(crate) fn unresolved_contradiction_claim_index<'a>(
-    objects: impl Iterator<Item = &'a crate::domain::graph::GraphKnowledgeObjectNode>,
-) -> BTreeMap<String, Vec<String>> {
-    let mut index: BTreeMap<String, Vec<String>> = BTreeMap::new();
-
-    for ko in objects {
-        if ko.kind != "contradiction" {
-            continue;
-        }
-        if ko.status.as_deref() != Some("unresolved") {
-            continue;
-        }
-        for claim_id in &ko.contradiction_claims {
-            index
-                .entry(claim_id.clone())
-                .or_default()
-                .push(ko.id.clone());
-        }
-    }
-
-    for ids in index.values_mut() {
-        ids.sort();
-        ids.dedup();
-    }
-
-    index
-}
-
-/// Cross-object post-pass: propagate `effective_status: "contradicted"` to claim
-/// nodes referenced by an **unresolved** contradiction node.
-///
-/// # Precedence
-///
-/// If a claim node already has `effective_status` set (e.g. `"stale"` from the
-/// TB2 expiry pass), it is **not** overwritten. Stale is the stronger lifecycle
-/// signal and always wins.
-///
-/// # Determinism with multiple contradictions
-///
-/// When more than one unresolved contradiction references the same claim, the
-/// `effective_reason` is set to `"contradiction:<id>"` where `<id>` is the
-/// **lexicographically smallest** contradiction id among those referencing the
-/// claim. This ensures the output is byte-stable regardless of iteration order.
-pub(crate) fn apply_contradiction_effective_status(nodes: &mut [crate::domain::graph::GraphNode]) {
-    use crate::domain::graph::GraphNode;
-
-    let contradicted = unresolved_contradiction_claim_index(nodes.iter().filter_map(|node| {
-        let GraphNode::KnowledgeObject(ko) = node else {
-            return None;
-        };
-        Some(ko)
-    }));
-
-    if contradicted.is_empty() {
-        return;
-    }
-
-    // Apply to each claim node that has no existing effective_status.
-    for node in nodes.iter_mut() {
-        let GraphNode::KnowledgeObject(ko) = node else {
-            continue;
-        };
-        if ko.kind != "claim" {
-            continue;
-        }
-        if ko.effective_status.is_some() {
-            // Stale (or any pre-set status) wins — do not overwrite.
-            continue;
-        }
-        if let Some(ids) = contradicted.get(&ko.id) {
-            ko.effective_status = Some("contradicted".to_string());
-            ko.effective_reason = Some(format!("contradiction:{}", ids[0]));
-        }
     }
 }
 

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -95,6 +95,7 @@ pub use domain::proposal::{
     ProposalDispositionInput, ProposalDispositionKind, ProposalPatch, ProposalPatchInput,
     ProposalRecord, ProposalRecordError,
 };
+pub use domain::retrieval::RetrievalPolicy;
 pub use domain::retrieval::{
     ProseRecord, RetrievalEntry, RetrievalMatch, RetrievalRecord, RetrievalRelations,
     RetrievalSource, SearchMode,

--- a/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.search.json
+++ b/crates/adoc-core/tests/fixtures/v1_4_semantic/hash_drift.search.json
@@ -9,7 +9,7 @@
     {
       "id": "billing.first",
       "entry_kind": "knowledge_object",
-      "content_hash": "sha256:0000000000000000000000000000000000000000000000000000000000000000",
+      "content_hash": "sha256:949065f1e3d9d1360e90f1cc0d2dc47dc87d5e74b2d1085ee1f7893ba8a33791",
       "vector": [
         0.0,
         0.0,

--- a/crates/adoc-core/tests/public_surface.rs
+++ b/crates/adoc-core/tests/public_surface.rs
@@ -264,6 +264,7 @@ fn public_surface_compiles_with_only_documented_imports() {
 
     let _: fn(RetrievalInput) -> RetrievalLoadResult = load_retrieval_session;
     let _: RetrievalInput = RetrievalInput {
+        policy: None,
         artifact_path: PathBuf::from("/missing-docs-graph-json-for-surface-test"),
         search_artifact_path: None,
     };

--- a/crates/adoc-core/tests/retrieval.rs
+++ b/crates/adoc-core/tests/retrieval.rs
@@ -44,6 +44,7 @@ fn load_session_from_objects(objects: Vec<Value>) -> RetrievalSession {
     let graph_json = graph_json_from_objects(objects, Vec::new());
     let artifact = write_temp_artifact("search", &graph_json);
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -61,6 +62,7 @@ fn load_session_from_objects_with_vectors(
     vectors: Vec<(&str, Vec<f32>)>,
 ) -> RetrievalSession {
     let graph_json = graph_json_from_objects(objects, Vec::new());
+    let graph: Value = serde_json::from_str(&graph_json).expect("graph fixture parses");
     let artifact = write_temp_artifact("hybrid-graph", &graph_json);
     let search_document = serde_json::json!({
         "schema_version": "adoc.search.v2",
@@ -75,7 +77,7 @@ fn load_session_from_objects_with_vectors(
             .map(|(id, vector)| serde_json::json!({
                 "id": id,
                 "entry_kind": "knowledge_object",
-                "content_hash": "sha256:test",
+                "content_hash": fixture_embedding_hash(&graph, id),
                 "vector": vector
             }))
             .collect::<Vec<_>>()
@@ -86,6 +88,7 @@ fn load_session_from_objects_with_vectors(
     );
 
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: Some(search_artifact.path().to_path_buf()),
     });
@@ -106,6 +109,7 @@ fn load_session_from_objects_with_graph(
     let artifact = write_temp_artifact("graph-search", &graph_json);
 
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -127,6 +131,44 @@ fn sha256_prefixed(bytes: &[u8]) -> String {
         let _ = write!(output, "{byte:02x}");
     }
     output
+}
+
+// Hash the documented Embedding Composition, not the object's semantic hash.
+fn fixture_embedding_hash(graph: &Value, id: &str) -> String {
+    let Some(node) = graph["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .find(|node| node["id"] == id)
+    else {
+        // Preserve orphan-vector fixtures; no current carrier can admit them.
+        return sha256_prefixed(b"absent fixture record");
+    };
+    let normalized = |text: &str| {
+        text.replace("\r\n", "\n")
+            .replace('\r', "\n")
+            .trim()
+            .to_string()
+    };
+    let input = match node["type"].as_str().unwrap() {
+        "knowledge_object" => format!(
+            "{}: {}\n[id: {id}] [status: {}] [owner: {}]",
+            node["kind"].as_str().unwrap(),
+            normalized(node["body"].as_str().unwrap()),
+            ["status", "severity", "trust"]
+                .iter()
+                .find_map(|key| node[*key].as_str())
+                .unwrap_or("unknown"),
+            node["fields"]["owner"].as_str().unwrap_or("unknown"),
+        ),
+        "paragraph" | "heading" => format!(
+            "prose: {}\n[page: {}]",
+            normalized(node["text"].as_str().unwrap()),
+            node["page_id"].as_str().unwrap(),
+        ),
+        kind => panic!("unexpected vector fixture carrier: {kind}"),
+    };
+    sha256_prefixed(input.as_bytes())
 }
 
 fn graph_json_from_objects(objects: Vec<Value>, edges: Vec<Value>) -> String {
@@ -255,6 +297,7 @@ fn relation_edge(source: &str, relation: GraphRelationKind, target: &str) -> Val
 
 fn load_workspace_fixture_session(relative: &str) -> RetrievalSession {
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: workspace_fixture_path(relative),
         search_artifact_path: None,
     });
@@ -740,6 +783,7 @@ fn retrieval_session_rejects_malformed_graph_artifacts_through_graph_index_valid
     let artifact = write_temp_artifact("duplicate", &graph_json);
 
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1653,6 +1697,7 @@ fn search_filter_validation_reports_each_supplied_filter_with_no_independent_mat
 fn why_object_returns_record_for_id_in_loaded_graph_artifact() {
     let artifact = verified_claim_graph_artifact();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1693,6 +1738,7 @@ fn why_object_returns_record_for_id_in_loaded_graph_artifact() {
 fn why_object_serializes_record_without_search_match_block() {
     let artifact = verified_claim_graph_artifact();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1760,6 +1806,7 @@ fn why_object_lists_answered_questions_resolving_the_target() {
 fn retrieval_envelope_serializes_stable_schema_with_records_and_diagnostics() {
     let artifact = verified_claim_graph_artifact();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1859,6 +1906,7 @@ fn retrieval_envelope_can_be_created_from_search_result() {
 fn why_object_reports_unknown_id_without_loading_source() {
     let artifact = verified_claim_graph_artifact();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1882,6 +1930,7 @@ fn why_object_reports_unknown_id_without_loading_source() {
 fn why_object_reports_invalid_id_without_lookup() {
     let artifact = verified_claim_graph_artifact();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1922,6 +1971,7 @@ fn load_retrieval_session_rejects_invalid_object_ids_inside_artifact() {
     );
 
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -1971,6 +2021,7 @@ fn load_retrieval_session_rejects_duplicate_object_ids_inside_artifact() {
     );
 
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -2044,6 +2095,7 @@ fn empty_graph_artifact() -> tempfile::NamedTempFile {
 fn load_prose_only_session(prose_blocks: usize) -> RetrievalSession {
     let artifact = prose_only_graph_artifact(prose_blocks);
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -2058,6 +2110,7 @@ fn load_prose_only_session(prose_blocks: usize) -> RetrievalSession {
 fn load_empty_graph_session() -> RetrievalSession {
     let artifact = empty_graph_artifact();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -2427,6 +2480,7 @@ fn load_prose_session(extension: &str) -> RetrievalSession {
         &prose_symmetry_graph_json(extension),
     );
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -2548,6 +2602,7 @@ fn load_prose_session_with_vectors(vectors: Vec<(&str, Vec<f32>)>) -> RetrievalS
         .expect("prose fixture has canonical shape");
     let graph_json =
         serde_json::to_string_pretty(&canonical).expect("prose fixture serializes canonically");
+    let graph: Value = serde_json::from_str(&graph_json).expect("graph fixture parses");
     let artifact = write_temp_artifact("prose-vectors-graph", &graph_json);
     let search_document = json!({
         "schema_version": "adoc.search.v2",
@@ -2562,7 +2617,7 @@ fn load_prose_session_with_vectors(vectors: Vec<(&str, Vec<f32>)>) -> RetrievalS
             .map(|(id, vector)| json!({
                 "id": id,
                 "entry_kind": if id.contains('#') { "prose" } else { "knowledge_object" },
-                "content_hash": "sha256:test",
+                "content_hash": fixture_embedding_hash(&graph, id),
                 "vector": vector
             }))
             .collect::<Vec<_>>()
@@ -2573,6 +2628,7 @@ fn load_prose_session_with_vectors(vectors: Vec<(&str, Vec<f32>)>) -> RetrievalS
     );
 
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: Some(search_artifact.path().to_path_buf()),
     });
@@ -2827,6 +2883,7 @@ fn blended_lexical_search_ranks_knowledge_objects_and_prose_by_honest_rank() {
     );
     let artifact = write_temp_artifact("mixed-blend", &graph_json);
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: artifact.path().to_path_buf(),
         search_artifact_path: None,
     });
@@ -2857,4 +2914,750 @@ fn blended_lexical_search_ranks_knowledge_objects_and_prose_by_honest_rank() {
         "a mixed corpus never fires the migration hint: {:?}",
         prose_first.diagnostics
     );
+}
+
+#[test]
+fn retrieval_policy_excludes_search_and_why_before_ranking() {
+    let public = retrieval_search_object(
+        "billing.public",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/public.adoc",
+        "Shared credits.",
+    );
+    let hidden = retrieval_search_object(
+        "billing.hidden",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/hidden.adoc",
+        "Shared credits credits credits.",
+    );
+    let policy: adoc_core::RetrievalPolicy = serde_json::from_value(json!({
+        "audience": "public", "allowed_visibilities": ["public"],
+        "excluded_object_ids": ["billing.hidden"]
+    }))
+    .expect("policy parses");
+    let load = |objects, policy| {
+        let artifact = write_temp_artifact("policy", &graph_json_from_objects(objects, Vec::new()));
+        let loaded = load_retrieval_session(RetrievalInput {
+            artifact_path: artifact.path().to_path_buf(),
+            search_artifact_path: None,
+            policy,
+        });
+        assert!(loaded.diagnostics.is_empty(), "{:?}", loaded.diagnostics);
+        loaded.session.expect("session loads")
+    };
+    let filtered = load(vec![public.clone(), hidden.clone()], Some(policy.clone()));
+    let absent = load(vec![public.clone()], Some(policy));
+    for text in ["", "credits", "billing.hidden", "billing"] {
+        let query = lexical_query(text, 10, SearchFilters::default());
+        let actual =
+            serde_json::to_value(RetrievalEnvelope::from(search(&filtered, query.clone())))
+                .unwrap();
+        let expected =
+            serde_json::to_value(RetrievalEnvelope::from(search(&absent, query))).unwrap();
+        assert_eq!(actual, expected, "query: {text}");
+    }
+    assert_eq!(
+        serde_json::to_value(RetrievalEnvelope::from(why_object(
+            &filtered,
+            "billing.hidden"
+        )))
+        .unwrap(),
+        serde_json::to_value(RetrievalEnvelope::from(why_object(
+            &absent,
+            "billing.hidden"
+        )))
+        .unwrap(),
+    );
+    let unrestricted = load(vec![public, hidden], None);
+    assert_eq!(why_object(&unrestricted, "billing.hidden").records.len(), 1);
+}
+
+#[test]
+fn retrieval_policy_withholds_carriers_from_prose_metadata_and_diagnostics() {
+    let mut public = retrieval_search_object(
+        "billing.public",
+        "question",
+        Some("answered"),
+        None,
+        "docs/public.adoc",
+        "Shared credits.",
+    );
+    public["relations"]["depends_on"] = json!(["billing.hidden"]);
+    public["fields"]["resolved_by"] = json!("billing.hidden");
+    public["evidence"] = json!([{"kind":"source_code", "value":"See billing.hidden"}]);
+    let hidden = retrieval_search_object(
+        "billing.hidden",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/hidden.adoc",
+        "Secret credits.",
+    );
+    let mut document: Value = serde_json::from_str(&graph_json_from_objects(vec![public, hidden], vec![
+        json!({"kind":"relation", "source":"billing.public", "target":"billing.hidden", "relation":"depends_on"})
+    ])).unwrap();
+    document["nodes"].as_array_mut().unwrap().push(json!({
+        "type":"paragraph", "id":"team.billing#block-1", "page_id":"team.billing", "order":1,
+        "text":"Secret credits from [[billing.hidden]].", "source_span":{"path":"docs/public.adoc","line":2,"column":1}
+    }));
+    document["nodes"][0]["evidence_quality"] = json!("high");
+    document["diagnostics"] = json!([{
+        "code":"ref.broken", "severity":"warning", "message":"Secret credits from billing.hidden"
+    }]);
+    let artifact = write_temp_artifact("policy-projection", &document.to_string());
+    let result = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().to_path_buf(),
+        search_artifact_path: None,
+        policy: Some(
+            serde_json::from_value(
+                json!({"audience":"public", "allowed_visibilities":["public"],
+            "excluded_object_ids":["billing.hidden"]}),
+            )
+            .unwrap(),
+        ),
+    });
+    assert!(result.diagnostics.is_empty(), "{:?}", result.diagnostics);
+    let session = result
+        .session
+        .expect("filtered graph loads without dangling edges");
+    let why = why_object(&session, "billing.public");
+    assert!(
+        why.records.is_empty(),
+        "a source carrier cannot retain its pre-redaction hash"
+    );
+    let why_json = serde_json::to_string(&RetrievalEnvelope::from(why)).unwrap();
+    assert!(!why_json.contains("billing.hidden"), "{why_json}");
+    let search_json = serde_json::to_string(&RetrievalEnvelope::from(search(
+        &session,
+        lexical_query("credits", 10, SearchFilters::default()),
+    )))
+    .unwrap();
+    assert!(!search_json.contains("billing.hidden"), "{search_json}");
+    assert!(!search_json.contains("Secret credits"), "{search_json}");
+}
+
+#[test]
+fn retrieval_policy_invalid_values_fail_closed_and_audience_is_a_ceiling() {
+    let mut object = retrieval_search_object(
+        "billing.internal",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/internal.adoc",
+        "Internal credits.",
+    );
+    object["visibility"] = json!("internal");
+    let graph = json!({"schema_version":"adoc.graph.v6", "repository_identity":null,
+        "nodes":[object], "edges":[], "diagnostics":[]});
+    let artifact = write_temp_artifact("policy-values", &graph.to_string());
+    let load = |policy| {
+        load_retrieval_session(RetrievalInput {
+            artifact_path: artifact.path().to_path_buf(),
+            search_artifact_path: None,
+            policy: Some(serde_json::from_value(policy).unwrap()),
+        })
+    };
+    for (policy, code) in [
+        (
+            json!({"audience":"unknown", "allowed_visibilities":["public"]}),
+            DiagnosticCode::RetrievalAudienceUnresolved,
+        ),
+        (
+            json!({"audience":"public", "allowed_visibilities":["secret"]}),
+            DiagnosticCode::RetrievalPolicyInvalid,
+        ),
+        (
+            json!({"audience":"public", "allowed_visibilities":[" public"]}),
+            DiagnosticCode::RetrievalPolicyInvalid,
+        ),
+        (
+            json!({"audience":"public", "allowed_visibilities":["public"], "excluded_object_ids":["bad"]}),
+            DiagnosticCode::RetrievalPolicyInvalid,
+        ),
+    ] {
+        let result = load(policy);
+        assert!(result.session.is_none());
+        assert_eq!(result.diagnostics.len(), 1);
+        assert_eq!(result.diagnostics[0].code, code);
+    }
+    for (audience, allowed, count) in [
+        ("public", vec!["internal"], 0),
+        ("internal", vec![], 0),
+        ("internal", vec!["internal"], 1),
+        ("restricted", vec!["internal"], 1),
+    ] {
+        let session = load(json!({"audience":audience, "allowed_visibilities":allowed}))
+            .session
+            .unwrap();
+        assert_eq!(
+            why_object(&session, "billing.internal").records.len(),
+            count
+        );
+    }
+    let mut invalid_graph = graph;
+    invalid_graph["nodes"][0]["visibility"] = json!("secret");
+    std::fs::write(artifact.path(), invalid_graph.to_string()).unwrap();
+    let invalid = load(json!({"audience":"public", "allowed_visibilities":["public"]}));
+    assert!(invalid.session.is_none());
+    assert_eq!(
+        invalid.diagnostics[0].code,
+        DiagnosticCode::RetrievalVisibilityUnavailable
+    );
+}
+
+#[test]
+fn project_config_carries_strict_retrieval_policy_and_defaults_exclusions() {
+    let base = "version: 1\nmode: strict\ndocs_path: docs\n";
+    assert!(
+        adoc_core::parse_project_config(base)
+            .unwrap()
+            .retrieval_policy
+            .is_none()
+    );
+    let configured =
+        format!("{base}retrieval_policy:\n  audience: public\n  allowed_visibilities: [public]\n");
+    let policy = adoc_core::parse_project_config(&configured)
+        .unwrap()
+        .retrieval_policy
+        .unwrap();
+    assert!(policy.excluded_object_ids.is_empty());
+    let encoded = serde_json::to_value(&policy).unwrap();
+    assert_eq!(
+        serde_json::from_value::<adoc_core::RetrievalPolicy>(encoded).unwrap(),
+        policy
+    );
+    assert!(adoc_core::parse_project_config(&format!("{configured}  typo: true\n")).is_err());
+    assert!(
+        adoc_core::parse_project_config(&format!("{base}retrieval_policy:\n  audience: public\n"))
+            .is_err()
+    );
+}
+
+#[test]
+fn retrieval_policy_preserves_artifact_failure_without_disclosing_content() {
+    let mut graph: Value =
+        serde_json::from_str(&graph_json_from_objects(Vec::new(), Vec::new())).unwrap();
+    graph["diagnostics"] = json!([{
+        "code":"ref.broken", "severity":"error", "message":"Secret billing.hidden is broken"
+    }]);
+    let artifact = write_temp_artifact("policy-invalid-corpus", &graph.to_string());
+    let result = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().to_path_buf(),
+        search_artifact_path: None,
+        policy: Some(
+            serde_json::from_value(
+                json!({"audience":"public", "allowed_visibilities":["public"],
+            "excluded_object_ids":["billing.hidden"]}),
+            )
+            .unwrap(),
+        ),
+    });
+    assert!(
+        result.session.is_none(),
+        "carried source errors must refuse even a structurally valid filtered session"
+    );
+    assert_eq!(result.diagnostics.len(), 1);
+    assert_eq!(
+        result.diagnostics[0].code,
+        DiagnosticCode::RetrievalVisibilityUnavailable
+    );
+    assert_eq!(result.diagnostics[0].severity, adoc_core::Severity::Error);
+    let help = result.diagnostics[0]
+        .help
+        .as_deref()
+        .expect("safe repair guidance");
+    assert!(
+        help.contains("adoc check") && help.contains("adoc build"),
+        "{help}"
+    );
+    let diagnostic = serde_json::to_string(&result.diagnostics).unwrap();
+    assert!(!diagnostic.contains("Secret"));
+    assert!(!diagnostic.contains("billing.hidden"));
+
+    graph["diagnostics"] = json!([]);
+    graph["edges"] = json!([{"kind":"relation", "source":"billing.missing", "target":"billing.other", "relation":"depends_on"}]);
+    std::fs::write(artifact.path(), graph.to_string()).unwrap();
+    let result = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().to_path_buf(),
+        search_artifact_path: None,
+        policy: Some(
+            serde_json::from_value(
+                json!({"audience":"public", "allowed_visibilities":["public"],
+            "excluded_object_ids":["billing.hidden"]}),
+            )
+            .unwrap(),
+        ),
+    });
+    assert!(
+        result.session.is_none(),
+        "unrelated broken edges must still fail graph validation"
+    );
+}
+
+#[test]
+fn permission_projection_recomputes_contradiction_status_without_hidden_ids() {
+    let mut public = retrieval_search_object(
+        "billing.public",
+        "claim",
+        Some("verified"),
+        None,
+        "docs/public.adoc",
+        "Shared credits.",
+    );
+    public["effective_status"] = json!("contradicted");
+    public["effective_reason"] = json!("contradiction:billing.hidden");
+    let mut hidden = retrieval_search_object(
+        "billing.hidden",
+        "contradiction",
+        Some("unresolved"),
+        None,
+        "docs/hidden.adoc",
+        "Private dispute.",
+    );
+    hidden["visibility"] = json!("restricted");
+    hidden["contradiction_claims"] = json!(["billing.public"]);
+    let artifact = write_temp_artifact(
+        "contradiction-privacy",
+        &json!({
+            "schema_version":"adoc.graph.v6", "repository_identity":null,
+            "nodes":[public, hidden], "edges":[], "diagnostics":[]
+        })
+        .to_string(),
+    );
+    let result = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().into(),
+        search_artifact_path: None,
+        policy: None,
+    });
+    let session = result.session.unwrap();
+    let record = &why_object(&session, "billing.public").records[0];
+    assert_eq!(record.effective_status, None);
+    assert_eq!(record.effective_reason, None);
+    assert_eq!(record.status.as_deref(), Some("verified"));
+}
+
+#[test]
+fn permission_projection_withholds_bodies_referencing_denied_objects_before_ranking() {
+    for (path, body) in [
+        ("docs/public.adoc", "See [[billing.hidden]] for credits."),
+        ("docs/billing.hidden.adoc", "Shared credits."),
+    ] {
+        let public =
+            retrieval_search_object("billing.public", "claim", Some("draft"), None, path, body);
+        let artifact = write_temp_artifact(
+            "body-privacy",
+            &graph_json_from_objects(vec![public], Vec::new()),
+        );
+        let loaded = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().into(), search_artifact_path: None,
+        policy: Some(serde_json::from_value(json!({"audience":"public", "allowed_visibilities":["public"], "excluded_object_ids":["billing.hidden"]})).unwrap()),
+    });
+        let session = loaded.session.unwrap();
+        assert!(
+            search(
+                &session,
+                lexical_query("credits", 10, SearchFilters::default())
+            )
+            .records
+            .is_empty()
+        );
+        assert!(why_object(&session, "billing.public").records.is_empty());
+    }
+}
+
+#[test]
+fn permission_projection_does_not_launder_invalid_hidden_nodes() {
+    let mut hidden = retrieval_search_object(
+        "billing.hidden",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/hidden.adoc",
+        "Secret claim.",
+    );
+    hidden["visibility"] = json!("restricted");
+    hidden.as_object_mut().unwrap().remove("content_hash");
+    let artifact = write_temp_artifact(
+        "invalid-hidden",
+        &json!({
+            "schema_version":"adoc.graph.v6", "repository_identity":null,
+            "nodes":[hidden], "edges":[], "diagnostics":[]
+        })
+        .to_string(),
+    );
+    let loaded = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().into(),
+        search_artifact_path: None,
+        policy: None,
+    });
+    assert!(loaded.session.is_none());
+    assert_eq!(
+        loaded.diagnostics[0].code,
+        DiagnosticCode::RetrievalVisibilityUnavailable
+    );
+    assert!(
+        !serde_json::to_string(&loaded.diagnostics)
+            .unwrap()
+            .contains("billing.hidden")
+    );
+}
+
+#[test]
+fn malformed_private_artifact_errors_never_echo_untrusted_values() {
+    let mut hidden = retrieval_search_object(
+        "billing.hidden",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/hidden.adoc",
+        "Private claim.",
+    );
+    hidden["visibility"] = json!("restricted");
+    hidden["source_span"]["line"] = json!("secret-internal-host");
+    let artifact = write_temp_artifact(
+        "private-parser-error",
+        &json!({
+            "schema_version":"adoc.graph.v6", "repository_identity":null,
+            "nodes":[hidden], "edges":[], "diagnostics":[]
+        })
+        .to_string(),
+    );
+    let loaded = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().into(),
+        search_artifact_path: None,
+        policy: None,
+    });
+    assert!(loaded.session.is_none());
+    assert_eq!(
+        loaded.diagnostics[0].code,
+        DiagnosticCode::IoArtifactMalformed
+    );
+    let encoded = serde_json::to_string(&loaded.diagnostics).unwrap();
+    assert!(!encoded.contains("secret-internal-host"), "{encoded}");
+    assert!(!encoded.contains("billing.hidden"), "{encoded}");
+}
+
+#[test]
+fn unsupported_artifact_versions_never_echo_untrusted_values() {
+    let valid = empty_graph_artifact();
+    let hostile = write_temp_artifact(
+        "hostile-version",
+        r#"{"schema_version":"secret-internal-host","model":{"id":"fixture","provider":"fastembed","dim":1},"graph_artifact_hash":"sha256:fixture","embeddings":[]}"#,
+    );
+    for search_artifact in [false, true] {
+        let loaded = load_retrieval_session(RetrievalInput {
+            artifact_path: if search_artifact {
+                valid.path()
+            } else {
+                hostile.path()
+            }
+            .into(),
+            search_artifact_path: search_artifact.then(|| hostile.path().into()),
+            policy: None,
+        });
+        assert!(
+            loaded
+                .diagnostics
+                .iter()
+                .any(|d| d.code == DiagnosticCode::SchemaUnsupportedVersion)
+        );
+        let encoded = serde_json::to_string(&loaded.diagnostics).unwrap();
+        assert!(!encoded.contains("secret-internal-host"), "{encoded}");
+        let guidance = if search_artifact {
+            "Rebuild the artifact"
+        } else {
+            "Regenerate the artifact"
+        };
+        assert!(encoded.contains(guidance), "{encoded}");
+    }
+}
+
+#[test]
+fn permission_projection_withholds_prose_with_denied_metadata() {
+    let mut leaking_carriers = Vec::new();
+    for carrier in ["id", "page_id", "path", "language", "noncanonical_code"] {
+        let mut block = json!({
+            "type":"paragraph", "id":"team.billing#block-1", "page_id":"team.billing", "order":1,
+            "text":"Shared credits.", "source_span":{"path":"docs/public.adoc","line":2,"column":1}
+        });
+        match carrier {
+            "id" => block["id"] = json!("billing.hidden#block-1"),
+            "page_id" => block["page_id"] = json!("billing.hidden"),
+            "path" => block["source_span"]["path"] = json!("docs/billing.hidden.adoc"),
+            "language" => block["language"] = json!("billing.hidden"),
+            "noncanonical_code" => block["code"] = json!("billing.hidden"),
+            _ => unreachable!(),
+        }
+        let artifact = write_temp_artifact(
+            "prose-metadata",
+            &json!({
+                "schema_version":"adoc.graph.v6", "repository_identity":null,
+                "nodes":[block], "edges":[], "diagnostics":[]
+            })
+            .to_string(),
+        );
+        let policy = serde_json::from_value(json!({
+            "audience":"public", "allowed_visibilities":["public"], "excluded_object_ids":["billing.hidden"]
+        })).unwrap();
+        let loaded = load_retrieval_session(RetrievalInput {
+            artifact_path: artifact.path().into(),
+            search_artifact_path: None,
+            policy: Some(policy),
+        });
+        assert!(loaded.diagnostics.is_empty(), "{:?}", loaded.diagnostics);
+        let session = loaded.session.unwrap();
+        let mut query = lexical_query("credits", 10, SearchFilters::default());
+        query.scope = SearchRecordScope::ProseOnly;
+        let encoded =
+            serde_json::to_string(&RetrievalEnvelope::from(search(&session, query))).unwrap();
+        if encoded.contains("billing.hidden") || encoded.contains("Shared credits") {
+            leaking_carriers.push(carrier);
+        }
+    }
+    assert!(
+        leaking_carriers.is_empty(),
+        "prose was not withheld for: {leaking_carriers:?}"
+    );
+}
+
+#[test]
+fn permission_projection_checks_every_serialized_scalar_carrier() {
+    for field in [
+        "id",
+        "status",
+        "kind",
+        "severity",
+        "trust",
+        "content_hash",
+        "effective_status",
+        "effective_reason",
+    ] {
+        let mut public = retrieval_search_object(
+            "billing.public",
+            "claim",
+            Some("draft"),
+            None,
+            "docs/public.adoc",
+            "Shared credits.",
+        );
+        public[field] = if field == "id" {
+            json!("billing.hidden.faq")
+        } else {
+            json!("pending billing.hidden")
+        };
+        let artifact = write_temp_artifact(
+            "scalar-privacy",
+            &json!({
+                "schema_version":"adoc.graph.v6", "repository_identity":null,
+                "nodes":[public], "edges":[], "diagnostics":[]
+            })
+            .to_string(),
+        );
+        let loaded = load_retrieval_session(RetrievalInput {
+            artifact_path:artifact.path().into(), search_artifact_path:None,
+            policy:Some(serde_json::from_value(json!({"audience":"public", "allowed_visibilities":["public"], "excluded_object_ids":["billing.hidden"]})).unwrap())
+        });
+        assert!(
+            !serde_json::to_string(&loaded.diagnostics)
+                .unwrap()
+                .contains("billing.hidden")
+        );
+        let Some(session) = loaded.session else {
+            assert_ne!(
+                field, "status",
+                "free-form claim status is valid authored metadata"
+            );
+            assert_eq!(
+                loaded.diagnostics[0].code,
+                DiagnosticCode::RetrievalVisibilityUnavailable
+            );
+            continue;
+        };
+        assert!(
+            why_object(&session, "billing.public").records.is_empty(),
+            "{field}"
+        );
+        assert!(
+            search(
+                &session,
+                lexical_query("credits", 10, SearchFilters::default())
+            )
+            .records
+            .is_empty(),
+            "{field}"
+        );
+    }
+}
+
+#[test]
+fn tool_guide_upgrade_policy_restores_all_classes_and_transitive_public_dependents() {
+    let object = |id| {
+        retrieval_search_object(
+            id,
+            "claim",
+            Some("draft"),
+            None,
+            "docs/migration.adoc",
+            "Migration fixture knowledge.",
+        )
+    };
+    let public = object("migration.public");
+    let mut internal = object("migration.internal");
+    internal["visibility"] = json!("internal");
+    let mut restricted = object("migration.restricted");
+    restricted["visibility"] = json!("restricted");
+    let mut direct = object("migration.direct");
+    direct["visibility"] = json!("public");
+    direct["relations"]["depends_on"] = json!(["migration.internal"]);
+    let mut transitive = object("migration.transitive");
+    transitive["visibility"] = json!("public");
+    transitive["relations"]["depends_on"] = json!(["migration.direct"]);
+    let artifact = write_temp_artifact("migration-policy", &json!({
+        "schema_version": "adoc.graph.v6", "repository_identity": null,
+        "nodes": [public, internal, restricted, direct, transitive],
+        "edges": [
+            {"kind":"relation", "source":"migration.direct", "target":"migration.internal", "relation":"depends_on"},
+            {"kind":"relation", "source":"migration.transitive", "target":"migration.direct", "relation":"depends_on"}
+        ],
+        "diagnostics": []
+    }).to_string());
+    let load = |policy| {
+        let loaded = load_retrieval_session(RetrievalInput {
+            artifact_path: artifact.path().to_path_buf(),
+            search_artifact_path: None,
+            policy,
+        });
+        assert!(loaded.diagnostics.is_empty(), "{:?}", loaded.diagnostics);
+        loaded.session.expect("migration artifact loads")
+    };
+    let default_session = load(None);
+    assert_eq!(
+        search_ids(&search(
+            &default_session,
+            lexical_query("", 10, SearchFilters::default())
+        )),
+        ["migration.public"]
+    );
+    for id in [
+        "migration.internal",
+        "migration.restricted",
+        "migration.direct",
+        "migration.transitive",
+    ] {
+        assert!(
+            why_object(&default_session, id).records.is_empty(),
+            "default deny: {id}"
+        );
+    }
+
+    let guide = include_str!("../../../docs/agent/v0/tool-guide.md");
+    let config_example = guide
+        .split("```yaml\n")
+        .skip(1)
+        .map(|block| block.split("```").next().unwrap())
+        .find(|block| block.contains("audience: restricted"))
+        .expect("tool guide must document the all-classes retrieval policy");
+    let policy = adoc_core::parse_project_config(&format!(
+        "version: 1\nmode: strict\ndocs_path: docs\n{config_example}"
+    ))
+    .expect("documented config parses")
+    .retrieval_policy
+    .expect("documented retrieval policy");
+    assert_eq!(policy.audience, "restricted");
+    assert_eq!(
+        policy.allowed_visibilities,
+        ["public", "internal", "restricted"]
+            .into_iter()
+            .map(String::from)
+            .collect()
+    );
+    assert!(policy.excluded_object_ids.is_empty());
+    let restored = load(Some(policy));
+    let ids = [
+        "migration.direct",
+        "migration.internal",
+        "migration.public",
+        "migration.restricted",
+        "migration.transitive",
+    ];
+    assert_eq!(
+        search_ids(&search(
+            &restored,
+            lexical_query("", 10, SearchFilters::default())
+        )),
+        ids
+    );
+    for id in ids {
+        assert_eq!(why_object(&restored, id).records.len(), 1, "restored: {id}");
+    }
+    assert_eq!(
+        why_object(&restored, "migration.direct").records[0]
+            .relations
+            .depends_on,
+        ["migration.internal"]
+    );
+    assert_eq!(
+        why_object(&restored, "migration.transitive").records[0]
+            .relations
+            .depends_on,
+        ["migration.direct"]
+    );
+}
+
+#[test]
+fn nonstructural_source_errors_fail_closed_without_raw_diagnostics() {
+    let public = retrieval_search_object(
+        "billing.public",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/public.adoc",
+        "Shared credits.",
+    );
+    let mut internal = retrieval_search_object(
+        "billing.internal",
+        "claim",
+        Some("draft"),
+        None,
+        "docs/internal.adoc",
+        "Private credits.",
+    );
+    internal["visibility"] = json!("internal");
+    let artifact = write_temp_artifact("nonstructural-source-errors", &json!({
+        "schema_version":"adoc.graph.v6", "repository_identity":null,
+        "nodes":[public, internal], "edges":[], "diagnostics":[
+            {"code":"schema.unknown_field", "severity":"error", "object_id":"billing.public",
+             "message":"raw-private-schema-payload names billing.internal", "help":"raw-private-schema-payload"},
+            {"code":"schema.unknown_field", "severity":"error", "object_id":"billing.internal",
+             "message":"raw-private-schema-payload"}
+        ]
+    }).to_string());
+    let loaded = load_retrieval_session(RetrievalInput {
+        artifact_path: artifact.path().to_path_buf(),
+        search_artifact_path: None,
+        policy: None,
+    });
+    assert!(
+        loaded.session.is_none(),
+        "carried errors must refuse retrieval"
+    );
+    assert_eq!(loaded.diagnostics.len(), 1);
+    let diagnostic = &loaded.diagnostics[0];
+    assert_eq!(
+        diagnostic.code,
+        DiagnosticCode::RetrievalVisibilityUnavailable
+    );
+    assert_eq!(diagnostic.severity, adoc_core::Severity::Error);
+    let help = diagnostic.help.as_deref().expect("safe repair guidance");
+    assert!(
+        help.contains("adoc check") && help.contains("adoc build"),
+        "{help}"
+    );
+    let encoded = serde_json::to_string(&loaded.diagnostics).unwrap();
+    assert!(!encoded.contains("raw-private-schema-payload"));
+    assert!(!encoded.contains("billing.internal"));
 }

--- a/crates/adoc-core/tests/retrieval_artifact_diagnostics.rs
+++ b/crates/adoc-core/tests/retrieval_artifact_diagnostics.rs
@@ -1,0 +1,111 @@
+use std::path::PathBuf;
+
+use adoc_core::{
+    DiagnosticCode, RetrievalInput, RetrievalLoadResult, Severity, load_retrieval_session,
+};
+use serde_json::{Value, json};
+
+const SENTINEL: &str = "raw-private-decode-payload";
+
+fn load_bad_artifact(search: bool, unsupported: bool) -> (PathBuf, RetrievalLoadResult) {
+    let workspace = tempfile::tempdir().unwrap();
+    let graph_path = workspace.path().join("caller-selected.graph.json");
+    let search_path = workspace.path().join("caller-selected.search.json");
+    let graph = json!({
+        "schema_version": "adoc.graph.v6", "repository_identity": null,
+        "nodes": [], "edges": [], "diagnostics": []
+    });
+    std::fs::write(&graph_path, graph.to_string()).unwrap();
+    let mut document = if search {
+        json!({
+            "schema_version": "adoc.search.v2",
+            "model": {"id": "fixture", "provider": "fixture", "dim": 1},
+            "graph_artifact_hash": "sha256:fixture", "embeddings": []
+        })
+    } else {
+        graph
+    };
+    if unsupported {
+        document["schema_version"] = json!(SENTINEL);
+    } else {
+        document[if search { "model" } else { "nodes" }] = json!(SENTINEL);
+    }
+    let selected_path = if search { &search_path } else { &graph_path };
+    std::fs::write(selected_path, document.to_string()).unwrap();
+    let loaded = load_retrieval_session(RetrievalInput {
+        artifact_path: graph_path.clone(),
+        search_artifact_path: search.then_some(search_path.clone()),
+        policy: None,
+    });
+    if search {
+        assert!(!loaded.session.as_ref().unwrap().has_semantic_index());
+    } else {
+        assert!(loaded.session.is_none());
+    }
+    (selected_path.clone(), loaded)
+}
+
+fn assert_safe_diagnostic(search: bool, unsupported: bool, expected_help: &str) {
+    let (path, loaded) = load_bad_artifact(search, unsupported);
+    let [diagnostic] = loaded.diagnostics.as_slice() else {
+        panic!("expected one reader diagnostic: {:?}", loaded.diagnostics);
+    };
+    assert_eq!(diagnostic.severity, Severity::Error);
+    assert_eq!(
+        diagnostic.code,
+        if unsupported {
+            DiagnosticCode::SchemaUnsupportedVersion
+        } else {
+            DiagnosticCode::IoArtifactMalformed
+        },
+    );
+    let encoded: Value = serde_json::to_value(diagnostic).unwrap();
+    assert!(!encoded.to_string().contains(SENTINEL), "{encoded}");
+    assert_eq!(
+        (
+            diagnostic.message.contains(path.to_str().unwrap()),
+            diagnostic.help.as_deref()
+        ),
+        (true, Some(expected_help)),
+        "retain the caller-selected path and trusted reader remediation: {encoded}",
+    );
+}
+
+#[test]
+fn malformed_graph_names_selected_path_and_preserves_graph_rebuild_help() {
+    assert_safe_diagnostic(
+        false,
+        false,
+        "Rebuild docs.graph.json from the source workspace.",
+    );
+}
+
+#[test]
+fn malformed_search_names_selected_path_and_preserves_search_rebuild_help() {
+    assert_safe_diagnostic(
+        true,
+        false,
+        "Rebuild docs.search.json from the source workspace.",
+    );
+}
+
+#[test]
+fn unsupported_graph_names_selected_path_and_preserves_safe_version_guidance() {
+    assert_safe_diagnostic(
+        false,
+        true,
+        &format!(
+            "Expected schema_version 'adoc.graph.v6'. {}",
+            DiagnosticCode::SchemaUnsupportedVersion.default_help(),
+        ),
+    );
+}
+
+#[test]
+fn unsupported_search_names_selected_path_and_preserves_safe_version_guidance() {
+    assert_safe_diagnostic(
+        true,
+        true,
+        "Expected schema_version 'adoc.search.v2'. Rebuild the artifact with `adoc build`.",
+    );
+}

--- a/crates/adoc-core/tests/v1_4_semantic_load.rs
+++ b/crates/adoc-core/tests/v1_4_semantic_load.rs
@@ -21,6 +21,7 @@ fn force_deterministic_provider() {
 fn missing_search_artifact_warns_and_disables_semantic() {
     force_deterministic_provider();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: fixture("hash_drift.graph.json"),
         search_artifact_path: Some(fixture("not_present.search.json")),
     });
@@ -41,6 +42,7 @@ fn missing_search_artifact_warns_and_disables_semantic() {
 fn mismatched_model_emits_error_and_disables_semantic() {
     force_deterministic_provider();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: fixture("hash_drift.graph.json"),
         search_artifact_path: Some(fixture("model_mismatch.search.json")),
     });
@@ -59,16 +61,17 @@ fn mismatched_model_emits_error_and_disables_semantic() {
 
 #[test]
 #[serial(env_provider)]
-fn hash_drift_warns_but_keeps_semantic_index_loaded() {
+fn unrelated_hash_drift_keeps_current_semantic_entries_loaded() {
     force_deterministic_provider();
     let result = load_retrieval_session(RetrievalInput {
+        policy: None,
         artifact_path: fixture("hash_drift.graph.json"),
         search_artifact_path: Some(fixture("hash_drift.search.json")),
     });
     let session = result.session.expect("session loads");
     assert!(
         session.has_semantic_index(),
-        "drift must NOT disable semantic"
+        "unrelated graph drift must preserve current composition-bound vectors"
     );
     let drift = result
         .diagnostics

--- a/crates/adoc-local/src/config.rs
+++ b/crates/adoc-local/src/config.rs
@@ -22,6 +22,7 @@ pub struct ProjectConfig {
     /// only bites opted-in projects; deliberately no version bump).
     pub mcp_patch_apply_enabled: bool,
     pub assessment_exclude_paths: Vec<String>,
+    pub retrieval_policy: Option<adoc_core::RetrievalPolicy>,
 }
 
 #[derive(Debug, Clone, Default)]
@@ -90,6 +91,7 @@ impl ProjectConfig {
             embeddings_provider: parsed.embeddings_provider,
             mcp_patch_apply_enabled: parsed.mcp_patch_apply_enabled,
             assessment_exclude_paths: parsed.assessment_exclude_paths,
+            retrieval_policy: parsed.retrieval_policy,
         })
     }
 }

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -832,22 +832,25 @@ where
 
 /// The shared read-command prefix (ADR-0038: every artifact reader locates
 /// the Graph Artifact the same way): resolve an explicit `--artifact` through
-/// the path policy, discover project config only when no explicit path was
-/// given, resolve the effective artifact path, and gate the final path
-/// through the policy again.
+/// the path policy, discover config when artifact defaults or retrieval policy
+/// require it, and gate the final artifact path through the path policy again.
 fn resolve_graph_artifact_for_read<P>(
     context: &LocalContext<P>,
     artifact_arg: Option<&Path>,
-) -> Result<PathBuf, LocalError>
+    needs_retrieval_policy: bool,
+) -> Result<(PathBuf, Option<ProjectConfig>), LocalError>
 where
     P: PathPolicy,
 {
     let artifact = artifact_arg
         .map(|path| context.path_policy().resolve_read_path(path))
         .transpose()?;
-    let config = discover_project_config_if(artifact.is_none(), context.config_start())?;
+    let config = discover_project_config_if(
+        artifact.is_none() || needs_retrieval_policy,
+        context.config_start(),
+    )?;
     let artifact = resolve_graph_artifact_path_with_config(artifact, config.as_ref());
-    context.path_policy().resolve_read_path(&artifact)
+    Ok((context.path_policy().resolve_read_path(&artifact)?, config))
 }
 
 /// Load the graph session for a read command. The session is usable only
@@ -870,11 +873,13 @@ fn why_with_context<P>(context: &LocalContext<P>, input: WhyInput) -> Result<Why
 where
     P: PathPolicy,
 {
-    let artifact = resolve_graph_artifact_for_read(context, input.artifact.as_deref())?;
+    let (artifact, config) =
+        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), true)?;
     let load_result = load_retrieval_session_with_embedding_provider(
         RetrievalInput {
             artifact_path: artifact.clone(),
             search_artifact_path: None,
+            policy: config.and_then(|config| config.retrieval_policy),
         },
         EmbeddingProviderSelection::Local,
     );
@@ -920,7 +925,8 @@ fn graph_with_context<P>(
 where
     P: PathPolicy,
 {
-    let graph_artifact = resolve_graph_artifact_for_read(context, input.artifact.as_deref())?;
+    let (graph_artifact, _) =
+        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), false)?;
     let (session, mut diagnostics) = load_graph_session_for_query(graph_artifact);
     let Some(session) = session else {
         let exit_code = graph_exit_code_for_diagnostics(&diagnostics);
@@ -965,7 +971,8 @@ fn stale_with_context<P>(
 where
     P: PathPolicy,
 {
-    let graph_artifact = resolve_graph_artifact_for_read(context, input.artifact.as_deref())?;
+    let (graph_artifact, _) =
+        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), false)?;
     let (session, diagnostics) = load_graph_session_for_query(graph_artifact);
     let Some(session) = session else {
         let exit_code = signal_query_exit_code(&diagnostics);
@@ -990,7 +997,8 @@ fn contradictions_with_context<P>(
 where
     P: PathPolicy,
 {
-    let graph_artifact = resolve_graph_artifact_for_read(context, input.artifact.as_deref())?;
+    let (graph_artifact, _) =
+        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), false)?;
     let (session, diagnostics) = load_graph_session_for_query(graph_artifact);
     let Some(session) = session else {
         let exit_code = signal_query_exit_code(&diagnostics);
@@ -1040,7 +1048,8 @@ where
         }
     };
 
-    let graph_artifact = resolve_graph_artifact_for_read(context, input.artifact.as_deref())?;
+    let (graph_artifact, _) =
+        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), false)?;
     let (session, diagnostics) = load_graph_session_for_query(graph_artifact);
     let Some(session) = session else {
         let exit_code = impacted_exit_code(&diagnostics);
@@ -1083,19 +1092,20 @@ where
         .as_deref()
         .map(|path| context.path_policy().resolve_read_path(path))
         .transpose()?;
-    let needs_search_config = matches!(requested_mode, SearchMode::Hybrid | SearchMode::Semantic)
-        && search_artifact.is_none();
-    let config = discover_project_config_if(
-        artifact.is_none() || needs_search_config,
-        context.config_start(),
-    )?;
-    let embedding_provider = resolve_embedding_provider_selection(config.as_ref());
-    let artifact = resolve_graph_artifact_path_with_config(artifact, config.as_ref());
+    // An explicit artifact changes the data source, never the policy source.
+    let config = ProjectConfig::discover_from(context.config_start())?;
+    // Policy discovery must not change the historical provider/path defaults
+    // for a search whose relevant artifact paths are all explicit.
+    let defaults_config = config.as_ref().filter(|_| {
+        artifact.is_none() || (requested_mode != SearchMode::Lexical && search_artifact.is_none())
+    });
+    let embedding_provider = resolve_embedding_provider_selection(defaults_config);
+    let artifact = resolve_graph_artifact_path_with_config(artifact, defaults_config);
     let artifact = context.path_policy().resolve_read_path(&artifact)?;
     let search_artifact_path = match requested_mode {
         SearchMode::Lexical => None,
         SearchMode::Hybrid | SearchMode::Semantic => {
-            let path = resolve_search_artifact_path_with_config(search_artifact, config.as_ref());
+            let path = resolve_search_artifact_path_with_config(search_artifact, defaults_config);
             Some(context.path_policy().resolve_read_path(&path)?)
         }
     };
@@ -1103,6 +1113,9 @@ where
         RetrievalInput {
             artifact_path: artifact,
             search_artifact_path,
+            policy: config
+                .as_ref()
+                .and_then(|config| config.retrieval_policy.clone()),
         },
         embedding_provider,
     );
@@ -1119,7 +1132,7 @@ where
         diagnostics.push(Diagnostic {
             code: DiagnosticCode::SearchArtifactMissing,
             severity: Severity::Error,
-            message: "Semantic search requested but no search artifact is loaded.".to_string(),
+            message: "Semantic search requested but no usable search index is loaded.".to_string(),
             span: None,
             object_id: None,
             help: Some(
@@ -1341,7 +1354,8 @@ where
         .as_of
         .unwrap_or_else(|| chrono::Utc::now().date_naive());
     let patch_path = context.path_policy().resolve_read_path(&input.patch_path)?;
-    let graph_artifact = resolve_graph_artifact_for_read(context, input.artifact.as_deref())?;
+    let (graph_artifact, _) =
+        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), false)?;
     let result = core_check_patch(PatchInput {
         graph_artifact_path: graph_artifact,
         patch_path,

--- a/docs/adr/0065-permission-filtered-retrieval-session.md
+++ b/docs/adr/0065-permission-filtered-retrieval-session.md
@@ -1,0 +1,102 @@
+# ADR-0065: Permission-Filtered Retrieval Session
+
+- Status: Accepted
+- Date: 2026-09-05
+- Slice: E6.1.T1
+
+## Context
+
+E6.1 requires authorization before retrieval candidate generation. Filtering
+responses in each adapter would leave ranking and graph-derived metadata able
+to reveal excluded Knowledge Objects. Explicit artifact paths must not bypass
+local policy discovery.
+
+## Decision
+
+The core Retrieval Session assembles its graph, lexical index, and vector
+index from an authorized projection. Its permission predicate consumes only
+the loaded Graph Artifact and explicit policy data; it performs no I/O and
+reads no clock or environment. Authored `agent_instruction` content never
+grants permission.
+
+Standalone CLI and MCP policy comes from `agentdoc.config.yaml`, including
+when a caller supplies `--artifact`. The optional `retrieval_policy` block
+names an explicit audience, allowed visibility classes from the existing
+`public | internal | restricted` vocabulary, and excluded Object IDs. This
+local configuration is trusted operator input, not authentication for a
+multi-user service. Cloud must resolve current Workspace authorization and
+source ACL ceilings before supplying policy to the same core predicate.
+
+Excluded objects are absent from the search/why result corpus, including an
+explicit ID lookup. No permission-denied diagnostic confirms their existence.
+Invalid policy or unresolved visibility fails closed. Current artifacts
+without visibility fields and without a policy keep their result corpus.
+Without policy, only public/unclassified objects are permitted; internal and
+restricted objects require an explicit authorized policy. This intentionally
+activates enforcement for the visibility carriage shipped in E1.1. Removing
+an explicit exclusion restores an otherwise-public object, not a grant to
+restricted content. An explicit deny takes precedence over an allowed visibility class.
+
+Sensitive-access delivery is implemented in E6.3. The local-CLI audit scope
+is being reconciled between the product amendment and E6.3.T1 before that
+bullet begins. This first tracer does not claim completed Cloud retrieval,
+graph-driver closure, field redaction, or sensitive-access delivery.
+
+## Consequences
+
+The policy is enforced before retrieval scoring, so hidden records cannot
+change ranks. Adapters load policy but do not implement permission filters.
+The E6.1.T1 CLI regression covers both `search` and `why` with an explicit
+artifact and proves that removing a policy exclusion restores the object.
+Records whose source metadata refers to excluded IDs are withheld whole,
+including their precomputed vectors. Each retained vector must also match the
+current carrier kind and the existing Embedding Composition hash; stale vectors
+are discarded while current vectors survive unrelated graph hash drift. Hash-covered fields and embedding inputs
+are never partially scrubbed while retaining the old content hash or vector.
+The closure checks complete Knowledge Object and prose block nodes, including
+non-response fields that contribute to hashes. Page nodes are not retrieval
+records and are outside this scan. Partial-field retrieval is E6.2 work.
+`graph`, `stale`, `contradictions`, and `impacted-by` still expose unfiltered
+artifact data in this tracer; E6.1.T3 closes those paths. This is not yet a
+complete privacy boundary. The tool guide includes the visibility upgrade
+notice and an explicit all-classes local policy recipe for valid classifications.
+That recipe cannot bypass `schema.visibility_invalid`; source repair and rebuild
+remain required. A CLI control pins unfiltered graph reads under an explicit
+exclusion policy for T1; T3 replaces that assertion with policy exclusion.
+
+Untrusted artifact decoder text is sanitized even without a policy: decoding
+can fail before authored visibility is known. Projected reads omit artifact
+warnings, which can quote denied content without an Object ID. Conditional
+warning withholding is not yet whole-response presence/absence parity:
+E6.1.T3 must close that diagnostic signal along with graph drivers, counts,
+and timing. Adding a new conditional warning or retaining unauthenticated
+warning prose by substring alone does not establish that property. When visibility
+or explicit policy supplies excluded IDs, carried build errors refuse the session
+with one generic `retrieval.visibility_unavailable` Error and check/build guidance;
+original diagnostic details and counts are withheld. For these artifact errors,
+search and why return no records and exit 2. With no excluded IDs, legacy carried diagnostics
+and refusal on errors remain unchanged pending the T3 compatibility decision.
+The all-public/no-policy CLI control also returns no records and exit 2 for
+carried source errors; classification changes diagnostic disclosure, not the
+existing refusal behavior.
+Structural corruption or a carried `schema.visibility_invalid` diagnostic
+still refuses the session, even without policy: missing metadata cannot be
+assumed public after a producer reports classification failure. Full build
+diagnostics remain available to the trusted artifact operator. Search-artifact
+model mismatch and hash drift use fixed message shapes with no corpus hashes
+or artifact-controlled model text, regardless of whether filtering changed data.
+If some permitted vectors are stale, semantic search retains the valid vectors
+and exits 0 with a warning that semantic results may be incomplete; hybrid search
+can retrieve changed carriers through lexical matching. If stale bindings leave
+no usable permitted vectors, semantic search refuses and hybrid falls back to
+lexical search. Withheld or absent carriers alone do not cause this refusal.
+Model errors retain the trusted active-provider identity. Decoder errors retain
+the caller-selected artifact path and trusted reader-supplied rebuild guidance,
+while suppressing artifact-controlled version values and decoder payload text.
+
+E6.1.T2 owns typed policy errors through config parsing and response assembly;
+T1 validates policy values at retrieval-session assembly. A generic config
+error conversion would lose T2's required audience/policy distinction.
+E6.1.T3's performance gate must measure default-deny classified repositories
+as well as explicit policies. Borrowed validation and fewer repeated scans
+are measured optimizations for that gate; T1 keeps the conservative projection.

--- a/docs/agent/v0/tool-guide.md
+++ b/docs/agent/v0/tool-guide.md
@@ -11,3 +11,82 @@ V2.2 MCP tools are the supported local agent workflow for AgentDoc projects.
 5. `adoc_patch_check` for any proposed `adoc.patch.v0` document.
 
 `refresh: "build"` follows the same local build behavior as `adoc_build`. Embeddings honor project config unless `no_embeddings` is true. If project status returns artifact diagnostics, carry them into the answer or handoff; `search.deterministic_quality` means the project is using repeatable hash embeddings rather than semantic-model quality.
+
+## Standalone retrieval policy (E6.1.T1)
+
+`search` and `why` discover local retrieval policy even with an explicit
+`--artifact`. For example, an operator can configure:
+
+```yaml
+retrieval_policy:
+  audience: public
+  allowed_visibilities: [public]
+  excluded_object_ids: [billing.internal-runbook]
+```
+
+This block belongs in the existing `agentdoc.config.yaml`. It narrows the
+`search` and `why` corpus before ranking; excluded IDs behave like absent IDs
+on those paths. Local
+policy is trusted operator configuration, not a multi-user authentication
+boundary. Unknown policy keys fail closed. Existing unclassified repositories
+without the block preserve their existing retrieval behavior.
+
+This first projection conservatively matches denied ID text in complete
+Knowledge Objects and prose blocks. That can also withhold namespace descendants,
+similarly prefixed IDs, or records citing them (for example, excluding `billing.target`
+can withhold `billing.target-rules`). It does not rewrite governed statements.
+Each Knowledge Object and prose block is checked in full, including metadata
+that contributes to its hash or embedding. Page nodes are not retrieval records
+and are outside this scan. A withheld carrier's precomputed vector is also
+removed; retained records keep their original source fields and content hashes. Vectors
+are admitted only when their kind and Embedding Composition hash match the
+current record; rebuild a stale search artifact to restore missing vectors.
+When only some permitted vectors are stale, semantic search uses the remaining
+valid vectors and exits 0 with a `search.hash_drift` warning that semantic results
+may be incomplete. Hybrid search can still retrieve changed records through
+lexical matching. Rebuild the search artifact to restore semantic coverage.
+If stale bindings leave no usable vectors for permitted records, `--semantic`
+fails with `search.artifact_missing` and exit 2; hybrid search uses lexical
+results. An empty corpus caused only by withheld or absent records does not
+trigger this stale-index failure.
+
+E6.1.T1 enforces this policy on `search` and `why` only. `graph`, `stale`,
+`contradictions`, and `impacted-by` still read the unfiltered artifact until
+the graph-driver tracer E6.1.T3 lands. A CLI regression explicitly pins this
+transitional unfiltered graph behavior; T3 must replace that assertion with
+policy exclusion. MCP gateway parity follows in E6.1.T4.
+T1 also withholds artifact warnings when records are excluded; diagnostic
+presence/absence parity is part of T3's whole-response closure, not a T1 guarantee.
+When visibility or explicit policy supplies excluded IDs, carried source errors
+refuse retrieval with one generic `retrieval.visibility_unavailable` error and
+`adoc check` / `adoc build` guidance. Search and why return no records and exit 2.
+With no excluded IDs, legacy carried diagnostics and CLI refusal on carried
+errors remain unchanged pending T3’s diagnostics compatibility decision.
+An all-public corpus with carried source errors also returns no records and
+exit 2; adding an internal object changes diagnostic disclosure, not availability.
+Structural corruption or a carried `schema.visibility_invalid` diagnostic still
+refuses retrieval, even without a configured policy.
+
+Upgrade note: objects already authored with `visibility: internal` or
+`visibility: restricted` now require an explicit policy to appear in `search`
+and `why`. Without that policy, public or unclassified objects can also
+disappear when their serialized content refers to denied objects. This includes
+relation targets, fields, evidence references or text, and contradiction claim
+IDs. The whole object is withheld; its fields are not partially redacted while
+its old hash or vector remains available. Withholding is transitive: if public
+object A depends on internal object B, and public object C depends on A, the
+default policy withholds B, A, and C.
+
+A trusted local operator authorized for all three classes can replace the
+retrieval policy with the following block in `agentdoc.config.yaml`. It restores
+internal/restricted objects and their public dependents by authorizing every
+visibility class and clearing explicit exclusions. This recipe applies to valid
+classifications; `schema.visibility_invalid` still requires source repair and a
+rebuild:
+
+```yaml
+retrieval_policy:
+  audience: restricted
+  allowed_visibilities: [public, internal, restricted]
+  excluded_object_ids: []
+```

--- a/docs/guides/graph-v6-migration.md
+++ b/docs/guides/graph-v6-migration.md
@@ -6,6 +6,12 @@ rejected with `schema.unsupported_version` — there is no tolerant
 dual-version reader. Artifacts are derived outputs, so migration is
 deterministic regeneration from source, never an in-place transform.
 
+`adoc search` and `adoc why` no longer echo the artifact-supplied schema
+version or raw decoder payloads. Their diagnostics name the caller-selected
+artifact path and retain `schema.unsupported_version` plus safe rebuild
+guidance, including the expected supported version. Trusted graph-artifact
+inspection can still name the version found in the artifact.
+
 ## Regenerate
 
 ```bash

--- a/docs/roadmap/v10/CONTRACT-REGISTRY.md
+++ b/docs/roadmap/v10/CONTRACT-REGISTRY.md
@@ -241,8 +241,11 @@ Explicit mapping (RT-21, like the attestation family): `audit.persistence_failed
 | `proposal_record.patch_invalid` |
 | `proposal_record.revision_unchanged` |
 | `ref.broken` |
+| `retrieval.audience_unresolved` |
 | `retrieval.no_knowledge_objects_consider_migration` |
 | `retrieval.object_not_found` |
+| `retrieval.policy_invalid` |
+| `retrieval.visibility_unavailable` |
 | `schema.agent_instruction_actions_not_disjoint` |
 | `schema.agent_instruction_invalid_trust` |
 | `schema.agent_instruction_missing_allowed_actions` |


### PR DESCRIPTION
Implements **E6.1.T1**: `search` and `why` apply retrieval policy in core session assembly before candidate generation. An explicit `--artifact` no longer bypasses project policy. Current unclassified artifacts retain their result corpus; internal/restricted records require an explicit authorized local policy.

Source records naming denied IDs are withheld whole and transitively, preserving source hash integrity. Vectors must match the permitted carrier kind and existing embedding-composition hash. Partially stale indexes warn that semantic results may be incomplete. Fully stale permitted indexes fail explicitly in semantic mode and fall back to lexical results in hybrid mode; excluded and absent corpora keep identical empty-index behavior. Artifact errors retain the existing refusal contract, with safe diagnostics and repair guidance. ADR-0065 and the tool guide describe the boundary and the all-classes upgrade recipe.

Validation: **2,721 workspace tests passed**, including equal-manifest stale-binding checks, real-build partial/full stale-vector CLI regressions, current-vector retention on unrelated drift, JSON/plain artifact-error refusals, metadata closure, and explicit-artifact config/provider compatibility. Formatting, Clippy with warnings denied, and documentation build passed. Independent local Codex and plugin-free Claude `-p --safe-mode` reviews completed without remaining T1 findings.

Stack: first E06 PR in `adoc`, based on `main`; the next tracer is E6.1.T2. Typed malformed-input assembly, whole-response diagnostic/timing parity, graph-driver closure, managed Cloud retrieval, field visibility, and sensitive audit remain separate later tracers.
