### PR TITLE
feat(core): return typed retrieval policy failures (E6.1.T2)

### DIFF
--- a/crates/adoc-cli/tests/assess_changes_cli.rs
+++ b/crates/adoc-cli/tests/assess_changes_cli.rs
@@ -51,6 +51,115 @@ fn repo() -> TestWorkspace {
 }
 
 #[test]
+#[cfg(unix)]
+fn assessment_does_not_skip_unreadable_child_config_for_parent_policy() {
+    let workspace = repo();
+    let config_path = workspace.root.join("agentdoc.config.yaml");
+    let mut config = std::fs::read_to_string(&config_path).expect("config readable");
+    config.push_str("retrieval_policy:\n  audience: restricted\n  allowed_visibilities: [public, internal, restricted]\n");
+    workspace.write("agentdoc.config.yaml", &config);
+    git(&workspace, &["add", "-A"]);
+    git(&workspace, &["commit", "-m", "parent policy"]);
+    let child = workspace.root.join("child");
+    std::fs::create_dir(&child).expect("child directory created");
+    let candidate = child.join("agentdoc.config.yaml");
+
+    for directory in [false, true] {
+        if directory {
+            std::fs::create_dir(&candidate).expect("config directory created");
+        } else {
+            std::os::unix::fs::symlink("missing-policy.yaml", &candidate)
+                .expect("dangling config created");
+        }
+        let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .current_dir(&child)
+            .args([
+                "assess-changes",
+                "--base",
+                "HEAD",
+                "--as-of",
+                "2026-07-22",
+                "--format",
+                "json",
+            ])
+            .output()
+            .expect("adoc assess-changes runs");
+        let value: serde_json::Value =
+            serde_json::from_slice(&output.stdout).expect("assessment JSON");
+        assert_eq!(output.status.code(), Some(2), "{value:#}");
+        assert_eq!(value["completeness"], "error");
+        assert_eq!(value["outcome"], "invalid");
+        assert_eq!(value["diagnostics"][0]["code"], "assessment.head_invalid");
+        assert_eq!(value["assessment_config"]["head"]["status"], "unavailable");
+        assert!(value["assessment_config"]["sha256"].is_null());
+        if directory {
+            std::fs::remove_dir(&candidate).expect("config directory removed");
+        } else {
+            std::fs::remove_file(&candidate).expect("dangling config removed");
+        }
+    }
+}
+
+#[test]
+#[cfg(unix)]
+fn pinned_assessment_and_baseline_use_snapshot_config_with_unreadable_worktree_config() {
+    let workspace = repo();
+    workspace.write(
+        "child/agentdoc.config.yaml",
+        "version: 1\nmode: strict\ndocs_path: docs\nembeddings:\n  provider: none\nretrieval_policy:\n  audience: public\n  allowed_visibilities: [public]\n",
+    );
+    workspace.write(
+        "child/docs/index.adoc",
+        "# Child @doc(team.child)\n\n::claim child.rule\nstatus: draft\n--\nChild rule.\n::\n",
+    );
+    git(&workspace, &["add", "-A"]);
+    git(&workspace, &["commit", "-m", "nested project"]);
+    let child = workspace.root.join("child");
+    let run = |args: &[&str]| {
+        let output = Command::new(env!("CARGO_BIN_EXE_adoc"))
+            .current_dir(&child)
+            .args(args)
+            .args(["--as-of", "2026-07-22", "--format", "json"])
+            .output()
+            .expect("assessment command runs");
+        assert!(
+            output.status.success(),
+            "{args:?}: {}\n{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        output.stdout
+    };
+    let commands: [&[&str]; 2] = [
+        &["assess-changes", "--base", "HEAD", "--head", "HEAD"],
+        &["baseline", "--ref", "HEAD"],
+    ];
+    let expected = commands.map(run);
+    let candidate = child.join("agentdoc.config.yaml");
+    std::fs::remove_file(&candidate).expect("worktree config removed");
+    for directory in [false, true] {
+        if directory {
+            std::fs::create_dir(&candidate).expect("config directory created");
+        } else {
+            std::os::unix::fs::symlink("missing-policy.yaml", &candidate)
+                .expect("dangling config created");
+        }
+        for (args, expected) in commands.iter().zip(&expected) {
+            assert_eq!(
+                run(args),
+                *expected,
+                "{args:?} must use the snapshot config"
+            );
+        }
+        if directory {
+            std::fs::remove_dir(&candidate).expect("config directory removed");
+        } else {
+            std::fs::remove_file(&candidate).expect("dangling config removed");
+        }
+    }
+}
+
+#[test]
 fn assessment_supports_a_project_below_the_repository_root() {
     let workspace = TestWorkspace::new("assess-changes-nested-project");
     git(&workspace, &["init", "--initial-branch=main"]);

--- a/crates/adoc-cli/tests/config_cli.rs
+++ b/crates/adoc-cli/tests/config_cli.rs
@@ -476,6 +476,37 @@ fn config_why_and_search_use_configured_artifacts_unless_args_are_explicit() {
 }
 
 #[test]
+fn config_policy_errors_refuse_non_retrieval_commands_at_exit_one() {
+    let workspace = TestWorkspace::new("config-policy-build-errors");
+    write_valid_source(&workspace, "docs/index.adoc");
+    for (policy, code) in [
+        ("null", "retrieval.policy_invalid"),
+        (
+            "{audience: bogus, allowed_visibilities: [public]}",
+            "retrieval.audience_unresolved",
+        ),
+    ] {
+        workspace.write(
+            "agentdoc.config.yaml",
+            &format!("version: 1\nmode: strict\ndocs_path: docs\noutputs:\n  dir: dist\nretrieval_policy: {policy}\n"),
+        );
+        for command in ["build", "check"] {
+            let output = adoc_command()
+                .current_dir(&workspace.root)
+                .arg(command)
+                .output()
+                .expect("CLI runs");
+            assert_eq!(output.status.code(), Some(1), "{command}: {output:?}");
+            assert!(
+                stderr(&output).contains(&format!("error[{code}]")),
+                "{command}: {output:?}"
+            );
+            assert!(!workspace.root.join("dist").exists());
+        }
+    }
+}
+
+#[test]
 fn config_invalid_mode_provider_and_version_exit_with_config_errors() {
     let cases = [
         (

--- a/crates/adoc-cli/tests/explicit_artifact_config_cli.rs
+++ b/crates/adoc-cli/tests/explicit_artifact_config_cli.rs
@@ -57,8 +57,16 @@ fn explicit_artifacts_ignore_broken_config_only_for_non_policy_drivers() {
         workspace.write("agentdoc.config.yaml", "version: [\n");
         let explicit = run(true);
         if needs_policy {
-            assert!(!explicit.status.success(), "{args:?} must discover policy");
-            assert!(stderr(&explicit).contains("config.parse"));
+            assert_eq!(
+                explicit.status.code(),
+                Some(2),
+                "{args:?} must discover policy"
+            );
+            let envelope: Value = serde_json::from_slice(&explicit.stdout).unwrap();
+            assert_eq!(
+                envelope["diagnostics"][0]["code"],
+                "retrieval.policy_invalid"
+            );
         } else {
             assert!(explicit.status.success(), "{args:?}: {}", stderr(&explicit));
             assert_eq!(
@@ -72,7 +80,16 @@ fn explicit_artifacts_ignore_broken_config_only_for_non_policy_drivers() {
             !implicit.status.success(),
             "{args:?} must resolve config defaults"
         );
-        assert!(stderr(&implicit).contains("config.parse"));
+        if needs_policy {
+            assert_eq!(implicit.status.code(), Some(2));
+            let envelope: Value = serde_json::from_slice(&implicit.stdout).unwrap();
+            assert_eq!(
+                envelope["diagnostics"][0]["code"],
+                "retrieval.policy_invalid"
+            );
+        } else {
+            assert!(stderr(&implicit).contains("config.parse"));
+        }
         fs::remove_file(workspace.root.join("agentdoc.config.yaml")).unwrap();
     }
 }

--- a/crates/adoc-cli/tests/patch_cli.rs
+++ b/crates/adoc-cli/tests/patch_cli.rs
@@ -312,6 +312,161 @@ fn patch_help_lists_check_apply_and_artifact_flags() {
     assert!(stdout.contains("adoc patch --apply patch.json"));
 }
 
+fn patch_visibility_failure_workspace(
+    name: &str,
+    change_graph: impl FnOnce(&mut serde_json::Value),
+) -> TestWorkspace {
+    let workspace = build_apply_workspace(name);
+    let hash = content_hash(&workspace, "billing.credits");
+    workspace.write(
+        "patch.json",
+        &replace_body_patch("billing.credits", &hash).to_string(),
+    );
+    let mut graph: serde_json::Value = serde_json::from_str(
+        &std::fs::read_to_string(workspace.root.join("dist/docs.graph.json"))
+            .expect("graph artifact is readable"),
+    )
+    .expect("graph artifact is JSON");
+    change_graph(&mut graph);
+    workspace.write("dist/docs.graph.json", &graph.to_string());
+    workspace
+}
+
+fn invalidate_graph_visibility(graph: &mut serde_json::Value) {
+    let node = graph["nodes"]
+        .as_array_mut()
+        .expect("nodes array")
+        .iter_mut()
+        .find(|node| node["id"] == "billing.credits")
+        .expect("billing.credits node exists");
+    node["visibility"] = serde_json::Value::Null;
+}
+
+#[test]
+fn patch_check_decoder_visibility_failure_exits_two() {
+    let workspace = patch_visibility_failure_workspace(
+        "patch-check-decoder-visibility",
+        invalidate_graph_visibility,
+    );
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["patch", "--check", "patch.json", "--format", "json"])
+        .output()
+        .expect("adoc patch runs");
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(envelope["valid"], false);
+    assert!(envelope.get("target").is_none());
+    assert_eq!(envelope["operation"], "");
+    assert_eq!(output.status.code(), Some(2), "{}", stdout(&output));
+    assert_eq!(envelope["diagnostics"][0]["code"], "io.artifact_malformed");
+    let help = envelope["diagnostics"][0]["help"]
+        .as_str()
+        .expect("repair guidance");
+    assert!(help.contains("adoc check") && help.contains("adoc build"));
+
+    let inline = adoc_core::check_patch_json(adoc_core::PatchJsonInput {
+        graph_artifact_path: workspace
+            .root
+            .join("dist/docs.graph.json")
+            .canonicalize()
+            .expect("artifact path resolves"),
+        patch: replace_body_patch("billing.credits", "sha256:unused"),
+    });
+    assert_eq!(
+        serde_json::to_value(&inline).expect("inline result serializes")["diagnostics"],
+        envelope["diagnostics"],
+        "path and inline checks must classify the same artifact failure identically"
+    );
+}
+
+#[test]
+fn patch_check_and_apply_carried_visibility_failure_still_exit_one() {
+    let workspace = patch_visibility_failure_workspace("patch-check-carried-visibility", |graph| {
+        // Carried source diagnostics need not have a span or object ID: neither
+        // field is a reliable discriminator for artifact-reader failures.
+        graph["diagnostics"] = serde_json::json!([{
+            "code": "schema.visibility_invalid",
+            "severity": "error",
+            "message": "Authored visibility needs repair.",
+            "span": null,
+            "object_id": null,
+            "help": "Repair the authored visibility."
+        }]);
+    });
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["patch", "--check", "patch.json", "--format", "json"])
+        .output()
+        .expect("adoc patch runs");
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(output.status.code(), Some(1), "{}", stdout(&output));
+    assert_eq!(envelope["valid"], false);
+    assert!(envelope.get("target").is_none());
+    assert_eq!(envelope["operation"], "");
+    assert_eq!(envelope["diagnostics"].as_array().map(Vec::len), Some(1));
+    assert_eq!(
+        envelope["diagnostics"][0]["code"],
+        "schema.visibility_invalid"
+    );
+    assert_eq!(
+        envelope["diagnostics"][0]["message"],
+        "Authored visibility needs repair."
+    );
+
+    let source_path = workspace.root.join("docs/billing.adoc");
+    let original = std::fs::read(&source_path).expect("source readable");
+    let apply = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["patch", "--apply", "patch.json", "--format", "json"])
+        .output()
+        .expect("adoc patch apply runs");
+    let refusal: serde_json::Value = serde_json::from_slice(&apply.stdout).expect("stdout is JSON");
+    assert_eq!(apply.status.code(), Some(1), "{}", stdout(&apply));
+    assert_eq!(refusal["applied"], false);
+    assert_eq!(refusal["written_files"], serde_json::json!([]));
+    assert_eq!(refusal["diagnostics"], envelope["diagnostics"]);
+    assert_eq!(
+        std::fs::read(source_path).expect("source readable"),
+        original
+    );
+}
+
+#[test]
+fn patch_apply_decoder_visibility_failure_refuses_with_exit_one_and_no_write() {
+    let workspace = patch_visibility_failure_workspace(
+        "patch-apply-decoder-visibility",
+        invalidate_graph_visibility,
+    );
+    let source_path = workspace.root.join("docs/billing.adoc");
+    let original = std::fs::read(&source_path).expect("source readable");
+    let output = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["patch", "--apply", "patch.json", "--format", "json"])
+        .output()
+        .expect("adoc patch runs");
+    let envelope: serde_json::Value =
+        serde_json::from_slice(&output.stdout).expect("stdout is JSON");
+    assert_eq!(output.status.code(), Some(1), "{}", stdout(&output));
+    assert_eq!(envelope["applied"], false);
+    assert_eq!(envelope["written_files"], serde_json::json!([]));
+    assert_eq!(envelope["diagnostics"][0]["code"], "io.artifact_malformed");
+    assert_eq!(
+        std::fs::read(source_path).expect("source readable"),
+        original
+    );
+    let check = adoc_command()
+        .current_dir(&workspace.root)
+        .args(["patch", "--check", "patch.json", "--format", "json"])
+        .output()
+        .expect("adoc patch check runs");
+    let check_envelope: serde_json::Value =
+        serde_json::from_slice(&check.stdout).expect("stdout is JSON");
+    assert_eq!(check.status.code(), Some(2));
+    assert_eq!(envelope["diagnostics"], check_envelope["diagnostics"]);
+}
+
 // ---------------------------------------------------------------------------
 // V6.4 TB1 — `adoc patch --apply`
 // ---------------------------------------------------------------------------

--- a/crates/adoc-cli/tests/retrieval_policy_errors_cli.rs
+++ b/crates/adoc-cli/tests/retrieval_policy_errors_cli.rs
@@ -1,0 +1,147 @@
+mod support;
+
+use std::{fs, process::Command};
+
+use serde_json::Value;
+use support::{TestWorkspace, fixture_path};
+
+const CONFIG: &str =
+    "version: 1\nmode: strict\ndocs_path: .\noutputs:\n  graph: dist/docs.graph.json\n";
+
+fn assert_refusal(workspace: &TestWorkspace, code: &str) {
+    for (command, mode) in [
+        ("search", Some("--lexical")),
+        ("search", None),
+        ("search", Some("--semantic")),
+        ("why", None),
+    ] {
+        for explicit in [false, true] {
+            for format in ["json", "plain"] {
+                let mut process = Command::new(env!("CARGO_BIN_EXE_adoc"));
+                process.current_dir(&workspace.root).args([
+                    command,
+                    "billing.refunds.issue-credit",
+                    "--format",
+                    format,
+                ]);
+                if let Some(mode) = mode {
+                    process.arg(mode);
+                }
+                if explicit {
+                    process.args(["--artifact", "dist/docs.graph.json"]);
+                }
+                let output = process.output().expect("CLI runs");
+                assert_eq!(output.status.code(), Some(2), "{code}: {output:?}");
+                for bytes in [&output.stdout, &output.stderr] {
+                    let text = String::from_utf8_lossy(bytes);
+                    assert!(!text.contains("private-sentinel"));
+                    // Artifact diagnostics retain their resolved input path,
+                    // whether supplied explicitly or through valid config.
+                    if code != "retrieval.visibility_unavailable" {
+                        let directory = workspace.root.file_name().unwrap().to_str().unwrap();
+                        assert!(
+                            !text.contains(directory),
+                            "config diagnostic disclosed {text}"
+                        );
+                    }
+                }
+                if format == "json" {
+                    let envelope: Value = serde_json::from_slice(&output.stdout).unwrap();
+                    assert!(envelope["records"].as_array().unwrap().is_empty());
+                    let diagnostics = envelope["diagnostics"].as_array().unwrap();
+                    assert_eq!(diagnostics.len(), 1, "{envelope}");
+                    assert_eq!(diagnostics[0]["code"], code, "{envelope}");
+                    assert_eq!(diagnostics[0]["severity"], "error");
+                } else {
+                    assert!(output.stdout.is_empty());
+                    assert!(
+                        String::from_utf8_lossy(&output.stderr).contains(&format!("error[{code}]"))
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn malformed_policy_refuses_every_retrieval_mode_with_typed_safe_output() {
+    let workspace = TestWorkspace::new("retrieval-policy-errors");
+    workspace.write(
+        "dist/docs.graph.json",
+        &fs::read_to_string(fixture_path("v1_1_why/valid_artifact.graph.json")).unwrap(),
+    );
+    for (policy, code) in [
+        (
+            "retrieval_policy: [private-sentinel\n",
+            "retrieval.policy_invalid",
+        ),
+        ("retrieval_policy: null\n", "retrieval.policy_invalid"),
+        (
+            "retrieval_policy:\n  audience: public\n  allowed_visibilities: [public]\n  private-sentinel: true\n",
+            "retrieval.policy_invalid",
+        ),
+        (
+            "retrieval_policy:\n  allowed_visibilities: [public]\n",
+            "retrieval.audience_unresolved",
+        ),
+        (
+            "retrieval_policy:\n  audience: private-sentinel\n  allowed_visibilities: [public]\n",
+            "retrieval.audience_unresolved",
+        ),
+    ] {
+        workspace.write("agentdoc.config.yaml", &format!("{CONFIG}{policy}"));
+        assert_refusal(&workspace, code);
+    }
+}
+
+#[test]
+fn invalid_utf8_policy_refuses_before_artifact_loading() {
+    let workspace = TestWorkspace::new("retrieval-invalid-utf8");
+    fs::write(workspace.root.join("agentdoc.config.yaml"), [0xff, 0xfe]).unwrap();
+    assert_refusal(&workspace, "retrieval.policy_invalid");
+}
+
+#[test]
+fn unreadable_policy_source_returns_a_typed_refusal() {
+    let workspace = TestWorkspace::new("retrieval-unreadable-policy");
+    fs::create_dir(workspace.root.join("agentdoc.config.yaml")).unwrap();
+    assert_refusal(&workspace, "retrieval.policy_invalid");
+}
+
+#[test]
+#[cfg(unix)]
+fn dangling_policy_symlink_returns_a_typed_refusal() {
+    let workspace = TestWorkspace::new("retrieval-dangling-policy");
+    std::os::unix::fs::symlink(
+        "missing-policy.yaml",
+        workspace.root.join("agentdoc.config.yaml"),
+    )
+    .unwrap();
+    assert_refusal(&workspace, "retrieval.policy_invalid");
+}
+
+#[test]
+fn unclassifiable_artifacts_refuse_every_retrieval_mode_without_payload_text() {
+    let workspace = TestWorkspace::new("retrieval-visibility-errors");
+    workspace.write("agentdoc.config.yaml", CONFIG);
+    let fixture = fs::read_to_string(fixture_path("v1_1_why/valid_artifact.graph.json")).unwrap();
+    for (field, value) in [
+        ("visibility", serde_json::json!(null)),
+        ("visibility", serde_json::json!("private-sentinel")),
+        (
+            "field_visibility",
+            serde_json::json!({"body": "private-sentinel"}),
+        ),
+    ] {
+        let mut graph: Value = serde_json::from_str(&fixture).unwrap();
+        let object = graph["nodes"]
+            .as_array_mut()
+            .unwrap()
+            .iter_mut()
+            .find(|node| node["type"] == "knowledge_object")
+            .unwrap();
+        object[field] = value;
+        workspace.write("dist/docs.graph.json", &graph.to_string());
+        assert_refusal(&workspace, "retrieval.visibility_unavailable");
+    }
+}

--- a/crates/adoc-core/src/application/apply.rs
+++ b/crates/adoc-core/src/application/apply.rs
@@ -16,7 +16,9 @@ use serde::Serialize;
 #[cfg(test)]
 use crate::application::compile::compile_with_provider;
 use crate::application::compile::compile_with_provider_for_date;
-use crate::application::patch::{PatchCheckResult, check_patch_documents};
+use crate::application::patch::{
+    PatchCheckResult, artifact_failure_diagnostics, check_patch_documents,
+};
 use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 use crate::domain::graph::{
     GraphArtifactDocument, GraphKnowledgeObjectNode, GraphNode, GraphPageNode,
@@ -230,7 +232,9 @@ where
     // 1. Load the artifact and run the unchanged V2 validation.
     let graph_document = match graph_reader.read(graph_artifact_path) {
         Ok(document) => document,
-        Err(diagnostics) => return PatchApplyResult::refused(diagnostics, trace),
+        Err(diagnostics) => {
+            return PatchApplyResult::refused(artifact_failure_diagnostics(diagnostics), trace);
+        }
     };
     let target_node = find_object(&graph_document, &patch.target).cloned();
     // TB3: a create with an `after` anchor splices against that anchor's

--- a/crates/adoc-core/src/application/artifact_inspection.rs
+++ b/crates/adoc-core/src/application/artifact_inspection.rs
@@ -227,10 +227,12 @@ fn load_status_for_reader_diagnostics(diagnostics: &[Diagnostic]) -> ArtifactLoa
     {
         return ArtifactLoadStatus::UnsupportedVersion;
     }
-    if diagnostics
-        .iter()
-        .any(|diagnostic| diagnostic.code == DiagnosticCode::IoArtifactMalformed)
-    {
+    if diagnostics.iter().any(|diagnostic| {
+        matches!(
+            diagnostic.code,
+            DiagnosticCode::IoArtifactMalformed | DiagnosticCode::SchemaVisibilityInvalid
+        )
+    }) {
         return ArtifactLoadStatus::Malformed;
     }
     ArtifactLoadStatus::Unreadable
@@ -284,6 +286,7 @@ fn deterministic_quality_diagnostic(path: &Path) -> Diagnostic {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use crate::infrastructure::artifact::{
         graph_json::SUPPORTED_GRAPH_SCHEMA_VERSION, search_json::SUPPORTED_SEARCH_SCHEMA_VERSION,
     };
@@ -292,5 +295,36 @@ mod tests {
     fn graph_schema_constants_match_readers() {
         assert_eq!(SUPPORTED_GRAPH_SCHEMA_VERSION, "adoc.graph.v6");
         assert_eq!(SUPPORTED_SEARCH_SCHEMA_VERSION, "adoc.search.v2");
+    }
+
+    #[test]
+    fn graph_inspection_classifies_invalid_visibility_as_malformed() {
+        let workspace = tempfile::tempdir().unwrap();
+        let path = workspace.path().join("invalid.graph.json");
+        for field in ["visibility", "field_visibility"] {
+            let artifact = serde_json::json!({
+                "schema_version": SUPPORTED_GRAPH_SCHEMA_VERSION,
+                "repository_identity": null,
+                "nodes": [{"type": "knowledge_object", field: null}],
+                "edges": [],
+                "diagnostics": []
+            });
+            std::fs::write(&path, serde_json::to_vec(&artifact).unwrap()).unwrap();
+            let result = crate::inspect_graph_artifact(GraphArtifactInspectionInput {
+                graph_artifact_path: path.clone(),
+            });
+            assert_eq!(result.load_status, ArtifactLoadStatus::Malformed);
+            assert!(result.exists);
+            assert_eq!(result.object_count, None);
+            assert_eq!(
+                result.schema_version.as_deref(),
+                Some(SUPPORTED_GRAPH_SCHEMA_VERSION)
+            );
+            assert_eq!(result.diagnostics.len(), 1);
+            assert_eq!(
+                result.diagnostics[0].code,
+                DiagnosticCode::SchemaVisibilityInvalid
+            );
+        }
     }
 }

--- a/crates/adoc-core/src/application/change_assessment.rs
+++ b/crates/adoc-core/src/application/change_assessment.rs
@@ -620,6 +620,8 @@ struct NormalizedConfig<'a> {
     embeddings_provider: &'a str,
     mcp_patch_apply_enabled: bool,
     assessment_exclude_paths: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    retrieval_policy: Option<&'a crate::domain::retrieval::RetrievalPolicy>,
 }
 
 fn load_snapshot_config(root: &Path) -> Result<LoadedConfig, SnapshotConfigError> {
@@ -638,6 +640,7 @@ fn load_snapshot_config(root: &Path) -> Result<LoadedConfig, SnapshotConfigError
         },
         mcp_patch_apply_enabled: parsed.mcp_patch_apply_enabled,
         assessment_exclude_paths: &parsed.assessment_exclude_paths,
+        retrieval_policy: parsed.retrieval_policy.as_ref(),
     };
     let normalized_json = serde_json::to_vec(&normalized).map_err(|error| {
         SnapshotConfigError::Other(format!("could not normalize {CONFIG_PATH}: {error}"))
@@ -656,9 +659,9 @@ fn config_error(error: ProjectConfigDocumentError) -> SnapshotConfigError {
         ProjectConfigDocumentError::InvalidAssessmentPath { .. } => {
             SnapshotConfigError::InvalidAssessmentPath(message)
         }
-        ProjectConfigDocumentError::Parse(_) | ProjectConfigDocumentError::Invalid(_) => {
-            SnapshotConfigError::Other(message)
-        }
+        ProjectConfigDocumentError::Parse(_)
+        | ProjectConfigDocumentError::Invalid(_)
+        | ProjectConfigDocumentError::RetrievalPolicy(_) => SnapshotConfigError::Other(message),
     }
 }
 
@@ -1795,6 +1798,58 @@ mod tests {
     use serde::ser::Error as _;
 
     struct SerializationFailure;
+
+    #[test]
+    fn retrieval_authority_is_bound_without_changing_legacy_config_bytes() {
+        let workspace = tempfile::tempdir().unwrap();
+        let path = workspace.path().join(super::CONFIG_PATH);
+        let base = "version: 1\nmode: strict\ndocs_path: docs\n";
+        std::fs::write(&path, base).unwrap();
+        let legacy = super::load_snapshot_config(workspace.path())
+            .map_err(|error| error.message())
+            .unwrap();
+        assert_eq!(legacy.normalized_json,
+            br#"{"docs_path":"docs","outputs":[],"embeddings_provider":"local","mcp_patch_apply_enabled":false,"assessment_exclude_paths":[]}"#);
+        let legacy_bound = super::complete_config(&legacy, &legacy).unwrap().sha256;
+        let mut digests = std::collections::BTreeSet::from([legacy.sha256.clone()]);
+        for policy in [
+            "{audience: public, allowed_visibilities: [public], excluded_object_ids: [billing.hidden]}",
+            "{audience: public, allowed_visibilities: [public]}",
+            "{audience: internal, allowed_visibilities: [public]}",
+            "{audience: internal, allowed_visibilities: [public, internal]}",
+        ] {
+            std::fs::write(&path, format!("{base}retrieval_policy: {policy}\n")).unwrap();
+            let changed = super::load_snapshot_config(workspace.path())
+                .map_err(|error| error.message())
+                .unwrap();
+            assert!(digests.insert(changed.sha256.clone()), "{policy}");
+            assert_ne!(
+                super::complete_config(&legacy, &changed).unwrap().sha256,
+                legacy_bound
+            );
+        }
+    }
+
+    #[test]
+    fn retrieval_policy_errors_keep_snapshot_config_failure_classification() {
+        let error = super::parse_project_config(
+            "version: 1\nmode: strict\ndocs_path: docs\nretrieval_policy: {audience: private-policy-sentinel, allowed_visibilities: [public]}\n",
+        ).expect_err("invalid audience must fail config parsing");
+        assert!(matches!(
+            error,
+            super::ProjectConfigDocumentError::RetrievalPolicy(_)
+        ));
+        let error = super::config_error(error);
+        assert!(matches!(error, super::SnapshotConfigError::Other(_)));
+        for fallback in [
+            super::DiagnosticCode::AssessmentHeadInvalid,
+            super::DiagnosticCode::AssessmentBasePartial,
+        ] {
+            assert_eq!(error.code(fallback), fallback);
+        }
+        assert!(error.message().contains("agentdoc.config.yaml"));
+        assert!(!error.message().contains("private-policy-sentinel"));
+    }
 
     impl serde::Serialize for SerializationFailure {
         fn serialize<S>(&self, _serializer: S) -> Result<S::Ok, S::Error>

--- a/crates/adoc-core/src/application/patch.rs
+++ b/crates/adoc-core/src/application/patch.rs
@@ -4,7 +4,7 @@ use std::path::PathBuf;
 
 use serde::Serialize;
 
-use crate::domain::diagnostic::{Diagnostic, Severity};
+use crate::domain::diagnostic::{Diagnostic, DiagnosticCode, Severity};
 use crate::domain::graph::{GraphArtifactDocument, GraphIndex};
 use crate::domain::obligation::ProofObligation;
 use crate::domain::patch::{
@@ -138,6 +138,17 @@ impl PatchCheckResult {
     }
 }
 
+pub(crate) fn artifact_failure_diagnostics(mut diagnostics: Vec<Diagnostic>) -> Vec<Diagnostic> {
+    // Only reader failures have artifact provenance; carried source
+    // diagnostics with the same code keep their validation-error meaning.
+    for diagnostic in &mut diagnostics {
+        if diagnostic.code == DiagnosticCode::SchemaVisibilityInvalid {
+            diagnostic.code = DiagnosticCode::IoArtifactMalformed;
+        }
+    }
+    diagnostics
+}
+
 pub(crate) fn check_patch_with_readers<G, P>(
     input: PatchInput,
     graph_reader: &G,
@@ -149,7 +160,9 @@ where
 {
     let graph_document = match graph_reader.read(&input.graph_artifact_path) {
         Ok(document) => document,
-        Err(diagnostics) => return PatchCheckResult::failure(diagnostics),
+        Err(diagnostics) => {
+            return PatchCheckResult::failure(artifact_failure_diagnostics(diagnostics));
+        }
     };
     let patch_document = match patch_reader.read(&input.patch_path) {
         Ok(document) => document,

--- a/crates/adoc-core/src/application/retrieval.rs
+++ b/crates/adoc-core/src/application/retrieval.rs
@@ -336,6 +336,16 @@ fn safe_artifact_diagnostics(path: &Path, diagnostics: Vec<Diagnostic>) -> Vec<D
     diagnostics
         .into_iter()
         .map(|diagnostic| match diagnostic.code {
+            DiagnosticCode::SchemaVisibilityInvalid => Diagnostic::error(
+                DiagnosticCode::RetrievalVisibilityUnavailable,
+                format!(
+                    "Artifact `{}` has unavailable visibility metadata.",
+                    path.display()
+                ),
+            )
+            .with_help(
+                "Run `adoc check` to repair visibility and `adoc build` to rebuild the artifact.",
+            ),
             DiagnosticCode::IoArtifactMalformed | DiagnosticCode::SchemaUnsupportedVersion => {
                 let safe = Diagnostic::error(
                     diagnostic.code,
@@ -1052,6 +1062,101 @@ mod tests {
 
         fn read(&self, _path: &Path) -> Result<Self::Output, Vec<Diagnostic>> {
             Ok(self.document.clone())
+        }
+    }
+
+    #[test]
+    fn retrieval_decoder_visibility_error_discards_payload_and_help() {
+        struct InvalidVisibilityReader;
+        impl ArtifactReader for InvalidVisibilityReader {
+            type Output = GraphArtifactDocument;
+
+            fn read(&self, _path: &Path) -> Result<Self::Output, Vec<Diagnostic>> {
+                let position = crate::domain::diagnostic::SourcePosition {
+                    line: 1,
+                    column: 1,
+                    offset: 0,
+                };
+                Err(vec![
+                    Diagnostic::error(DiagnosticCode::SchemaVisibilityInvalid, "private-payload")
+                        .with_object_id("private.object")
+                        .with_span(crate::domain::diagnostic::SourceSpan {
+                            file: "private-source.adoc".into(),
+                            start: position,
+                            end: position,
+                        })
+                        .with_help("private-repair-payload"),
+                ])
+            }
+        }
+
+        for explicit_policy in [false, true] {
+            let result = load_retrieval_session_with_readers(
+                RetrievalInput {
+                    artifact_path: "caller.graph.json".into(),
+                    search_artifact_path: None,
+                    policy: explicit_policy.then(|| RetrievalPolicy {
+                        audience: "public".into(),
+                        allowed_visibilities: BTreeSet::from(["public".into()]),
+                        excluded_object_ids: BTreeSet::new(),
+                    }),
+                },
+                &StubSearchArtifactReader {
+                    document: search_document("sha256:unused"),
+                },
+                &InvalidVisibilityReader,
+                None,
+            );
+            assert!(result.session.is_none());
+            let expected = Diagnostic::error(
+                DiagnosticCode::RetrievalVisibilityUnavailable,
+                "Artifact `caller.graph.json` has unavailable visibility metadata.",
+            )
+            .with_help(
+                "Run `adoc check` to repair visibility and `adoc build` to rebuild the artifact.",
+            );
+            assert_eq!(
+                serde_json::to_value(&result.diagnostics).unwrap(),
+                serde_json::to_value([expected]).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn retrieval_decoder_other_errors_preserve_codes_and_repair_help() {
+        let workspace = tempfile::tempdir().unwrap();
+        let path = workspace.path().join("caller.graph.json");
+        for (contents, code, help) in [
+            (
+                "{",
+                DiagnosticCode::IoArtifactMalformed,
+                "Rebuild docs.graph.json from the source workspace.".to_string(),
+            ),
+            (
+                r#"{"schema_version":"private-version-payload","nodes":[{"type":"knowledge_object","visibility":null}]}"#,
+                DiagnosticCode::SchemaUnsupportedVersion,
+                format!(
+                    "Expected schema_version 'adoc.graph.v6'. {}",
+                    DiagnosticCode::SchemaUnsupportedVersion.default_help()
+                ),
+            ),
+        ] {
+            std::fs::write(&path, contents).unwrap();
+            let result = crate::load_retrieval_session(RetrievalInput {
+                artifact_path: path.clone(),
+                search_artifact_path: None,
+                policy: None,
+            });
+            assert!(result.session.is_none());
+            let expected = Diagnostic::error(
+                code,
+                format!("Artifact `{}` could not be loaded.", path.display()),
+            )
+            .with_help(help);
+            assert_eq!(
+                serde_json::to_value(&result.diagnostics).unwrap(),
+                serde_json::to_value([expected]).unwrap()
+            );
         }
     }
 

--- a/crates/adoc-core/src/domain/project_config.rs
+++ b/crates/adoc-core/src/domain/project_config.rs
@@ -3,7 +3,8 @@ use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
 
-use super::retrieval::RetrievalPolicy;
+use super::diagnostic::{Diagnostic, DiagnosticCode};
+use super::retrieval::{RetrievalPolicy, canonical_visibility};
 use super::source::LogicalPath;
 
 #[derive(Debug, Clone)]
@@ -37,6 +38,8 @@ pub enum ProjectConfigDocumentError {
     Parse(#[from] serde_saphyr::Error),
     #[error("{0}")]
     Invalid(String),
+    #[error("invalid retrieval policy: {}", .0.message)]
+    RetrievalPolicy(Box<Diagnostic>),
     #[error(
         "assessment.exclude_paths entry {entry:?} must be an exact portable project-relative file or a directory prefix ending in `/`"
     )]
@@ -85,7 +88,39 @@ struct RawAssessment {
 }
 
 pub fn parse_project_config(text: &str) -> Result<ParsedProjectConfig, ProjectConfigDocumentError> {
-    let raw: RawProjectConfig = serde_saphyr::from_str(text)?;
+    // ponytail: preflight small configs for typed errors; replace the two parses
+    // with presence-preserving deserialization if T3's benchmarks require it.
+    let value: serde_json::Value = serde_saphyr::from_str(text)?;
+    let validated_policy = if let Some(policy) = value.get("retrieval_policy") {
+        if policy.is_object()
+            && policy
+                .get("audience")
+                .and_then(serde_json::Value::as_str)
+                .and_then(canonical_visibility)
+                .is_none()
+        {
+            return Err(ProjectConfigDocumentError::RetrievalPolicy(Box::new(
+                Diagnostic::error(
+                    DiagnosticCode::RetrievalAudienceUnresolved,
+                    "Retrieval audience must be public, internal, or restricted.",
+                ),
+            )));
+        }
+        let policy: RetrievalPolicy = serde_json::from_value(policy.clone()).map_err(|_| {
+            ProjectConfigDocumentError::RetrievalPolicy(Box::new(Diagnostic::error(
+                DiagnosticCode::RetrievalPolicyInvalid,
+                "Retrieval policy must contain only the supported fields with their required types.",
+            )))
+        })?;
+        policy
+            .validate()
+            .map_err(ProjectConfigDocumentError::RetrievalPolicy)?;
+        Some(policy)
+    } else {
+        None
+    };
+    let mut raw: RawProjectConfig = serde_saphyr::from_str(text)?;
+    raw.retrieval_policy = validated_policy;
     if raw.version != 1 {
         return Err(ProjectConfigDocumentError::Invalid(format!(
             "unsupported version {}; expected 1",
@@ -183,6 +218,160 @@ fn portable_docs_path(path: &Path) -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn explicit_null_retrieval_policy_is_invalid() {
+        let error = parse_project_config(
+            "version: 1\nmode: strict\ndocs_path: docs\nretrieval_policy: null\n",
+        )
+        .expect_err("explicit null policy must not be treated as absent");
+        let ProjectConfigDocumentError::RetrievalPolicy(diagnostic) = error else {
+            panic!("expected typed policy diagnostic: {error:?}");
+        };
+        assert_eq!(diagnostic.code, DiagnosticCode::RetrievalPolicyInvalid);
+    }
+
+    #[test]
+    fn unresolved_retrieval_audience_has_its_own_diagnostic() {
+        for audience in [
+            None,
+            Some("null"),
+            Some("17"),
+            Some("true"),
+            Some("[]"),
+            Some("{}"),
+            Some("''"),
+            Some("unknown"),
+            Some("' public'"),
+            Some("Public"),
+        ] {
+            let audience = audience
+                .map(|value| format!("  audience: {value}\n"))
+                .unwrap_or_default();
+            let error = parse_project_config(&format!(
+                "version: 1\nmode: strict\ndocs_path: docs\nretrieval_policy:\n{audience}  allowed_visibilities: [public]\n"
+            )).expect_err("unresolved audience must fail");
+            let ProjectConfigDocumentError::RetrievalPolicy(diagnostic) = error else {
+                panic!("expected typed audience diagnostic: {error:?}");
+            };
+            assert_eq!(
+                diagnostic.code,
+                DiagnosticCode::RetrievalAudienceUnresolved,
+                "{audience:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn unresolved_audience_precedes_other_policy_errors() {
+        let error = parse_project_config(
+            "version: 1\nmode: strict\ndocs_path: docs\nretrieval_policy: {audience: unknown, allowed_visibilities: wrong, unexpected: true}\n",
+        ).expect_err("mixed invalid policy must fail");
+        let ProjectConfigDocumentError::RetrievalPolicy(diagnostic) = error else {
+            panic!("expected typed audience diagnostic: {error:?}");
+        };
+        assert_eq!(diagnostic.code, DiagnosticCode::RetrievalAudienceUnresolved);
+    }
+
+    #[test]
+    fn malformed_retrieval_policy_shapes_and_values_have_safe_typed_errors() {
+        for policy in [
+            "null",
+            "[]",
+            "true",
+            "17",
+            "private-policy-sentinel",
+            "{audience: public}",
+            "{audience: public, allowed_visibilities: null}",
+            "{audience: public, allowed_visibilities: public}",
+            "{audience: public, allowed_visibilities: [17]}",
+            "{audience: public, allowed_visibilities: [private-policy-sentinel]}",
+            "{audience: public, allowed_visibilities: [' public']}",
+            "{audience: public, allowed_visibilities: [public], excluded_object_ids: null}",
+            "{audience: public, allowed_visibilities: [public], excluded_object_ids: billing.hidden}",
+            "{audience: public, allowed_visibilities: [public], excluded_object_ids: [true]}",
+            "{audience: public, allowed_visibilities: [public], excluded_object_ids: [private-policy-sentinel]}",
+            "{audience: public, allowed_visibilities: [public], private-policy-sentinel: true}",
+        ] {
+            let error = parse_project_config(&format!(
+                "version: 1\nmode: strict\ndocs_path: docs\nretrieval_policy: {policy}\n"
+            ))
+            .expect_err("malformed policy must fail");
+            let ProjectConfigDocumentError::RetrievalPolicy(diagnostic) = error else {
+                panic!("expected typed policy diagnostic for {policy}: {error:?}");
+            };
+            assert_eq!(
+                diagnostic.code,
+                DiagnosticCode::RetrievalPolicyInvalid,
+                "{policy}"
+            );
+            assert_eq!(
+                diagnostic.severity,
+                super::super::diagnostic::Severity::Error
+            );
+            assert!(diagnostic.help.is_some());
+            assert!(diagnostic.span.is_none() && diagnostic.object_id.is_none());
+            assert!(
+                !serde_json::to_string(&diagnostic)
+                    .unwrap()
+                    .contains("private-policy-sentinel")
+            );
+        }
+    }
+
+    #[test]
+    fn absent_and_valid_retrieval_policies_preserve_config_defaults() {
+        let base = "version: 1\nmode: strict\ndocs_path: docs\n";
+        let absent = parse_project_config(base).unwrap();
+        assert!(absent.retrieval_policy.is_none());
+        assert_eq!(absent.embeddings_provider, EmbeddingsProvider::Local);
+        for audience in ["public", "internal", "restricted"] {
+            let parsed = parse_project_config(&format!(
+                "{base}retrieval_policy: {{audience: {audience}, allowed_visibilities: [restricted, public, internal, public]}}\n"
+            )).expect("canonical policy parses");
+            let policy = parsed.retrieval_policy.unwrap();
+            assert_eq!(policy.audience, audience);
+            assert_eq!(
+                policy.allowed_visibilities,
+                BTreeSet::from(["public".into(), "internal".into(), "restricted".into()])
+            );
+            assert!(policy.excluded_object_ids.is_empty());
+            assert_eq!(parsed.docs_path, absent.docs_path);
+            assert_eq!(parsed.embeddings_provider, absent.embeddings_provider);
+        }
+        let parsed = parse_project_config(&format!(
+            "{base}retrieval_policy: {{audience: public, allowed_visibilities: [], excluded_object_ids: [billing.hidden]}}\n"
+        )).expect("empty allowlist is valid deny-all policy");
+        let policy = parsed.retrieval_policy.unwrap();
+        assert!(policy.allowed_visibilities.is_empty());
+        assert_eq!(
+            policy.excluded_object_ids,
+            BTreeSet::from(["billing.hidden".into()])
+        );
+    }
+
+    #[test]
+    fn malformed_yaml_and_duplicate_keys_remain_parse_errors() {
+        let base = "version: 1\nmode: strict\ndocs_path: docs\n";
+        for config in [
+            "version: [\n".to_string(),
+            format!("{base}version: 1\n"),
+            format!(
+                "{base}retrieval_policy: null\nretrieval_policy: {{audience: public, allowed_visibilities: []}}\n"
+            ),
+            format!(
+                "{base}retrieval_policy: {{audience: public, audience: restricted, allowed_visibilities: []}}\n"
+            ),
+        ] {
+            assert!(
+                matches!(
+                    parse_project_config(&config),
+                    Err(ProjectConfigDocumentError::Parse(_))
+                ),
+                "{config}"
+            );
+        }
+    }
 
     #[test]
     fn parses_complete_shipped_configuration() {

--- a/crates/adoc-core/src/domain/retrieval/mod.rs
+++ b/crates/adoc-core/src/domain/retrieval/mod.rs
@@ -68,7 +68,9 @@ impl RetrievalPolicy {
     }
 }
 
-fn canonical_visibility(value: &str) -> Option<super::value_objects::visibility::Visibility> {
+pub(crate) fn canonical_visibility(
+    value: &str,
+) -> Option<super::value_objects::visibility::Visibility> {
     super::value_objects::visibility::Visibility::try_new(value)
         .ok()
         .filter(|visibility| visibility.as_str() == value)

--- a/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
+++ b/crates/adoc-core/src/infrastructure/artifact/graph_json.rs
@@ -21,6 +21,7 @@ use crate::domain::knowledge_object::{
     contradiction::Contradiction, policy::Policy, projection::MetadataField,
 };
 use crate::domain::ports::{artifact_reader::ArtifactReader, artifact_writer::ArtifactWriter};
+use crate::domain::retrieval::canonical_visibility;
 use crate::domain::value_objects::evidence_kind::EvidenceKind;
 use crate::domain::value_objects::visibility::{Visibility, parse_field_visibility};
 
@@ -76,6 +77,40 @@ pub(crate) fn parse_graph_artifact_document(
                 DiagnosticCode::SchemaUnsupportedVersion.default_help()
             )),
         ]);
+    }
+
+    // Inspect presence before serde turns an explicit null into an absent Option.
+    let valid_visibility =
+        |value: &serde_json::Value| value.as_str().and_then(canonical_visibility).is_some();
+    for node in value
+        .get("nodes")
+        .and_then(serde_json::Value::as_array)
+        .into_iter()
+        .flatten()
+        .filter(|node| {
+            node.get("type").and_then(serde_json::Value::as_str) == Some("knowledge_object")
+        })
+    {
+        if node
+            .get(VISIBILITY_FIELD)
+            .is_some_and(|value| !valid_visibility(value))
+            || node.get(FIELD_VISIBILITY_FIELD).is_some_and(|value| {
+                value.as_object().is_none_or(|fields| {
+                    fields.iter().any(|(field, value)| {
+                        let trimmed = crate::domain::values::trim_ascii_edges(field);
+                        trimmed.is_empty() || trimmed != field || !valid_visibility(value)
+                    })
+                })
+            })
+        {
+            return Err(vec![
+                Diagnostic::error(
+                    DiagnosticCode::SchemaVisibilityInvalid,
+                    format!("Artifact '{}' contains invalid visibility metadata.", path.display()),
+                )
+                .with_help("Run `adoc check` to repair visibility and `adoc build` to rebuild the artifact."),
+            ]);
+        }
     }
 
     let document = match serde_json::from_value::<GraphArtifactDocument>(value) {
@@ -935,6 +970,180 @@ mod tests {
     use crate::domain::identity::PageId;
     use crate::domain::inline::InlineSegment;
     use crate::domain::ports::artifact_writer::ArtifactWriter;
+
+    fn decoder_fixture() -> serde_json::Value {
+        serde_json::json!({
+            "schema_version": SUPPORTED_GRAPH_SCHEMA_VERSION,
+            "repository_identity": null,
+            "nodes": [GraphNode::KnowledgeObject(make_ko_node(None, None))],
+            "edges": [],
+            "diagnostics": []
+        })
+    }
+
+    #[test]
+    fn graph_decoder_rejects_present_invalid_object_visibility() {
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!(false),
+            serde_json::json!(1),
+            serde_json::json!([]),
+            serde_json::json!({}),
+            serde_json::json!("secret"),
+            serde_json::json!("Public"),
+            serde_json::json!(" public "),
+            serde_json::json!(""),
+        ] {
+            let mut artifact = decoder_fixture();
+            artifact["nodes"][0]["visibility"] = value.clone();
+            let diagnostics = parse_graph_artifact_document(
+                Path::new("caller.graph.json"),
+                &serde_json::to_vec(&artifact).unwrap(),
+            )
+            .expect_err("present invalid visibility must not default public");
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaVisibilityInvalid);
+            assert_eq!(
+                diagnostics[0].severity,
+                crate::domain::diagnostic::Severity::Error
+            );
+            assert!(
+                diagnostics[0]
+                    .help
+                    .as_ref()
+                    .is_some_and(|help| !help.is_empty())
+            );
+        }
+    }
+
+    #[test]
+    fn graph_decoder_rejects_present_invalid_field_visibility() {
+        for value in [
+            serde_json::json!(null),
+            serde_json::json!(false),
+            serde_json::json!(1),
+            serde_json::json!([]),
+            serde_json::json!("owner=restricted"),
+            serde_json::json!({"owner": null}),
+            serde_json::json!({"owner": false}),
+            serde_json::json!({"owner": 1}),
+            serde_json::json!({"owner": []}),
+            serde_json::json!({"owner": {}}),
+            serde_json::json!({"owner": "secret"}),
+            serde_json::json!({"owner": "Public"}),
+            serde_json::json!({"owner": " restricted "}),
+            serde_json::json!({"owner": ""}),
+            serde_json::json!({"owner": "public", "body": "secret"}),
+        ] {
+            let mut artifact = decoder_fixture();
+            artifact["nodes"][0]["field_visibility"] = value.clone();
+            let diagnostics = parse_graph_artifact_document(
+                Path::new("caller.graph.json"),
+                &serde_json::to_vec(&artifact).unwrap(),
+            )
+            .expect_err("invalid field visibility must refuse");
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaVisibilityInvalid);
+        }
+    }
+
+    #[test]
+    fn graph_decoder_rejects_empty_or_noncanonical_field_visibility_names() {
+        for field in ["", " \t\r\n ", "  owner  ", "\towner", "owner\r\n"] {
+            let mut artifact = decoder_fixture();
+            artifact["nodes"][0]["field_visibility"] = serde_json::json!({field: "public"});
+            let diagnostics = parse_graph_artifact_document(
+                Path::new("caller.graph.json"),
+                &serde_json::to_vec(&artifact).unwrap(),
+            )
+            .expect_err("field visibility requires a nonempty canonical field name");
+            assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaVisibilityInvalid);
+        }
+    }
+
+    #[test]
+    fn graph_decoder_accepts_omitted_and_canonical_visibility_metadata() {
+        for visibility in [None, Some("public"), Some("internal"), Some("restricted")] {
+            for fields in [
+                None,
+                Some(serde_json::json!({})),
+                Some(serde_json::json!({
+                    "owner": "internal", "body": "restricted", "unregistered_field": "public"
+                })),
+            ] {
+                let mut artifact = decoder_fixture();
+                if let Some(visibility) = visibility {
+                    artifact["nodes"][0]["visibility"] = serde_json::json!(visibility);
+                }
+                if let Some(fields) = &fields {
+                    artifact["nodes"][0]["field_visibility"] = fields.clone();
+                }
+                let document = parse_graph_artifact_document(
+                    Path::new("caller.graph.json"),
+                    &serde_json::to_vec(&artifact).unwrap(),
+                )
+                .expect("canonical visibility metadata remains accepted");
+                let object = document.nodes[0].as_knowledge_object().unwrap();
+                assert_eq!(object.visibility.as_deref(), visibility);
+                assert_eq!(
+                    serde_json::to_value(&object.field_visibility).unwrap(),
+                    fields.unwrap_or_default()
+                );
+                if visibility.is_none() {
+                    assert!(
+                        crate::domain::retrieval::RetrievalPolicy::permits(None, object).unwrap()
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn graph_decoder_preserves_json_and_version_error_precedence() {
+        let path = Path::new("caller.graph.json");
+        let diagnostics = parse_graph_artifact_document(path, b"{").unwrap_err();
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IoArtifactMalformed);
+        assert_eq!(
+            diagnostics[0].help.as_deref(),
+            Some("Rebuild docs.graph.json from the source workspace.")
+        );
+
+        let mut artifact = decoder_fixture();
+        artifact["nodes"][0]["body"] = serde_json::json!(false);
+        let diagnostics =
+            parse_graph_artifact_document(path, &serde_json::to_vec(&artifact).unwrap())
+                .unwrap_err();
+        assert_eq!(diagnostics[0].code, DiagnosticCode::IoArtifactMalformed);
+
+        artifact["nodes"][0]["visibility"] = serde_json::Value::Null;
+        let diagnostics =
+            parse_graph_artifact_document(path, &serde_json::to_vec(&artifact).unwrap())
+                .unwrap_err();
+        assert_eq!(diagnostics[0].code, DiagnosticCode::SchemaVisibilityInvalid);
+
+        for version in ["adoc.graph.v5", "adoc.graph.v99"] {
+            artifact["schema_version"] = serde_json::json!(version);
+            let diagnostics =
+                parse_graph_artifact_document(path, &serde_json::to_vec(&artifact).unwrap())
+                    .unwrap_err();
+            assert_eq!(diagnostics.len(), 1);
+            assert_eq!(
+                diagnostics[0].code,
+                DiagnosticCode::SchemaUnsupportedVersion
+            );
+            assert_eq!(
+                diagnostics[0].help.as_deref(),
+                Some(
+                    format!(
+                        "Expected schema_version '{}'. {}",
+                        SUPPORTED_GRAPH_SCHEMA_VERSION,
+                        DiagnosticCode::SchemaUnsupportedVersion.default_help()
+                    )
+                    .as_str()
+                )
+            );
+        }
+    }
 
     fn dummy_span() -> SourceSpan {
         SourceSpan {

--- a/crates/adoc-core/src/lib.rs
+++ b/crates/adoc-core/src/lib.rs
@@ -715,7 +715,11 @@ pub fn check_patch_json(input: PatchJsonInput) -> PatchCheckResult {
     let graph_document =
         match infrastructure::artifact::GraphJsonArtifact.read(&input.graph_artifact_path) {
             Ok(document) => document,
-            Err(diagnostics) => return application::patch::PatchCheckResult::failure(diagnostics),
+            Err(diagnostics) => {
+                return application::patch::PatchCheckResult::failure(
+                    application::patch::artifact_failure_diagnostics(diagnostics),
+                );
+            }
         };
     let patch_document = match infrastructure::artifact::read_patch_document_value(
         input.patch,

--- a/crates/adoc-local/src/config.rs
+++ b/crates/adoc-local/src/config.rs
@@ -8,6 +8,14 @@ use crate::LocalError;
 
 pub(crate) const CONFIG_FILE_NAME: &str = "agentdoc.config.yaml";
 
+pub(crate) fn config_path_present(path: &Path) -> std::io::Result<bool> {
+    match fs::symlink_metadata(path) {
+        Ok(_) => Ok(true),
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => Ok(false),
+        Err(error) => Err(error),
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct ProjectConfig {
     pub path: PathBuf,
@@ -46,8 +54,15 @@ impl ProjectConfig {
 
         loop {
             let candidate = current_dir.join(CONFIG_FILE_NAME);
-            if candidate.exists() {
-                return Self::read(&candidate).map(Some);
+            match config_path_present(&candidate) {
+                Ok(true) => return Self::read(&candidate).map(Some),
+                Ok(false) => {}
+                Err(source) => {
+                    return Err(LocalError::ConfigRead {
+                        path: candidate,
+                        source,
+                    });
+                }
             }
 
             if current_dir.parent().is_none() {
@@ -74,6 +89,12 @@ impl ProjectConfig {
             source,
         })?;
         let parsed = parse_project_config(&text).map_err(|error| match error {
+            ProjectConfigDocumentError::RetrievalPolicy(diagnostic) => {
+                LocalError::RetrievalPolicy {
+                    path: path.to_path_buf(),
+                    diagnostic,
+                }
+            }
             ProjectConfigDocumentError::Parse(source) => LocalError::ConfigParse {
                 path: path.to_path_buf(),
                 source: Box::new(source),
@@ -153,6 +174,32 @@ mod tests {
     }
 
     const BASE_CONFIG: &str = "version: 1\nmode: strict\ndocs_path: docs\n";
+
+    #[test]
+    #[cfg(unix)]
+    fn dangling_config_symlink_never_falls_back_to_parent_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE_NAME), BASE_CONFIG).unwrap();
+        let child = dir.path().join("child");
+        fs::create_dir(&child).unwrap();
+        let candidate = child.join(CONFIG_FILE_NAME);
+        std::os::unix::fs::symlink("missing-policy.yaml", &candidate).unwrap();
+        let candidate = fs::canonicalize(&child).unwrap().join(CONFIG_FILE_NAME);
+        assert!(matches!(ProjectConfig::discover_from(&child),
+            Err(LocalError::ConfigRead { path, .. }) if path == candidate));
+    }
+
+    #[test]
+    fn config_directory_never_falls_back_to_parent_policy() {
+        let dir = tempfile::tempdir().unwrap();
+        fs::write(dir.path().join(CONFIG_FILE_NAME), BASE_CONFIG).unwrap();
+        let child = dir.path().join("child");
+        let candidate = child.join(CONFIG_FILE_NAME);
+        fs::create_dir_all(&candidate).unwrap();
+        let candidate = fs::canonicalize(candidate).unwrap();
+        assert!(matches!(ProjectConfig::discover_from(&child),
+            Err(LocalError::ConfigRead { path, .. }) if path == candidate));
+    }
 
     #[test]
     fn docs_path_must_be_a_portable_project_relative_path() {

--- a/crates/adoc-local/src/error.rs
+++ b/crates/adoc-local/src/error.rs
@@ -28,6 +28,12 @@ pub enum LocalError {
     #[error("error[config.invalid] invalid config {}: {message}", path.display())]
     ConfigInvalid { path: PathBuf, message: String },
 
+    #[error("error[{}] invalid retrieval policy in {}: {}", diagnostic.code, path.display(), diagnostic.message)]
+    RetrievalPolicy {
+        path: PathBuf,
+        diagnostic: Box<adoc_core::Diagnostic>,
+    },
+
     #[error("error[config.missing] {message}{}", format_config_path(config_path))]
     ConfigMissing {
         message: String,

--- a/crates/adoc-local/src/use_cases.rs
+++ b/crates/adoc-local/src/use_cases.rs
@@ -35,7 +35,7 @@ use adoc_core::{
 use adoc_core::{MigrateMode, MigrateReportEnvelope};
 use serde::Serialize;
 
-use crate::config::CONFIG_FILE_NAME;
+use crate::config::{CONFIG_FILE_NAME, config_path_present};
 use crate::{EmbeddingsProvider, LocalContext, LocalError, PathPolicy, ProjectConfig};
 
 const DEFAULT_GRAPH_ARTIFACT_PATH: &str = "dist/docs.graph.json";
@@ -874,7 +874,19 @@ where
     P: PathPolicy,
 {
     let (artifact, config) =
-        resolve_graph_artifact_for_read(context, input.artifact.as_deref(), true)?;
+        match resolve_graph_artifact_for_read(context, input.artifact.as_deref(), true) {
+            Ok(resolved) => resolved,
+            Err(error) => {
+                let diagnostic = retrieval_config_diagnostic(error)?;
+                return Ok(WhyOutcome {
+                    artifact: resolve_graph_artifact_path_with_config(input.artifact, None),
+                    records: Vec::new(),
+                    diagnostics: vec![diagnostic],
+                    duration: Duration::ZERO,
+                    exit_code: 2,
+                });
+            }
+        };
     let load_result = load_retrieval_session_with_embedding_provider(
         RetrievalInput {
             artifact_path: artifact.clone(),
@@ -1093,7 +1105,16 @@ where
         .map(|path| context.path_policy().resolve_read_path(path))
         .transpose()?;
     // An explicit artifact changes the data source, never the policy source.
-    let config = ProjectConfig::discover_from(context.config_start())?;
+    let config = match ProjectConfig::discover_from(context.config_start()) {
+        Ok(config) => config,
+        Err(error) => {
+            return Ok(search_outcome(
+                Vec::new(),
+                vec![retrieval_config_diagnostic(error)?],
+                2,
+            ));
+        }
+    };
     // Policy discovery must not change the historical provider/path defaults
     // for a search whose relevant artifact paths are all explicit.
     let defaults_config = config.as_ref().filter(|_| {
@@ -1990,7 +2011,9 @@ fn assessment_project_root(start: &Path) -> Option<PathBuf> {
     let repository_root = git_project_root(start)?;
     let mut current = start.canonicalize().ok()?;
     loop {
-        if current.join(CONFIG_FILE_NAME).is_file() {
+        // Stop on present or inaccessible config paths; only the selected
+        // snapshot may supply config contents or report its read failure.
+        if config_path_present(&current.join(CONFIG_FILE_NAME)).unwrap_or(true) {
             return Some(current);
         }
         if current == repository_root || !current.pop() {
@@ -2079,6 +2102,27 @@ fn diagnostics_have_errors(diagnostics: &[Diagnostic]) -> bool {
     diagnostics
         .iter()
         .any(|diagnostic| diagnostic.severity == Severity::Error)
+}
+
+/// An unreadable or malformed config cannot establish retrieval authority.
+/// Preserve typed policy errors without exposing parser or filesystem details.
+fn retrieval_config_diagnostic(error: LocalError) -> Result<Diagnostic, LocalError> {
+    match error {
+        LocalError::RetrievalPolicy { diagnostic, .. } => return Ok(*diagnostic),
+        LocalError::ConfigParse { .. } | LocalError::ConfigRead { .. } => {}
+        error => return Err(error),
+    }
+    Ok(Diagnostic {
+        code: DiagnosticCode::RetrievalPolicyInvalid,
+        severity: Severity::Error,
+        message: format!(
+            "Config `{}` could not be read or parsed; retrieval policy cannot be established.",
+            CONFIG_FILE_NAME
+        ),
+        span: None,
+        object_id: None,
+        help: Some("Run `adoc check` to diagnose the config, then make it readable and valid before retrying retrieval.".to_string()),
+    })
 }
 
 fn merge_diagnostics(

--- a/docs/adr/0065-permission-filtered-retrieval-session.md
+++ b/docs/adr/0065-permission-filtered-retrieval-session.md
@@ -2,7 +2,7 @@
 
 - Status: Accepted
 - Date: 2026-09-05
-- Slice: E6.1.T1
+- Slices: E6.1.T1–T2
 
 ## Context
 
@@ -91,12 +91,50 @@ can retrieve changed carriers through lexical matching. If stale bindings leave
 no usable permitted vectors, semantic search refuses and hybrid falls back to
 lexical search. Withheld or absent carriers alone do not cause this refusal.
 Model errors retain the trusted active-provider identity. Decoder errors retain
-the caller-selected artifact path and trusted reader-supplied rebuild guidance,
+the resolved artifact path (from an explicit input or valid config) and trusted reader-supplied rebuild guidance,
 while suppressing artifact-controlled version values and decoder payload text.
 
-E6.1.T2 owns typed policy errors through config parsing and response assembly;
-T1 validates policy values at retrieval-session assembly. A generic config
-error conversion would lose T2's required audience/policy distinction.
+E6.1.T2 preserves typed policy errors through shared config parsing and local
+response assembly. An unreadable config, malformed YAML, or malformed present policy produces
+`retrieval.policy_invalid`; an absent, invalid, or noncanonical audience in a
+present policy produces `retrieval.audience_unresolved`. An omitted policy is
+valid; an explicit null policy is not. Search and why return empty records and
+exit 2 without parser snippets or filesystem details. This includes dangling
+config symlinks; discovery never substitutes a parent or default policy after a
+present config fails to load. Other semantic configuration errors, such as an
+unsupported config version/provider or a non-portable `docs_path`, retain
+`config.invalid` and exit 1. The graph decoder checks present object and field visibility before
+deserializing optional fields, so explicit null cannot become unclassified.
+Invalid classification produces `schema.visibility_invalid` for artifact
+inspection and safe `retrieval.visibility_unavailable` for retrieval. Valid
+field-level access enforcement remains E6.2.
+
+Policy validation is part of shared config parsing. Non-retrieval commands
+that load config, including build/check, also refuse malformed policy
+with `retrieval.policy_invalid` or `retrieval.audience_unresolved` and exit 1.
+Remove a null placeholder policy block to preserve omitted-policy behavior.
+Commands that already bypass config with explicit inputs retain that behavior;
+search/why always load policy and use the typed empty response with exit 2.
+Assessment and repository-baseline root selection use the same presence check;
+config contents and read failures still come from the selected Git/workdir snapshot.
+
+Graph JSON currently uses the decoder's last-member-wins map semantics:
+duplicate members collapse before classification validation, so earlier invalid
+or stricter values are not examined. E6.2.T2 must reject ambiguous duplicate
+object `visibility` and `field_visibility` members, including duplicate field
+names inside the latter map, at admission. YAML policy duplicates are already
+rejected. T2 does not claim strict duplicate-member rejection for graph JSON.
+
+Patch check and apply classify decoder visibility failures as
+`io.artifact_malformed`. Check exits 2 for this artifact failure; apply refuses
+before writing and exits 1. Carried source diagnostics retain their original
+validation codes. Artifact inspection still reports `schema.visibility_invalid`.
+
+Normalized assessment configuration digests include a present retrieval policy;
+omitting it preserves legacy config bytes. The existing `policy_changes` section
+still describes assessment exclusions and generated outputs, not authorization
+approval. Binding retrieval authority into the config digest does not grant it.
+
 E6.1.T3's performance gate must measure default-deny classified repositories
 as well as explicit policies. Borrowed validation and fewer repeated scans
 are measured optimizations for that gate; T1 keeps the conservative projection.

--- a/docs/agent/v0/tool-guide.md
+++ b/docs/agent/v0/tool-guide.md
@@ -12,7 +12,7 @@ V2.2 MCP tools are the supported local agent workflow for AgentDoc projects.
 
 `refresh: "build"` follows the same local build behavior as `adoc_build`. Embeddings honor project config unless `no_embeddings` is true. If project status returns artifact diagnostics, carry them into the answer or handoff; `search.deterministic_quality` means the project is using repeatable hash embeddings rather than semantic-model quality.
 
-## Standalone retrieval policy (E6.1.T1)
+## Standalone retrieval policy (E6.1.T1–T2)
 
 `search` and `why` discover local retrieval policy even with an explicit
 `--artifact`. For example, an operator can configure:
@@ -30,6 +30,22 @@ on those paths. Local
 policy is trusted operator configuration, not a multi-user authentication
 boundary. Unknown policy keys fail closed. Existing unclassified repositories
 without the block preserve their existing retrieval behavior.
+
+An unreadable config, malformed YAML, or malformed policy block returns
+`retrieval.policy_invalid`. A dangling config symlink cannot select a parent or
+default policy.
+A present policy with a missing or invalid audience returns
+`retrieval.audience_unresolved`. Explicit null policy is invalid; omit the block
+to use the public/unclassified default. Invalid present object or field visibility,
+including null, returns `retrieval.visibility_unavailable`. Search and why return
+no records and exit 2 with these typed diagnostics, in JSON or plain output.
+Repair the config or classification and rebuild invalid artifacts before retrying.
+
+Malformed policy also refuses non-retrieval commands that load config, including
+`build` and `check`, with a `retrieval.policy_invalid` or
+`retrieval.audience_unresolved` error and exit 1. This includes null policy
+placeholders: remove the block instead. Existing explicit-input paths that bypass
+config still do so; search/why always load policy and use exit 2 as above.
 
 This first projection conservatively matches denied ID text in complete
 Knowledge Objects and prose blocks. That can also withhold namespace descendants,

--- a/docs/guides/graph-v6-migration.md
+++ b/docs/guides/graph-v6-migration.md
@@ -7,8 +7,8 @@ dual-version reader. Artifacts are derived outputs, so migration is
 deterministic regeneration from source, never an in-place transform.
 
 `adoc search` and `adoc why` no longer echo the artifact-supplied schema
-version or raw decoder payloads. Their diagnostics name the caller-selected
-artifact path and retain `schema.unsupported_version` plus safe rebuild
+version or raw decoder payloads. Their diagnostics name the resolved artifact
+path (from an explicit input or valid config) and retain `schema.unsupported_version` plus safe rebuild
 guidance, including the expected supported version. Trusted graph-artifact
 inspection can still name the version found in the artifact.
 


### PR DESCRIPTION
Implements **E6.1.T2**, stacked on #203. Malformed retrieval policy or classification now produces an empty search/why response with the appropriate `retrieval.policy_invalid`, `retrieval.audience_unresolved`, or `retrieval.visibility_unavailable` code and exit 2. Explicit null can no longer deserialize as absent policy or public classification; omitted legacy fields retain their defaults.

Validation lives in shared config parsing and graph decoding, with typed errors preserved through local outcomes. Unreadable policy sources and YAML/UTF-8 failures return typed refusals without parser payloads or discovered host paths; diagnostics use the stable config filename. Config discovery refuses a dangling config symlink instead of falling back to a parent/default policy. Assessment and baseline share the metadata-only presence check while continuing to read config contents from the selected snapshot. Non-retrieval commands that load malformed policy refuse with the same typed code at exit 1; existing explicit-input config bypasses remain unchanged. Normalized assessment configuration digests bind a present retrieval policy while preserving exact legacy bytes when omitted; the existing assessment-only `policy_changes` contract is unchanged. Field-visibility keys must be canonical. Patch check/apply classify decoder visibility failures as malformed artifacts while preserving their distinct refusal exit codes and carried source errors. Artifact inspection classifies malformed visibility correctly; unrelated explicit-artifact and provider behavior stays covered.

Validation: **2,750 workspace tests passed**, plus build, formatting, Clippy/rustdoc with warnings denied, and packaged-runtime golden/determinism/tamper-refusal checks. Independent local Codex and plugin-free Claude `-p --safe-mode` reviews completed; their T2 findings are addressed. Focused red-to-green cases cover all CLI retrieval modes, JSON/plain output, explicit/discovered artifacts, nullable classifications, malformed config shapes, and symlink discovery.

Stack base: `feat/e6.1-t1-permission-retrieval`. Field ACL enforcement, strict graph JSON duplicate-member rejection, full graph/diagnostic closure, and explicit MCP gateway audience remain their later E6 tracers. ADR-0065 explicitly scopes the current last-member-wins JSON parsing behavior; E6.2.T2 owns duplicate classification admission.
